### PR TITLE
Fix migrate command breaking with uppercase relations

### DIFF
--- a/lib/sqlgen/compile.go
+++ b/lib/sqlgen/compile.go
@@ -112,11 +112,11 @@ func GenerateSQL(analyses []RelationAnalysis, inline InlineSQLData) (GeneratedSQ
 
 // functionName returns the name for a specialized check function.
 func functionName(objectType, relation string) string {
-	return fmt.Sprintf("check_%s_%s", sanitizeIdentifier(objectType), sanitizeIdentifier(relation))
+	return strings.ToLower(fmt.Sprintf("check_%s_%s", sanitizeIdentifier(objectType), sanitizeIdentifier(relation)))
 }
 
 func functionNameNoWildcard(objectType, relation string) string {
-	return fmt.Sprintf("check_%s_%s_no_wildcard", sanitizeIdentifier(objectType), sanitizeIdentifier(relation))
+	return strings.ToLower(fmt.Sprintf("check_%s_%s_no_wildcard", sanitizeIdentifier(objectType), sanitizeIdentifier(relation)))
 }
 
 // sanitizeIdentifier converts a type/relation name to a valid SQL identifier.

--- a/lib/sqlgen/list_functions.go
+++ b/lib/sqlgen/list_functions.go
@@ -1,6 +1,9 @@
 package sqlgen
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+)
 
 // ListGeneratedSQL contains all SQL generated for list functions.
 // This is separate from check function generation to keep concerns isolated.
@@ -87,11 +90,11 @@ func buildAnalysisLookup(analyses []RelationAnalysis) map[string]*RelationAnalys
 }
 
 func listObjectsFunctionName(objectType, relation string) string {
-	return ListObjectsFunctionName(objectType, relation)
+	return strings.ToLower(ListObjectsFunctionName(objectType, relation))
 }
 
 func listSubjectsFunctionName(objectType, relation string) string {
-	return ListSubjectsFunctionName(objectType, relation)
+	return strings.ToLower(ListSubjectsFunctionName(objectType, relation))
 }
 
 // generateListObjectsFunctionWithLookup generates a list_objects function with analysis lookup for TTU optimization.


### PR DESCRIPTION
This takes the naive approach of converting the function names to lowercase, which at least makes the migrate command work properly.

A proper fix would probably involve preserving the casing in the function names and quoting the function names everywhere.