### PR TITLE
Fix intersection parsing for unions containing tuple-to-userset patterns

### DIFF
--- a/pkg/parser/parser_test.go
+++ b/pkg/parser/parser_test.go
@@ -1,0 +1,279 @@
+package parser
+
+import (
+	"testing"
+)
+
+func TestExpandIntersection_TTUUnion(t *testing.T) {
+	// Test case: viewer and (member from group or owner from group)
+	// This should produce TWO intersection groups via distribution:
+	// - Group 1: Relations: ["viewer"], ParentRelations: [{member, group}]
+	// - Group 2: Relations: ["viewer"], ParentRelations: [{owner, group}]
+
+	schemaStr := `model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define owner: [user]
+    define member: [user]
+
+type folder
+  relations
+    define group: [group]
+    define viewer: [user]
+    define can_view: viewer and (member from group or owner from group)`
+
+	types, err := ParseSchemaString(schemaStr)
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	// Find folder type
+	folderTypeIdx := -1
+	for i := range types {
+		if types[i].Name == "folder" {
+			folderTypeIdx = i
+			break
+		}
+	}
+	if folderTypeIdx < 0 {
+		t.Fatal("folder type not found")
+	}
+	folderType := types[folderTypeIdx]
+
+	// Find can_view relation
+	canViewRelIdx := -1
+	for i := range folderType.Relations {
+		if folderType.Relations[i].Name == "can_view" {
+			canViewRelIdx = i
+			break
+		}
+	}
+	if canViewRelIdx < 0 {
+		t.Fatal("can_view relation not found")
+	}
+	canViewRel := folderType.Relations[canViewRelIdx]
+
+	// Verify intersection groups exist
+	if len(canViewRel.IntersectionGroups) == 0 {
+		t.Fatal("expected intersection groups to be populated")
+	}
+
+	// The distributive law should produce 2 groups:
+	// Group 1: viewer AND (member from group)
+	// Group 2: viewer AND (owner from group)
+	if len(canViewRel.IntersectionGroups) != 2 {
+		t.Errorf("expected 2 intersection groups (distributed), got %d", len(canViewRel.IntersectionGroups))
+		for i, g := range canViewRel.IntersectionGroups {
+			t.Logf("Group %d: Relations=%v, ParentRelations=%v", i, g.Relations, g.ParentRelations)
+		}
+	}
+
+	// Verify each group has viewer relation
+	for i, g := range canViewRel.IntersectionGroups {
+		hasViewer := false
+		for _, rel := range g.Relations {
+			if rel == "viewer" {
+				hasViewer = true
+				break
+			}
+		}
+		if !hasViewer {
+			t.Errorf("group %d missing 'viewer' relation: %v", i, g.Relations)
+		}
+
+		// Each group should have exactly one parent relation
+		if len(g.ParentRelations) != 1 {
+			t.Errorf("group %d: expected 1 parent relation, got %d: %v", i, len(g.ParentRelations), g.ParentRelations)
+		}
+	}
+
+	// Verify we have both member and owner parent relations across groups
+	foundMember := false
+	foundOwner := false
+	for _, g := range canViewRel.IntersectionGroups {
+		for _, pr := range g.ParentRelations {
+			if pr.Relation == "member" && pr.LinkingRelation == "group" {
+				foundMember = true
+			}
+			if pr.Relation == "owner" && pr.LinkingRelation == "group" {
+				foundOwner = true
+			}
+		}
+	}
+	if !foundMember {
+		t.Error("missing parent relation for 'member from group'")
+	}
+	if !foundOwner {
+		t.Error("missing parent relation for 'owner from group'")
+	}
+}
+
+func TestExpandIntersection_MixedUnion(t *testing.T) {
+	// Test case: viewer and (editor or member from group)
+	// This is a mixed union with both simple relation and TTU
+
+	schemaStr := `model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define member: [user]
+
+type folder
+  relations
+    define group: [group]
+    define viewer: [user]
+    define editor: [user]
+    define can_view: viewer and (editor or member from group)`
+
+	types, err := ParseSchemaString(schemaStr)
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	folderTypeIdx := -1
+	for i := range types {
+		if types[i].Name == "folder" {
+			folderTypeIdx = i
+			break
+		}
+	}
+	if folderTypeIdx < 0 {
+		t.Fatal("folder type not found")
+	}
+	folderType := types[folderTypeIdx]
+
+	canViewRelIdx := -1
+	for i := range folderType.Relations {
+		if folderType.Relations[i].Name == "can_view" {
+			canViewRelIdx = i
+			break
+		}
+	}
+	if canViewRelIdx < 0 {
+		t.Fatal("can_view relation not found")
+	}
+	canViewRel := folderType.Relations[canViewRelIdx]
+
+	// Should produce 2 groups:
+	// Group 1: viewer AND editor
+	// Group 2: viewer AND (member from group)
+	if len(canViewRel.IntersectionGroups) != 2 {
+		t.Errorf("expected 2 intersection groups, got %d", len(canViewRel.IntersectionGroups))
+		for i, g := range canViewRel.IntersectionGroups {
+			t.Logf("Group %d: Relations=%v, ParentRelations=%v", i, g.Relations, g.ParentRelations)
+		}
+	}
+
+	// Find the groups
+	groupWithEditorIdx, groupWithParentIdx := -1, -1
+	for i := range canViewRel.IntersectionGroups {
+		g := canViewRel.IntersectionGroups[i]
+		for _, rel := range g.Relations {
+			if rel == "editor" {
+				groupWithEditorIdx = i
+			}
+		}
+		if len(g.ParentRelations) > 0 {
+			groupWithParentIdx = i
+		}
+	}
+
+	if groupWithEditorIdx < 0 {
+		t.Error("missing group with 'editor' relation")
+	} else {
+		groupWithEditor := canViewRel.IntersectionGroups[groupWithEditorIdx]
+		// This group should have viewer + editor, no parent relations
+		if len(groupWithEditor.ParentRelations) != 0 {
+			t.Errorf("editor group should have no parent relations, got %v", groupWithEditor.ParentRelations)
+		}
+	}
+
+	if groupWithParentIdx < 0 {
+		t.Error("missing group with parent relation")
+	} else {
+		groupWithParent := canViewRel.IntersectionGroups[groupWithParentIdx]
+		// This group should have viewer + parent relation for member from group
+		if len(groupWithParent.ParentRelations) != 1 {
+			t.Errorf("expected 1 parent relation, got %d", len(groupWithParent.ParentRelations))
+		} else {
+			pr := groupWithParent.ParentRelations[0]
+			if pr.Relation != "member" || pr.LinkingRelation != "group" {
+				t.Errorf("expected member from group, got %s from %s", pr.Relation, pr.LinkingRelation)
+			}
+		}
+	}
+}
+
+func TestExpandIntersection_SimpleIntersection(t *testing.T) {
+	// Test that simple intersections still work
+	schemaStr := `model
+  schema 1.1
+
+type user
+
+type doc
+  relations
+    define writer: [user]
+    define editor: [user]
+    define can_edit: writer and editor`
+
+	types, err := ParseSchemaString(schemaStr)
+	if err != nil {
+		t.Fatalf("failed to parse schema: %v", err)
+	}
+
+	docTypeIdx := -1
+	for i := range types {
+		if types[i].Name == "doc" {
+			docTypeIdx = i
+			break
+		}
+	}
+	if docTypeIdx < 0 {
+		t.Fatal("doc type not found")
+	}
+	docType := types[docTypeIdx]
+
+	canEditRelIdx := -1
+	for i := range docType.Relations {
+		if docType.Relations[i].Name == "can_edit" {
+			canEditRelIdx = i
+			break
+		}
+	}
+	if canEditRelIdx < 0 {
+		t.Fatal("can_edit relation not found")
+	}
+	canEditRel := docType.Relations[canEditRelIdx]
+
+	// Should have 1 group with writer AND editor
+	if len(canEditRel.IntersectionGroups) != 1 {
+		t.Errorf("expected 1 intersection group, got %d", len(canEditRel.IntersectionGroups))
+	}
+
+	g := canEditRel.IntersectionGroups[0]
+	if len(g.Relations) != 2 {
+		t.Errorf("expected 2 relations, got %d: %v", len(g.Relations), g.Relations)
+	}
+
+	hasWriter := false
+	hasEditor := false
+	for _, rel := range g.Relations {
+		if rel == "writer" {
+			hasWriter = true
+		}
+		if rel == "editor" {
+			hasEditor = true
+		}
+	}
+	if !hasWriter || !hasEditor {
+		t.Errorf("missing expected relations: writer=%v, editor=%v, got %v", hasWriter, hasEditor, g.Relations)
+	}
+}

