### PR TITLE
Use pnpm pack + npm whoami for dry-run npm publish step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,8 +205,15 @@ jobs:
           pnpm build
           npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
           if [ "$DRY_RUN" = "true" ]; then
-            pnpm publish --dry-run --access public --no-git-checks
-            echo "↪ dry-run: pnpm publish --dry-run completed"
+            # `pnpm publish --dry-run` still hits the registry's version-collision
+            # check, which fails because dry-runs don't bump package.json. Pack
+            # the tarball locally instead, and use `npm whoami` to confirm the
+            # auth token is valid.
+            echo "↪ dry-run: verifying npm auth..."
+            npm whoami
+            echo "↪ dry-run: building and packing tarball..."
+            pnpm pack
+            echo "↪ dry-run: tarball created at clients/typescript/$(ls -1t *.tgz | head -1)"
             exit 0
           fi
           # Idempotent: skip if this version is already on the registry


### PR DESCRIPTION
## Summary

PR #52's dry-run reached the npm publish step but failed:

\`\`\`
npm error You cannot publish over the previously published versions: 0.8.1.
\`\`\`

\`pnpm publish --dry-run\` still calls into the registry's version-collision check, which rejects because the package.json on disk still says \`0.8.1\` (release-please bumps it for real releases, not for dry-runs). Splitting the dry-run into:

- \`npm whoami\` — verifies the \`NPM_TOKEN\` is valid (cheap auth check)
- \`pnpm pack\` — builds the tarball locally with no registry contact

…gets us all the validation we want without depending on the version not yet existing.

## Test plan

- [ ] After merge: re-run \`release\` workflow with \`dry_run: true\` and \`v0.9.0-test\`
- [ ] Verify dry-run reaches the end (cmd/melange dry-run preview prints, job exits 0)
- [ ] Verify \`npm whoami\` resolves to the expected user
- [ ] Verify \`pnpm pack\` produces a tarball

🤖 Generated with [Claude Code](https://claude.com/claude-code)