### PR TITLE
Fix list_objects recursive CTE propagating non-TTU relations

### DIFF
--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -25,7 +25,11 @@ func BuildListObjectsRecursiveBlocks(plan ListPlan) (RecursiveBlockSet, error) {
 	selfRefSQL := buildSelfReferentialLinkingRelations(parentRelations)
 	selfRefLinkingRelations := dequoteLinkingRelations(selfRefSQL)
 
-	baseBlocks, err := buildRecursiveBaseBlocks(plan, parentRelations)
+	// Compute which relations should propagate through the recursive step.
+	// Only relations that satisfy a self-referential TTU target should propagate.
+	propagatableRelations := computePropagatableRelations(plan, parentRelations)
+
+	baseBlocks, err := buildRecursiveBaseBlocks(plan, parentRelations, propagatableRelations)
 	if err != nil {
 		return RecursiveBlockSet{}, err
 	}
@@ -43,14 +47,81 @@ func BuildListObjectsRecursiveBlocks(plan ListPlan) (RecursiveBlockSet, error) {
 	return result, nil
 }
 
+// computePropagatableRelations returns the set of relations whose results should
+// seed the recursive step. A relation is propagatable if it satisfies any relation
+// that has a self-referential TTU pattern. For example, with "can_view: viewer or
+// folder_viewer" where viewer has "viewer from parent", the propagatable set is
+// {viewer, editor, manager} — relations that satisfy "viewer". folder_viewer is
+// excluded because it does not satisfy any TTU-bearing relation.
+func computePropagatableRelations(plan ListPlan, parentRelations []ListParentRelationData) map[string]bool {
+	result := make(map[string]bool)
+
+	for _, p := range parentRelations {
+		if !p.IsSelfReferential {
+			continue
+		}
+		ttuRelation := p.Relation // e.g., "viewer"
+
+		if plan.AnalysisLookup != nil {
+			key := plan.ObjectType + "." + ttuRelation
+			if relAnalysis, ok := plan.AnalysisLookup[key]; ok {
+				for _, sat := range relAnalysis.SatisfyingRelations {
+					result[sat] = true
+				}
+			}
+		}
+
+		result[ttuRelation] = true
+	}
+
+	return result
+}
+
+// anyRelationPropagatable checks if any relation in the list is in the propagatable set.
+func anyRelationPropagatable(relations []string, propagatable map[string]bool) bool {
+	for _, r := range relations {
+		if propagatable[r] {
+			return true
+		}
+	}
+	return false
+}
+
 // buildRecursiveBaseBlocks builds the base case blocks for the recursive CTE.
-func buildRecursiveBaseBlocks(plan ListPlan, parentRelations []ListParentRelationData) ([]TypedQueryBlock, error) {
+// Each block is tagged with Propagatable based on whether its source relation
+// satisfies a self-referential TTU target.
+func buildRecursiveBaseBlocks(plan ListPlan, parentRelations []ListParentRelationData, propagatable map[string]bool) ([]TypedQueryBlock, error) {
 	blocks := make([]TypedQueryBlock, 0, 8)
 
-	blocks = append(blocks, buildRecursiveDirectBlock(plan))
-	blocks = append(blocks, buildRecursiveComplexClosureBlocks(plan)...)
-	blocks = append(blocks, buildRecursiveIntersectionClosureBlocks(plan)...)
-	blocks = append(blocks, buildRecursiveUsersetPatternBlocks(plan)...)
+	directBlock := buildRecursiveDirectBlock(plan)
+	directBlock.Propagatable = anyRelationPropagatable(plan.RelationList, propagatable)
+	blocks = append(blocks, directBlock)
+
+	for _, rel := range plan.ComplexClosure {
+		block := buildRecursiveComplexClosureBlock(plan, rel)
+		block.Propagatable = propagatable[rel]
+		blocks = append(blocks, block)
+	}
+
+	for _, rel := range plan.Analysis.IntersectionClosureRelations {
+		block := buildRecursiveIntersectionClosureBlock(plan, rel)
+		block.Propagatable = propagatable[rel]
+		blocks = append(blocks, block)
+	}
+
+	patterns := buildListUsersetPatternInputs(plan.Analysis)
+	for _, pattern := range patterns {
+		var block TypedQueryBlock
+		if pattern.IsComplex {
+			block = buildRecursiveComplexUsersetBlock(plan, pattern)
+		} else {
+			block = buildRecursiveSimpleUsersetBlock(plan, pattern)
+		}
+		block.Propagatable = anyRelationPropagatable(pattern.SourceRelations, propagatable)
+		blocks = append(blocks, block)
+	}
+
+	// Cross-type TTU blocks are non-propagatable (one-hop, not self-referential).
 	blocks = append(blocks, buildCrossTypeTTUBlocks(plan, parentRelations)...)
 
 	return blocks, nil
@@ -79,88 +150,51 @@ func buildRecursiveDirectBlock(plan ListPlan) TypedQueryBlock {
 	}
 }
 
-// buildRecursiveComplexClosureBlocks builds blocks for complex closure relations.
-func buildRecursiveComplexClosureBlocks(plan ListPlan) []TypedQueryBlock {
-	if len(plan.ComplexClosure) == 0 {
-		return nil
-	}
-
-	var blocks []TypedQueryBlock
-	for _, rel := range plan.ComplexClosure {
-		q := Tuples("t").
-			ObjectType(plan.ObjectType).
-			Relations(rel).
-			Where(
-				Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
-				In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
-				SubjectIDMatch(Col{Table: "t", Column: "subject_id"}, SubjectID, plan.AllowWildcard),
-				CheckPermission{
-					Subject:     SubjectParams(),
-					Relation:    rel,
-					Object:      LiteralObject(plan.ObjectType, Col{Table: "t", Column: "object_id"}),
-					ExpectAllow: true,
-				},
-			).
-			SelectCol("object_id").
-			Distinct()
-
-		for _, pred := range plan.Exclusions.BuildPredicates() {
-			q.Where(pred)
-		}
-
-		blocks = append(blocks, TypedQueryBlock{
-			Comments: []string{fmt.Sprintf("-- Complex closure relation: %s", rel)},
-			Query:    q.Build(),
-		})
-	}
-
-	return blocks
-}
-
-// buildRecursiveIntersectionClosureBlocks builds blocks for intersection closure relations.
-func buildRecursiveIntersectionClosureBlocks(plan ListPlan) []TypedQueryBlock {
-	if len(plan.Analysis.IntersectionClosureRelations) == 0 {
-		return nil
-	}
-
-	var blocks []TypedQueryBlock
-	for _, rel := range plan.Analysis.IntersectionClosureRelations {
-		funcName := listObjectsFunctionName(plan.ObjectType, rel)
-		stmt := SelectStmt{
-			ColumnExprs: []Expr{Col{Table: "icr", Column: "object_id"}},
-			FromExpr: FunctionCallExpr{
-				Name:  funcName,
-				Args:  []Expr{SubjectType, SubjectID, Null{}, Null{}},
-				Alias: "icr",
+// buildRecursiveComplexClosureBlock builds a block for a single complex closure relation.
+func buildRecursiveComplexClosureBlock(plan ListPlan, rel string) TypedQueryBlock {
+	q := Tuples("t").
+		ObjectType(plan.ObjectType).
+		Relations(rel).
+		Where(
+			Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
+			In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
+			SubjectIDMatch(Col{Table: "t", Column: "subject_id"}, SubjectID, plan.AllowWildcard),
+			CheckPermission{
+				Subject:     SubjectParams(),
+				Relation:    rel,
+				Object:      LiteralObject(plan.ObjectType, Col{Table: "t", Column: "object_id"}),
+				ExpectAllow: true,
 			},
-		}
+		).
+		SelectCol("object_id").
+		Distinct()
 
-		blocks = append(blocks, TypedQueryBlock{
-			Comments: []string{fmt.Sprintf("-- Intersection closure: %s", rel)},
-			Query:    stmt,
-		})
+	for _, pred := range plan.Exclusions.BuildPredicates() {
+		q.Where(pred)
 	}
 
-	return blocks
+	return TypedQueryBlock{
+		Comments: []string{fmt.Sprintf("-- Complex closure relation: %s", rel)},
+		Query:    q.Build(),
+	}
 }
 
-// buildRecursiveUsersetPatternBlocks builds blocks for userset patterns.
-func buildRecursiveUsersetPatternBlocks(plan ListPlan) []TypedQueryBlock {
-	patterns := buildListUsersetPatternInputs(plan.Analysis)
-	if len(patterns) == 0 {
-		return nil
+// buildRecursiveIntersectionClosureBlock builds a block for a single intersection closure relation.
+func buildRecursiveIntersectionClosureBlock(plan ListPlan, rel string) TypedQueryBlock {
+	funcName := listObjectsFunctionName(plan.ObjectType, rel)
+	stmt := SelectStmt{
+		ColumnExprs: []Expr{Col{Table: "icr", Column: "object_id"}},
+		FromExpr: FunctionCallExpr{
+			Name:  funcName,
+			Args:  []Expr{SubjectType, SubjectID, Null{}, Null{}},
+			Alias: "icr",
+		},
 	}
 
-	var blocks []TypedQueryBlock
-	for _, pattern := range patterns {
-		if pattern.IsComplex {
-			blocks = append(blocks, buildRecursiveComplexUsersetBlock(plan, pattern))
-		} else {
-			blocks = append(blocks, buildRecursiveSimpleUsersetBlock(plan, pattern))
-		}
+	return TypedQueryBlock{
+		Comments: []string{fmt.Sprintf("-- Intersection closure: %s", rel)},
+		Query:    stmt,
 	}
-
-	return blocks
 }
 
 // buildRecursiveComplexUsersetBlock builds a block for complex userset patterns.
@@ -284,6 +318,8 @@ func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelation
 }
 
 // buildRecursiveTTUBlock builds the recursive term block for self-referential TTU.
+// Filters on a.propagatable to ensure only results from TTU-bearing relations
+// seed the recursive step (e.g., folder_viewer results do NOT propagate).
 func buildRecursiveTTUBlock(plan ListPlan, linkingRelations []string) *TypedQueryBlock {
 	exclusions := buildExclusionInput(
 		plan.Analysis,
@@ -294,7 +330,7 @@ func buildRecursiveTTUBlock(plan ListPlan, linkingRelations []string) *TypedQuer
 
 	stmt := SelectStmt{
 		Distinct: true,
-		Columns:  []string{"child.object_id", "a.depth + 1 AS depth"},
+		Columns:  []string{"child.object_id", "a.depth + 1 AS depth", "TRUE AS propagatable"},
 		From:     "accessible",
 		Alias:    "a",
 		Joins: []JoinClause{
@@ -310,7 +346,10 @@ func buildRecursiveTTUBlock(plan ListPlan, linkingRelations []string) *TypedQuer
 				),
 			},
 		},
-		Where: Lt{Left: Col{Table: "a", Column: "depth"}, Right: Int(25)},
+		Where: And(
+			Col{Table: "a", Column: "propagatable"},
+			Lt{Left: Col{Table: "a", Column: "depth"}, Right: Int(25)},
+		),
 	}
 
 	if predicates := exclusions.BuildPredicates(); len(predicates) > 0 {

--- a/lib/sqlgen/list_objects_render_recursive.go
+++ b/lib/sqlgen/list_objects_render_recursive.go
@@ -25,7 +25,7 @@ func RenderListObjectsRecursiveFunction(plan ListPlan, blocks RecursiveBlockSet)
 		Recursive: true,
 		CTEs: []CTEDef{{
 			Name:    "accessible",
-			Columns: []string{"object_id", "depth"},
+			Columns: []string{"object_id", "depth", "propagatable"},
 			Query:   Raw(cteBody),
 		}},
 		Query: finalStmt,
@@ -66,13 +66,14 @@ func RenderListObjectsRecursiveFunction(plan ListPlan, blocks RecursiveBlockSet)
 func renderRecursiveCTEBody(blocks RecursiveBlockSet) string {
 	baseBlocksSQL := make([]string, 0, len(blocks.BaseBlocks))
 	for _, block := range blocks.BaseBlocks {
-		wrappedSQL := wrapQueryWithDepthForRender(block.Query.SQL(), "0", "base")
+		wrappedSQL := wrapQueryWithDepthAndPropagatable(block.Query.SQL(), "0", "base", block.Propagatable)
 		baseBlocksSQL = append(baseBlocksSQL, formatQueryBlockSQL(block.Comments, wrappedSQL))
 	}
 
 	cteBody := joinUnionBlocksSQL(baseBlocksSQL)
 
 	if blocks.RecursiveBlock != nil {
+		// Recursive block emits its own propagatable column (TRUE) via the Columns field
 		recursiveSQL := formatQueryBlockSQL(blocks.RecursiveBlock.Comments, blocks.RecursiveBlock.Query.SQL())
 		cteBody = appendUnionAll(cteBody, recursiveSQL)
 	}

--- a/lib/sqlgen/list_shared_blocks.go
+++ b/lib/sqlgen/list_shared_blocks.go
@@ -5,6 +5,14 @@ package sqlgen
 type TypedQueryBlock struct {
 	Comments []string
 	Query    SelectStmt
+
+	// Propagatable indicates whether results from this block should seed
+	// the recursive step in a recursive CTE. Only results from relations
+	// that participate in self-referential TTU patterns should propagate.
+	// For example, with "can_view: viewer or folder_viewer" where only
+	// viewer has "viewer from parent", blocks matching folder_viewer
+	// should NOT propagate through the parent chain.
+	Propagatable bool
 }
 
 // BlockSet contains query blocks for a list function.

--- a/lib/sqlgen/list_shared_render.go
+++ b/lib/sqlgen/list_shared_render.go
@@ -28,6 +28,17 @@ func wrapQueryWithDepthForRender(sql, depthExpr, alias string) string {
 		alias, depthExpr, sql, alias)
 }
 
+// wrapQueryWithDepthAndPropagatable wraps a query to include depth and propagatable columns.
+// The propagatable column controls whether results from this block seed the recursive step.
+func wrapQueryWithDepthAndPropagatable(sql, depthExpr, alias string, propagatable bool) string {
+	propVal := "FALSE"
+	if propagatable {
+		propVal = "TRUE"
+	}
+	return fmt.Sprintf("SELECT DISTINCT %s.object_id, %s AS depth, %s AS propagatable\nFROM (\n%s\n) AS %s",
+		alias, depthExpr, propVal, sql, alias)
+}
+
 // formatQueryBlockSQL formats a query block with comments.
 func formatQueryBlockSQL(comments []string, sql string) string {
 	lines := make([]string, 0, len(comments)+1)

--- a/test/openfgatests/testdata/melange_tests.yaml
+++ b/test/openfgatests/testdata/melange_tests.yaml
@@ -528,3 +528,81 @@ tests:
             expectation:
               - document:doc1
               - document:doc2
+
+  # ---------------------------------------------------------------------------
+  # non_propagating_relation_in_recursive_list
+  # Pattern: can_view: viewer or folder_viewer
+  #          viewer: [user] or viewer from parent (propagates)
+  #          folder_viewer: [user]                (does NOT propagate)
+  # Verifies that list_objects does not propagate non-propagating relations
+  # through parent TTU in the recursive CTE.
+  # Regression test for: the recursive step in list_*_objects treats ALL base
+  # results as propagatable parents, so folder_viewer on a parent incorrectly
+  # gives can_view on children.
+  # ---------------------------------------------------------------------------
+  - name: non_propagating_relation_in_recursive_list
+    stages:
+      - model: |
+          model
+            schema 1.1
+
+          type user
+
+          type folder
+            relations
+              define parent: [folder]
+              define viewer: [user] or viewer from parent
+              define folder_viewer: [user]
+              define can_view: viewer or folder_viewer
+        tuples:
+          # folder:child's parent is folder:root
+          - user: folder:root
+            relation: parent
+            object: folder:child
+          # alice has folder_viewer on root (non-propagating)
+          - user: user:alice
+            relation: folder_viewer
+            object: folder:root
+          # bob has viewer on root (propagating)
+          - user: user:bob
+            relation: viewer
+            object: folder:root
+        checkAssertions:
+          - name: alice_can_view_root_via_folder_viewer
+            tuple:
+              user: user:alice
+              relation: can_view
+              object: folder:root
+            expectation: true
+          - name: alice_cannot_view_child_folder_viewer_does_not_propagate
+            tuple:
+              user: user:alice
+              relation: can_view
+              object: folder:child
+            expectation: false
+          - name: bob_can_view_root_via_viewer
+            tuple:
+              user: user:bob
+              relation: can_view
+              object: folder:root
+            expectation: true
+          - name: bob_can_view_child_viewer_propagates
+            tuple:
+              user: user:bob
+              relation: can_view
+              object: folder:child
+            expectation: true
+        listObjectsAssertions:
+          - request:
+              user: user:alice
+              type: folder
+              relation: can_view
+            expectation:
+              - folder:root
+          - request:
+              user: user:bob
+              type: folder
+              relation: can_view
+            expectation:
+              - folder:child
+              - folder:root


### PR DESCRIPTION
## Problem

`list_*_objects` recursive CTEs treat all base results as propagatable parents. When a computed permission unions a propagating relation (e.g. `viewer: [user] or viewer from parent`) with a non-propagating relation (e.g. `folder_viewer: [user]`), results from `folder_viewer` on a parent incorrectly propagate to children via the recursive step.

For example, with `can_view: viewer or folder_viewer` where only `viewer` has a `from parent` TTU, a user with `folder_viewer` on `folder:root` incorrectly gets `can_view` on `folder:child`. `check_permission` correctly denies this — only `list_*_objects` is affected.

Minimal reproduction: https://github.com/jtbeach/melange-non-propagating-bug

## Fix

Add a `propagatable` boolean column to the recursive CTE. Each base block is tagged based on whether its source relation satisfies a self-referential TTU target (looked up via `AnalysisLookup.SatisfyingRelations`). The recursive step filters on `a.propagatable` so only TTU-bearing relation results seed further expansion.

```diff
- WITH RECURSIVE accessible(object_id, depth) AS (
-     SELECT ... 0 AS depth FROM (...)          -- folder_viewer block
-     UNION
-     SELECT ... 0 AS depth FROM (...)          -- viewer block
+ WITH RECURSIVE accessible(object_id, depth, propagatable) AS (
+     SELECT ... 0 AS depth, FALSE AS propagatable FROM (...)  -- folder_viewer
+     UNION
+     SELECT ... 0 AS depth, TRUE AS propagatable FROM (...)   -- viewer
      UNION ALL
-     SELECT child.object_id, a.depth + 1
+     SELECT child.object_id, a.depth + 1, TRUE AS propagatable
      FROM accessible a
      INNER JOIN melange_tuples child ON ...
-     WHERE a.depth < 25
+     WHERE a.propagatable AND a.depth < 25
  )
```

## Test

Adds `non_propagating_relation_in_recursive_list` regression test to `melange_tests.yaml`.

The test uses a model where `can_view` unions `viewer` (propagating via `viewer from parent`) with `folder_viewer` (non-propagating). Without the fix, `list_objects` returns `{folder:root, folder:child}` for a user with only `folder_viewer` on root. With the fix, it correctly returns `{folder:root}` only.

## Benchmarks

No regression (`BenchmarkOpenFGA_All`, default scale):

| Benchmark | Without fix | With fix |
|-----------|------------|----------|
| DirectAssignment/this/Check/0 | 105µs | 97µs |
| DirectAssignment/this/ListObjects/0 | 139µs | 115µs |
| TupleToUserset/tuple_to_userset/Check/0 | 125µs | 112µs |
| TupleToUserset/tuple_to_userset/ListObjects/0 | 188µs | 169µs |
