### PR TITLE
Fix CI failures caused by missing Go workspace in GitHub Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup Go workspace
+        run: go work init . ./cmd/melange ./docs ./melange
+
       - name: Install tools
         run: go install tool
 
@@ -38,6 +41,7 @@ jobs:
           # After `go install tool`, binary is in $GOPATH/bin which is in PATH
           golangci-lint run ./...
           cd melange && golangci-lint run ./...
+          cd ../cmd/melange && golangci-lint run ./...
 
   unit-tests:
     name: Unit Tests
@@ -51,6 +55,9 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - name: Setup Go workspace
+        run: go work init . ./cmd/melange ./docs ./melange
+
       - name: Generate test authz package
         run: go run ./cmd/melange generate client --runtime go --schema test/testutil/testdata/schema.fga --output test/authz/ --package authz --id-type int64
 
@@ -59,6 +66,10 @@ jobs:
 
       - name: Run unit tests (melange core module)
         working-directory: melange
+        run: go test -short -race ./...
+
+      - name: Run unit tests (cmd/melange module)
+        working-directory: cmd/melange
         run: go test -short -race ./...
 
   integration-tests:
@@ -99,6 +110,9 @@ jobs:
         uses: pnpm/action-setup@v4
         with:
           version: 10
+
+      - name: Setup Go workspace
+        run: go work init . ./cmd/melange ./docs ./melange
 
       - name: Generate test authz package
         run: go run ./cmd/melange generate client --runtime go --schema test/testutil/testdata/schema.fga --output test/authz/ --package authz --id-type int64


### PR DESCRIPTION
All three CI jobs (Lint, Unit Tests, Integration Tests) fail at the "Generate test authz package" step because `go.work` is gitignored and `cmd/melange` is a separate module. Without the workspace, Go cannot resolve `go run ./cmd/melange`.

- Add a "Setup Go workspace" step to all three jobs that runs `go work init . ./cmd/melange ./docs ./melange` to recreate the local workspace configuration
- Extend lint job to also lint the cmd/melange module
- Add unit test step for the cmd/melange module

The go.work file stays in .gitignore to avoid breaking `go install github.com/pthm/melange/cmd/melange@latest`.