### PR TITLE
Initialize Go workspace before goreleaser runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -79,6 +79,12 @@ jobs:
           go-version-file: go.mod
           cache: true
 
+      # go.work is gitignored (each contributor owns theirs) but goreleaser
+      # builds cmd/melange, which lives in a separate module. Synthesize a
+      # workspace so cross-module builds resolve.
+      - name: Setup Go workspace
+        run: go work init . ./cmd/melange ./docs ./melange
+
       # mise.toml pins goreleaser, node, pnpm, and quill (via ubi backend) — one
       # source of truth for tooling between local dev and CI.
       - uses: jdx/mise-action@v2


### PR DESCRIPTION
## Summary

PR #50's dry-run got further but failed in goreleaser:

\`\`\`
build failed: exit status 1: main module (github.com/pthm/melange) does not contain package github.com/pthm/melange/cmd/melange
\`\`\`

\`cmd/melange\` is its own Go module (\`github.com/pthm/melange/cmd/melange\`), and \`go.work\` is gitignored (each contributor manages their own). On a fresh CI checkout, there's no workspace, so cross-module builds fail.

The existing \`ci.yml\` and \`openfga-tests.yml\` already handle this with a \`go work init . ./cmd/melange ./docs ./melange\` step. Same fix applied to \`release.yml\`, placed right after \`actions/setup-go\` and before any go-related operations.

## Test plan

- [ ] After merge: re-run \`release\` workflow with \`dry_run: true\` and \`v0.9.0-test\`
- [ ] Verify all goreleaser builds succeed (darwin/linux/windows × amd64/arm64)
- [ ] Verify quill sign-and-notarize runs on the darwin binaries
- [ ] Verify nfpm + dockers_v2 stages complete

🤖 Generated with [Claude Code](https://claude.com/claude-code)