--- a/test/intersection_ttu_union_test.go
+++ b/test/intersection_ttu_union_test.go
@@ -1,0 +1,363 @@
+package test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/pkg/parser"
+	"github.com/pthm/melange/pkg/schema"
+	"github.com/pthm/melange/test/testutil"
+	"github.com/stretchr/testify/require"
+)
+
+// TestIntersectionWithTTUUnionParsing verifies that intersection rules containing
+// unions of tuple-to-userset patterns are correctly parsed.
+//
+// Schema: can_view: viewer and (member from group or owner from group)
+// This should produce 2 intersection groups (via distributive law):
+//   - Group 1: viewer AND (member from group)
+//   - Group 2: viewer AND (owner from group)
+func TestIntersectionWithTTUUnionParsing(t *testing.T) {
+	dsl := `
+model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define owner: [user]
+    define member: [user]
+
+type folder
+  relations
+    define group: [group]
+    define viewer: [user]
+    define can_view: viewer and (member from group or owner from group)
+`
+
+	types, err := parser.ParseSchemaString(dsl)
+	require.NoError(t, err)
+
+	// Find the can_view relation on folder
+	var canViewRel *schema.RelationDefinition
+	for i := range types {
+		if types[i].Name != "folder" {
+			continue
+		}
+		for j := range types[i].Relations {
+			if types[i].Relations[j].Name == "can_view" {
+				canViewRel = &types[i].Relations[j]
+				break
+			}
+		}
+	}
+	require.NotNil(t, canViewRel, "can_view relation not found")
+
+	// Should have 2 intersection groups due to distributive expansion
+	require.Len(t, canViewRel.IntersectionGroups, 2,
+		"expected 2 intersection groups from distributive law: (viewer AND member from group) OR (viewer AND owner from group)")
+
+	// Each group should have the viewer relation
+	for i, g := range canViewRel.IntersectionGroups {
+		require.Contains(t, g.Relations, "viewer",
+			"group %d should contain 'viewer' relation", i)
+		require.Len(t, g.ParentRelations, 1,
+			"group %d should have exactly 1 parent relation", i)
+		require.Equal(t, "group", g.ParentRelations[0].LinkingRelation,
+			"group %d parent relation should link via 'group'", i)
+	}
+
+	// Verify we have both member and owner parent relations across groups
+	parentRels := make(map[string]bool)
+	for _, g := range canViewRel.IntersectionGroups {
+		for _, pr := range g.ParentRelations {
+			parentRels[pr.Relation] = true
+		}
+	}
+	require.True(t, parentRels["member"], "should have 'member from group' parent relation")
+	require.True(t, parentRels["owner"], "should have 'owner from group' parent relation")
+}
+
+// TestIntersectionWithTTUUnionSQL verifies that the generated SQL correctly
+// enforces the intersection semantics with TTU unions.
+//
+// Schema: can_view: viewer and (member from group or owner from group)
+//
+// A user can view a folder if:
+//   - They have the 'viewer' relation on the folder, AND
+//   - They are either 'member' OR 'owner' of the folder's linked group
+func TestIntersectionWithTTUUnionSQL(t *testing.T) {
+	dsl := `
+model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define owner: [user]
+    define member: [user]
+
+type folder
+  relations
+    define group: [group]
+    define viewer: [user]
+    define can_view: viewer and (member from group or owner from group)
+`
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	err := migrator.MigrateFromString(ctx, db, dsl)
+	require.NoError(t, err)
+
+	// Create test data:
+	// - group:engineering with member:alice, owner:bob
+	// - folder:docs linked to group:engineering
+	// - viewer relations: alice, bob, charlie (charlie is NOT in group)
+	_, err = db.ExecContext(ctx, `
+		CREATE VIEW melange_tuples AS
+		SELECT * FROM (VALUES
+			-- Group membership
+			('user', 'alice', 'member', 'group', 'engineering'),
+			('user', 'bob', 'owner', 'group', 'engineering'),
+
+			-- Folder -> Group link
+			('group', 'engineering', 'group', 'folder', 'docs'),
+
+			-- Viewer relations on folder
+			('user', 'alice', 'viewer', 'folder', 'docs'),
+			('user', 'bob', 'viewer', 'folder', 'docs'),
+			('user', 'charlie', 'viewer', 'folder', 'docs'),
+
+			-- Diana is member of group but NOT viewer of folder
+			('user', 'diana', 'member', 'group', 'engineering')
+		) AS t(subject_type, subject_id, relation, object_type, object_id)
+	`)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		user     string
+		expected bool
+		reason   string
+	}{
+		{
+			name:     "alice_allowed",
+			user:     "alice",
+			expected: true,
+			reason:   "alice is viewer AND member of group",
+		},
+		{
+			name:     "bob_allowed",
+			user:     "bob",
+			expected: true,
+			reason:   "bob is viewer AND owner of group",
+		},
+		{
+			name:     "charlie_denied",
+			user:     "charlie",
+			expected: false,
+			reason:   "charlie is viewer but NOT member or owner of group",
+		},
+		{
+			name:     "diana_denied",
+			user:     "diana",
+			expected: false,
+			reason:   "diana is member of group but NOT viewer of folder",
+		},
+		{
+			name:     "unknown_denied",
+			user:     "unknown",
+			expected: false,
+			reason:   "unknown user has no relations",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var allowed bool
+			err := db.QueryRowContext(ctx,
+				`SELECT check_permission('user', $1, 'can_view', 'folder', 'docs')`,
+				tc.user,
+			).Scan(&allowed)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, allowed, tc.reason)
+		})
+	}
+}
+
+// TestIntersectionWithMixedUnionSQL tests intersection with a union containing
+// both a simple relation and a TTU pattern.
+//
+// Schema: can_edit: editor and (admin or owner from org)
+//
+// A user can edit if:
+//   - They have the 'editor' relation, AND
+//   - They are either 'admin' directly OR 'owner' of the linked org
+func TestIntersectionWithMixedUnionSQL(t *testing.T) {
+	dsl := `
+model
+  schema 1.1
+
+type user
+
+type org
+  relations
+    define owner: [user]
+
+type document
+  relations
+    define org: [org]
+    define editor: [user]
+    define admin: [user]
+    define can_edit: editor and (admin or owner from org)
+`
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	err := migrator.MigrateFromString(ctx, db, dsl)
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, `
+		CREATE VIEW melange_tuples AS
+		SELECT * FROM (VALUES
+			-- Org ownership
+			('user', 'ceo', 'owner', 'org', 'acme'),
+
+			-- Document -> Org link
+			('org', 'acme', 'org', 'document', 'report'),
+
+			-- Editor relations
+			('user', 'alice', 'editor', 'document', 'report'),
+			('user', 'bob', 'editor', 'document', 'report'),
+			('user', 'ceo', 'editor', 'document', 'report'),
+			('user', 'charlie', 'editor', 'document', 'report'),
+
+			-- Admin relations (direct, no org needed)
+			('user', 'alice', 'admin', 'document', 'report')
+		) AS t(subject_type, subject_id, relation, object_type, object_id)
+	`)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name     string
+		user     string
+		expected bool
+		reason   string
+	}{
+		{
+			name:     "alice_allowed_via_admin",
+			user:     "alice",
+			expected: true,
+			reason:   "alice is editor AND admin (direct relation path)",
+		},
+		{
+			name:     "ceo_allowed_via_org_owner",
+			user:     "ceo",
+			expected: true,
+			reason:   "ceo is editor AND owner of linked org (TTU path)",
+		},
+		{
+			name:     "bob_denied",
+			user:     "bob",
+			expected: false,
+			reason:   "bob is editor but NOT admin and NOT owner of org",
+		},
+		{
+			name:     "charlie_denied",
+			user:     "charlie",
+			expected: false,
+			reason:   "charlie is editor but NOT admin and NOT owner of org",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var allowed bool
+			err := db.QueryRowContext(ctx,
+				`SELECT check_permission('user', $1, 'can_edit', 'document', 'report')`,
+				tc.user,
+			).Scan(&allowed)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, allowed, tc.reason)
+		})
+	}
+}
+
+// BenchmarkIntersectionWithTTUUnion benchmarks permission checks for
+// intersection rules with TTU unions.
+//
+// Schema: can_view: viewer and (member from group or owner from group)
+func BenchmarkIntersectionWithTTUUnion(b *testing.B) {
+	dsl := `
+model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define owner: [user]
+    define member: [user]
+
+type folder
+  relations
+    define group: [group]
+    define viewer: [user]
+    define can_view: viewer and (member from group or owner from group)
+`
+
+	db := testutil.EmptyDB(b)
+	ctx := context.Background()
+
+	err := migrator.MigrateFromString(ctx, db, dsl)
+	require.NoError(b, err)
+
+	_, err = db.ExecContext(ctx, `
+		CREATE VIEW melange_tuples AS
+		SELECT * FROM (VALUES
+			('user', 'alice', 'member', 'group', 'engineering'),
+			('user', 'bob', 'owner', 'group', 'engineering'),
+			('group', 'engineering', 'group', 'folder', 'docs'),
+			('user', 'alice', 'viewer', 'folder', 'docs'),
+			('user', 'bob', 'viewer', 'folder', 'docs'),
+			('user', 'charlie', 'viewer', 'folder', 'docs'),
+			('user', 'diana', 'member', 'group', 'engineering')
+		) AS t(subject_type, subject_id, relation, object_type, object_id)
+	`)
+	require.NoError(b, err)
+
+	benchmarks := []struct {
+		name     string
+		user     string
+		expected bool
+	}{
+		{"allowed_via_member", "alice", true},
+		{"allowed_via_owner", "bob", true},
+		{"denied_not_in_group", "charlie", false},
+		{"denied_not_viewer", "diana", false},
+	}
+
+	for _, bm := range benchmarks {
+		b.Run(bm.name, func(b *testing.B) {
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				var allowed bool
+				err := db.QueryRowContext(ctx,
+					`SELECT check_permission('user', $1, 'can_view', 'folder', 'docs')`,
+					bm.user,
+				).Scan(&allowed)
+				if err != nil {
+					b.Fatal(err)
+				}
+				if allowed != bm.expected {
+					b.Fatalf("expected %v, got %v", bm.expected, allowed)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
Fixes #13 reported by @jake-wickstrom.

When parsing intersection rules like `viewer and (member from group or owner  from group)`, the union containing TupleToUserset (TTU) patterns was silently dropped. This caused the generated SQL to only check the `viewer` relation, ignoring the group membership requirement entirely - a serious authorization bypass.

Root cause: The `extractUnionRelations()` function only extracted simple ComputedUserset relations from unions, not TupleToUserset patterns. When a union contained only TTU patterns, it returned an empty slice, so the union was never distributed into the intersection groups.

The fix:
- Add `unionContents` struct to hold both Relations and ParentRelations
- Replace `extractUnionRelations()` with `extractUnionContents()` that extracts both simple relations and TTU patterns from unions
- Add `distributeUnionContents()` to properly distribute both types using the distributive law: A ∧ (B ∨ C) = (A ∧ B) ∨ (A ∧ C)
- Add `cloneGroupWithRelation()` and `cloneGroupWithParentRelation()` helpers
- Fix nested intersection handling to also copy ParentRelations

Also adds comprehensive tests:
- Unit tests for parsing intersection+TTU union patterns
- Integration tests verifying correct SQL behavior with PostgreSQL
- Benchmark for the specific pattern (~150μs per check)