### PR TITLE
Add Codecov integration for code coverage reporting

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,47 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...90"
+
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 2%
+    patch:
+      default:
+        target: 80%
+
+comment:
+  layout: "reach,diff,flags,files"
+  behavior: default
+  require_changes: true
+
+ignore:
+  - "test/**"
+  - "docs/**"
+  - "clients/**"
+  - "cmd/melange/**"
+  - "bin/**"
+  - "scripts/**"
+  - "**/*_test.go"
+
+flags:
+  unit:
+    paths:
+      - "!test/"
+      - "!docs/"
+      - "!clients/"
+    carryforward: true
+  integration:
+    paths:
+      - "!docs/"
+      - "!clients/"
+    carryforward: true
+  runtime:
+    paths:
+      - "melange/"
+    carryforward: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,15 +72,15 @@ jobs:
         run: go run ./cmd/melange generate client --runtime go --schema test/testutil/testdata/schema.fga --output test/authz/ --package authz --id-type int64
 
       - name: Run unit tests (root module)
-        run: go test -short -race ./...
+        run: go test -short -race -coverprofile=coverage-root.out -covermode=atomic ./...
 
       - name: Run unit tests (melange core module)
         working-directory: melange
-        run: go test -short -race ./...
+        run: go test -short -race -coverprofile=coverage-runtime.out -covermode=atomic ./...
 
       - name: Run unit tests (cmd/melange module)
         working-directory: cmd/melange
-        run: go test -short -race ./...
+        run: go test -short -race -coverprofile=coverage-cmd.out -covermode=atomic ./...
 
       - name: Install TypeScript dependencies
         working-directory: clients/typescript
@@ -89,6 +89,14 @@ jobs:
       - name: Run TypeScript unit tests
         working-directory: clients/typescript
         run: pnpm test:unit
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage-root.out,./melange/coverage-runtime.out,./cmd/melange/coverage-cmd.out
+          flags: unit
+          fail_ci_if_error: false
 
   integration-tests:
     name: Integration Tests (Go + TypeScript)
@@ -141,8 +149,16 @@ jobs:
 
       - name: Run Go integration tests
         working-directory: test
-        run: go test -timeout 5m -race -p 1 -parallel 1 ./...
+        run: go test -timeout 5m -race -p 1 -parallel 1 -coverprofile=coverage-integration.out -covermode=atomic -coverpkg=github.com/pthm/melange/... ./...
 
       - name: Run TypeScript integration tests
         working-directory: clients/typescript
         run: pnpm test
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./test/coverage-integration.out
+          flags: integration
+          fail_ci_if_error: false

--- a/.github/workflows/openfga-tests.yml
+++ b/.github/workflows/openfga-tests.yml
@@ -30,4 +30,14 @@ jobs:
         working-directory: test
         run: |
           go test -count=1 -timeout 5m -race -v \
+            -coverprofile=coverage-openfga.out -covermode=atomic \
+            -coverpkg=github.com/pthm/melange/... \
             -run "TestOpenFGA_" ./openfgatests/...
+
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./test/coverage-openfga.out
+          flags: integration
+          fail_ci_if_error: false

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 ![GitHub Release](https://img.shields.io/github/v/release/pthm/melange)
 [![Go Reference](https://pkg.go.dev/badge/github.com/pthm/melange.svg)](https://pkg.go.dev/github.com/pthm/melange)
 [![Go Report Card](https://goreportcard.com/badge/github.com/pthm/melange)](https://goreportcard.com/report/github.com/pthm/melange)
+[![codecov](https://codecov.io/gh/pthm/melange/graph/badge.svg)](https://codecov.io/gh/pthm/melange)
 
 <img align="right" width="300" src="assets/mascot.png">
 


### PR DESCRIPTION
- Add .codecov.yml with project/patch coverage targets, PR comment config, ignore patterns for test/docs/scripts, and flags (unit, integration, runtime)
- Update CI workflow to collect coverage profiles from all three Go modules (root, melange runtime, cmd/melange) and upload with unit flag
- Update integration test workflow to collect coverage with -coverpkg for library code exercised by integration tests
- Update OpenFGA test workflow to collect and upload coverage
- Add Codecov badge to README

Coverage uploads use codecov/codecov-action@v5 with fail_ci_if_error: false so coverage collection never blocks CI. The repo is public so no upload token is needed. Carryforward is enabled on all flags so partial CI runs still produce a complete coverage picture.