### PR TITLE
Move release job to ubuntu-latest and use mise to install tooling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,7 +42,7 @@ jobs:
   release:
     needs: release-please
     if: needs.release-please.outputs.release_created == 'true' || github.event_name == 'workflow_dispatch'
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
       VERSION: ${{ needs.release-please.outputs.tag_name || github.event.inputs.version }}
@@ -79,14 +79,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - uses: pnpm/action-setup@v4
+      # mise.toml pins goreleaser, node, pnpm, and quill (via ubi backend) — one
+      # source of truth for tooling between local dev and CI.
+      - uses: jdx/mise-action@v2
         with:
-          version: 9
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: "22"
-          registry-url: "https://registry.npmjs.org"
+          experimental: true
+          cache: true
 
       - uses: docker/setup-buildx-action@v3
 
@@ -176,10 +174,7 @@ jobs:
             ' CHANGELOG.md > .release-notes.md || true
           fi
 
-      - uses: goreleaser/goreleaser-action@v6
-        with:
-          version: "~> v2"
-          args: ${{ env.DRY_RUN == 'true' && 'release --snapshot --clean --skip=publish --release-notes .release-notes.md' || 'release --clean --release-notes .release-notes.md' }}
+      - name: Run goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
@@ -188,6 +183,12 @@ jobs:
           QUILL_NOTARY_KEY: ${{ secrets.QUILL_NOTARY_KEY }}
           QUILL_NOTARY_KEY_ID: ${{ secrets.QUILL_NOTARY_KEY_ID }}
           QUILL_NOTARY_ISSUER: ${{ secrets.QUILL_NOTARY_ISSUER }}
+        run: |
+          if [ "$DRY_RUN" = "true" ]; then
+            goreleaser release --snapshot --clean --skip=publish --release-notes .release-notes.md
+          else
+            goreleaser release --clean --release-notes .release-notes.md
+          fi
 
       - name: Publish to npm
         env:

--- a/scripts/sign-macos.sh
+++ b/scripts/sign-macos.sh
@@ -34,15 +34,17 @@ if [[ -n "${MELANGE_SKIP_SIGN:-}" ]]; then
     exit 0
 fi
 
-# Check if we're on macOS
-if [[ "$(uname)" != "Darwin" ]]; then
-    echo "Skipping signing: not on macOS"
-    exit 0
-fi
-
 # Check if this is a darwin binary
 if ! file "$BINARY" | grep -q "Mach-O"; then
     echo "Skipping signing: not a Mach-O binary"
+    exit 0
+fi
+
+# Quill works on any OS via Apple's notary API. Only fall back to "skip on
+# non-macOS" when CI credentials aren't set (i.e. local non-macOS dev that
+# can't reach 1Password and has no env vars — nothing to sign with).
+if [[ "$(uname)" != "Darwin" ]] && [[ -z "${QUILL_SIGN_P12:-}" ]]; then
+    echo "Skipping signing: not on macOS and no QUILL_SIGN_P12 in env"
     exit 0
 fi
 


### PR DESCRIPTION
## Summary

The dry-run on PR #49's release workflow failed because GitHub-hosted \`macos-latest\` runners don't ship a Docker daemon, so \`docker/setup-buildx-action\` errors out before goreleaser starts. Quill is OS-agnostic (signs/notarizes via Apple's notary API without macOS toolchain), so the whole pipeline can move to Linux.

Three changes:

1. \`runs-on: macos-latest\` → \`ubuntu-latest\` — Docker buildx works natively, runners are faster and cheaper
2. Use \`jdx/mise-action\` instead of separate \`actions/setup-node\` + \`pnpm/action-setup\` + manual quill install + \`goreleaser/goreleaser-action\`. The repo's existing \`mise.toml\` already pins \`node\`, \`pnpm\`, \`goreleaser\`, \`quill\` (via \`ubi:anchore/quill\`) and \`1password-cli\` — one source of truth between local dev and CI. Goreleaser is then invoked as a plain shell command.
3. Reorder \`sign-macos.sh\` so the CI-credentials path runs on any OS; the \"skip on non-macOS\" branch now only fires when there are also no signing env vars (i.e. local non-macOS dev — nothing to sign with)

## Test plan

- [ ] After merge: re-run the release workflow with \`dry_run: true\` and version \`v0.9.0-test\`
- [ ] Verify mise-action installs node, pnpm, goreleaser, quill from mise.toml
- [ ] Verify docker buildx initializes and \`dockers_v2\` builds run cleanly
- [ ] Verify \`quill sign-and-notarize\` runs against Apple's API for the darwin binaries (real signing in dry-run is fine — it's idempotent and doesn't push to ghcr or npm)

🤖 Generated with [Claude Code](https://claude.com/claude-code)