### PR TITLE
Fix uppercase relation names breaking re-migration

### DIFF
--- a/lib/sqlgen/sqldsl/sql.go
+++ b/lib/sqlgen/sqldsl/sql.go
@@ -375,13 +375,17 @@ func UsersetTable(rows []ValuesRow, alias string) TableExpr {
 // =============================================================================
 
 // Ident sanitizes an identifier for use in SQL.
-// Replaces non-alphanumeric characters with underscores.
+// Replaces non-alphanumeric characters with underscores and folds to lowercase
+// to match PostgreSQL's behavior with unquoted identifiers.
 func Ident(name string) string {
 	var result strings.Builder
 	for _, r := range name {
-		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '_' {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9') || r == '_':
 			result.WriteRune(r)
-		} else {
+		case r >= 'A' && r <= 'Z':
+			result.WriteRune(r + ('a' - 'A'))
+		default:
 			result.WriteRune('_')
 		}
 	}

--- a/test/mixed_case_test.go
+++ b/test/mixed_case_test.go
@@ -1,0 +1,95 @@
+package test
+
+import (
+	"context"
+	"database/sql"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/pkg/parser"
+	"github.com/pthm/melange/test/testutil"
+)
+
+// TestMixedCaseRelations_RemigrateSurvives verifies that relations with uppercase
+// characters don't get dropped on re-migration. This is a regression test for #26
+// where CollectFunctionNames preserved the original casing but PostgreSQL stores
+// function names as lowercase, causing the orphan detection to drop valid functions.
+func TestMixedCaseRelations_RemigrateSurvives(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	const schema = `
+model
+  schema 1.1
+
+type user
+
+type organization
+  relations
+    define Member: [user]
+    define Viewer: [user] or Member
+`
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	types, err := parser.ParseSchemaString(schema)
+	require.NoError(t, err)
+
+	m := migrator.NewMigrator(db, "")
+
+	// Use MigrateWithTypesAndOptions which includes orphan detection,
+	// unlike MigrateWithTypes which only does CREATE OR REPLACE.
+	opts := migrator.InternalMigrateOptions{
+		SchemaContent: schema,
+	}
+
+	// First migration: creates the functions.
+	err = m.MigrateWithTypesAndOptions(ctx, types, opts)
+	require.NoError(t, err)
+
+	expectedFunctions := []string{
+		"check_organization_member",
+		"check_organization_member_no_wildcard",
+		"check_organization_viewer",
+		"check_organization_viewer_no_wildcard",
+		"list_organization_member_objects",
+		"list_organization_member_subjects",
+		"list_organization_viewer_objects",
+		"list_organization_viewer_subjects",
+		"check_permission",
+	}
+
+	assertFunctionsExist(t, db, ctx, expectedFunctions)
+
+	// Second migration (forced): triggers orphan detection which previously
+	// dropped functions due to case mismatch between CollectFunctionNames
+	// (which preserved original casing) and pg_proc (which stores lowercase).
+	opts.Force = true
+	err = m.MigrateWithTypesAndOptions(ctx, types, opts)
+	require.NoError(t, err)
+
+	assertFunctionsExist(t, db, ctx, expectedFunctions)
+}
+
+func assertFunctionsExist(t *testing.T, db *sql.DB, ctx context.Context, expectedFunctions []string) {
+	t.Helper()
+
+	for _, fn := range expectedFunctions {
+		var exists bool
+		err := db.QueryRowContext(ctx, `
+			SELECT EXISTS (
+				SELECT 1 FROM pg_proc p
+				JOIN pg_namespace n ON p.pronamespace = n.oid
+				WHERE n.nspname = current_schema()
+				AND p.proname = $1
+			)
+		`, fn).Scan(&exists)
+		require.NoError(t, err)
+		assert.True(t, exists, "function %s should exist", fn)
+	}
+}


### PR DESCRIPTION
PostgreSQL folds unquoted identifiers to lowercase, so CREATE FUNCTION check_organization_Member(...) creates a function named check_organization_member in pg_proc. However, CollectFunctionNames returned names with the original casing (e.g., check_organization_Member), causing the orphan detection to see the real lowercase functions as unexpected and drop them on re-migration.

Fix Ident() to fold uppercase letters to lowercase, matching PostgreSQL's identifier folding behavior. This ensures CollectFunctionNames returns names that match what pg_proc actually stores.

Add an integration test that migrates a schema with uppercase relation names twice and verifies functions survive re-migration.

Fixes #26