### PR TITLE
Skip codesign verify on non-macOS in sign-macos.sh

### DIFF
--- a/scripts/sign-macos.sh
+++ b/scripts/sign-macos.sh
@@ -172,7 +172,11 @@ else
     quill sign "$BINARY" -vv </dev/null
 fi
 
-# Verify signature
-echo "Verifying signature..."
-codesign --verify --verbose "$BINARY"
+# Verify signature with codesign (macOS only). Quill's sign-and-notarize
+# already confirms the signature with Apple's notary service, so this is
+# a belt-and-braces local check, not the source of truth.
+if [[ "$(uname)" == "Darwin" ]]; then
+    echo "Verifying signature..."
+    codesign --verify --verbose "$BINARY"
+fi
 echo "Signed successfully: $BINARY"


### PR DESCRIPTION
## Summary

PR #51's dry-run got past goreleaser's build phase, quill connected to Apple's notary and signing+notarization succeeded for both darwin binaries. The very last line of \`sign-macos.sh\` then crashed with:

\`\`\`
./scripts/sign-macos.sh: line 177: codesign: command not found
\`\`\`

\`codesign\` is a macOS-only tool (part of Xcode CLI). The \"verify signature with codesign\" step was added as a belt-and-braces local sanity check, but quill's \`sign-and-notarize\` already confirms the signature with Apple's notary service before returning success — so it's safe to gate the \`codesign --verify\` call on \`uname == Darwin\`.

## Test plan

- [ ] After merge: re-run \`release\` workflow with \`dry_run: true\` and \`v0.9.0-test\`
- [ ] Verify the dry-run reaches goreleaser's nfpm + dockers_v2 + homebrew stages
- [ ] Verify \`pnpm publish --dry-run\` runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)