### PR TITLE
Fix list_objects missing results for closure userset patterns

### DIFF
--- a/lib/sqlgen/analysis/analysis_types.go
+++ b/lib/sqlgen/analysis/analysis_types.go
@@ -1302,7 +1302,7 @@ func ComputeCanGenerate(analyses []RelationAnalysis) []RelationAnalysis {
 					continue
 				}
 				for _, pattern := range relAnalysis.UsersetPatterns {
-					key := pattern.SubjectType + "#" + pattern.SubjectRelation
+					key := rel + "::" + pattern.SubjectType + "#" + pattern.SubjectRelation
 					if !seen[key] {
 						seen[key] = true
 						// Copy the pattern and set SourceRelation to the closure relation

--- a/test/openfgatests/testdata/melange_tests.yaml
+++ b/test/openfgatests/testdata/melange_tests.yaml
@@ -459,3 +459,72 @@ tests:
               relation: can_edit
               object: document:report
             expectation: false
+
+  # ---------------------------------------------------------------------------
+  # closure_userset_all_relations
+  # Pattern: can_view: editor, editor: [user, group#member] or manager,
+  #          manager: [user, group#member]
+  # Verifies that list_objects expands group#member usersets for ALL relations
+  # in a computed permission's closure, not just the first one encountered.
+  # Regression test for: group#member userset expansion was deduplicated by
+  # subject pattern alone, causing list_objects to miss grant tuples on
+  # implied relations (e.g. manager) when a closer relation (e.g. editor)
+  # shared the same userset pattern.
+  # ---------------------------------------------------------------------------
+  - name: closure_userset_all_relations
+    stages:
+      - model: |
+          model
+            schema 1.1
+
+          type user
+
+          type group
+            relations
+              define member: [user, group#member]
+
+          type document
+            relations
+              define manager: [user, group#member]
+              define editor: [user, group#member] or manager
+              define can_view: editor
+        tuples:
+          # alice is a member of the engineering group
+          - user: user:alice
+            relation: member
+            object: group:engineering
+          # engineering group has MANAGER on doc1
+          - user: group:engineering#member
+            relation: manager
+            object: document:doc1
+          # engineering group has EDITOR on doc2
+          - user: group:engineering#member
+            relation: editor
+            object: document:doc2
+        checkAssertions:
+          - name: alice_can_view_doc1_via_manager
+            tuple:
+              user: user:alice
+              relation: can_view
+              object: document:doc1
+            expectation: true
+          - name: alice_can_view_doc2_via_editor
+            tuple:
+              user: user:alice
+              relation: can_view
+              object: document:doc2
+            expectation: true
+          - name: alice_cannot_view_doc3
+            tuple:
+              user: user:alice
+              relation: can_view
+              object: document:doc3
+            expectation: false
+        listObjectsAssertions:
+          - request:
+              user: user:alice
+              type: document
+              relation: can_view
+            expectation:
+              - document:doc1
+              - document:doc2


### PR DESCRIPTION
Fixes https://github.com/pthm/melange/issues/29

## Problem                                                                                                                               
                                                                                                                                           
  `list_*_objects` functions only expand `group#member` userset lookups for the first relation encountered in a computed permission's      
  closure. When multiple relations share the same userset pattern (e.g. both `editor` and `manager` accept `group#member`), only one gets
  SQL expansion — the rest are silently dropped.                                                                                           
                                                                                               
  Minimal reproduction: https://github.com/jtbeach/melange-list-objects-bug

  ## Fix

  The dedup key in `ClosureUsersetPatterns` (`analysis_types.go:1305`) used `SubjectType#SubjectRelation` alone. Adding the source relation
   to the key ensures each contributing relation gets its own SQL expansion.
                                                                                                                                           
  ```diff                                                                                      
  - key := pattern.SubjectType + "#" + pattern.SubjectRelation
  + key := rel + "::" + pattern.SubjectType + "#" + pattern.SubjectRelation
  ```                                                                                                                                      
   
  ## Test                                                                                                                                  
                                                                                               
  Adds `closure_userset_all_relations` regression test to `melange_tests.yaml`.                                                            
   
  The test uses a model where `can_view` is a computed permission that traverses two relations (`editor` and `manager`), both accepting `group#member` usersets. Without the fix, `list_objects` only returns objects granted via `editor` and misses those granted via `manager`.                                                                              
                                                                                               
  ## Benchmarks                                

  No regression (`bench-quick`, 1K scale):                                                                                                 
   
  | Benchmark | Without fix | With fix |                                                                                                   
  |-----------|------------|----------|                                                        
  | DirectMembership | 137µs | 117µs |                                                                                                     
  | InheritedPermission | 191µs | 175µs |
  | ExclusionPattern | 249µs | 216µs |                                                                                                     
  | DeniedPermission | 135µs | 120µs | 