### PR TITLE
Pin Go to mise.toml, unify CI on mise-action, bump GH Actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: go.mod
+          experimental: true
+          cache: true
+
+      - name: Cache Go modules and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Setup Go workspace
         run: go work init . ./cmd/melange ./docs ./melange
@@ -48,22 +58,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: go.mod
+          experimental: true
+          cache: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Cache Go modules and build
+        uses: actions/cache@v5
         with:
-          node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Setup Go workspace
         run: go work init . ./cmd/melange ./docs ./melange
@@ -91,7 +101,7 @@ jobs:
         run: pnpm test:unit
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage-root.out,./melange/coverage-runtime.out,./cmd/melange/coverage-cmd.out
@@ -120,22 +130,22 @@ jobs:
       DATABASE_URL: postgresql://test:test@localhost:5432/postgres?sslmode=disable
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: go.mod
+          experimental: true
+          cache: true
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
+      - name: Cache Go modules and build
+        uses: actions/cache@v5
         with:
-          node-version: '20'
-
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 10
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Setup Go workspace
         run: go work init . ./cmd/melange ./docs ./melange
@@ -156,7 +166,7 @@ jobs:
         run: pnpm test
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./test/coverage-integration.out

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -35,14 +35,14 @@ jobs:
       HUGO_VERSION: 0.154.2
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # fetch all history for .GitInfo and .Lastmod
           submodules: recursive
 
       - name: Setup Pages
         id: pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Setup Hugo
         run: |
@@ -60,7 +60,7 @@ jobs:
             --baseURL "${{ steps.pages.outputs.base_url }}/"
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: ./docs/public
 
@@ -74,4 +74,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/openfga-tests.yml
+++ b/.github/workflows/openfga-tests.yml
@@ -16,12 +16,22 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
-      - name: Setup Go
-        uses: actions/setup-go@v5
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: go.mod
+          experimental: true
+          cache: true
+
+      - name: Cache Go modules and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       - name: Setup Go workspace
         run: go work init . ./cmd/melange ./docs ./melange
@@ -35,7 +45,7 @@ jobs:
             -run "TestOpenFGA_" ./openfgatests/...
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@v6
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ./test/coverage-openfga.out

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       version: ${{ steps.rp.outputs.version }}
       body: ${{ steps.rp.outputs.body }}
     steps:
-      - uses: googleapis/release-please-action@v4
+      - uses: googleapis/release-please-action@v5
         id: rp
         with:
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -64,7 +64,7 @@ jobs:
             echo "::notice title=Release::Releasing $VERSION"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.RELEASE_PLEASE_TOKEN }}
@@ -74,10 +74,22 @@ jobs:
           git config user.name "melange-release-bot"
           git config user.email "melange-release-bot@users.noreply.github.com"
 
-      - uses: actions/setup-go@v5
+      # mise.toml pins go, goreleaser, node, pnpm, and quill (via ubi backend)
+      # — one source of truth for tooling between local dev and CI.
+      - uses: jdx/mise-action@v4
         with:
-          go-version-file: go.mod
+          experimental: true
           cache: true
+
+      - name: Cache Go modules and build
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
 
       # go.work is gitignored (each contributor owns theirs) but goreleaser
       # builds cmd/melange, which lives in a separate module. Synthesize a
@@ -85,16 +97,9 @@ jobs:
       - name: Setup Go workspace
         run: go work init . ./cmd/melange ./docs ./melange
 
-      # mise.toml pins goreleaser, node, pnpm, and quill (via ubi backend) — one
-      # source of truth for tooling between local dev and CI.
-      - uses: jdx/mise-action@v2
-        with:
-          experimental: true
-          cache: true
+      - uses: docker/setup-buildx-action@v4
 
-      - uses: docker/setup-buildx-action@v3
-
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}

--- a/mise.toml
+++ b/mise.toml
@@ -6,6 +6,10 @@ auto_install = true
 experimental = true
 
 [tools]
+# Toolchain — pinned to major.minor so patch updates flow through but minor
+# bumps are explicit. go.mod's `go` directives top out at 1.25.
+go = "1.25"
+
 # Release automation
 goreleaser = "latest"
 node = "lts"


### PR DESCRIPTION
## Summary

Two related cleanups in one PR:

### 1. Pin Go and unify CI tooling on mise

- Add \`go = \"1.25\"\` to \`mise.toml\` (track 1.25.x patches; matches \`go.mod\`'s \`go 1.25.0\`)
- Drop \`actions/setup-go\`, \`actions/setup-node\`, and \`pnpm/action-setup\` from \`ci.yml\`, \`openfga-tests.yml\`, and \`release.yml\` in favour of \`jdx/mise-action\` — one source of truth for toolchain versions
- Add explicit \`actions/cache@v5\` for Go modules (\`~/go/pkg/mod\`, \`~/.cache/go-build\`) since mise-action only caches its install dir

### 2. Bump GitHub Actions to current latest

| Action | Before | After |
|---|---|---|
| \`actions/cache\` | v4 | v5 |
| \`actions/checkout\` | v4 | v6 |
| \`actions/configure-pages\` | v4 | v6 |
| \`actions/deploy-pages\` | v4 | v5 |
| \`actions/upload-pages-artifact\` | v3 | v5 |
| \`codecov/codecov-action\` | v5 | v6 |
| \`docker/login-action\` | v3 | v4 |
| \`docker/setup-buildx-action\` | v3 | v4 |
| \`googleapis/release-please-action\` | v4 | v5 |
| \`jdx/mise-action\` | v2 | v4 |

The breaking change in each major bump is the Node 20 → 24 runtime upgrade — clears the Node 20 deprecation warnings GitHub started emitting. None of these have schema-level breaking changes that affect the workflows here.

## Behavioural changes worth knowing

- **pnpm**: workflows previously pinned \`v10\`; mise.toml has \`pnpm = \"latest\"\` (currently 10.33.0). Same major.
- **node**: workflows previously pinned \`v20\`; mise.toml has \`node = \"lts\"\` (currently 24.12.0). \`package.json\` engines \`\">=18\"\` covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)