### PR TITLE
Auto-relabel release-please PR after publishing + tighten dispatch gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
     #      detect the merge by the commit-message convention release-please uses.
     if: |
       needs.release-please.outputs.release_created == 'true' ||
-      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '') ||
       (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release '))
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -309,3 +309,29 @@ jobs:
         run: |
           echo "↪ dry-run: would bump cmd/melange/go.mod to require github.com/pthm/melange@${VERSION}"
           echo "↪ dry-run: would tag and push cmd/melange/${VERSION}"
+
+      # release-please tracks the lifecycle of its own release PRs via two
+      # labels: `autorelease: pending` (PR merged, tag not yet created) and
+      # `autorelease: tagged` (release complete). When release-please owns
+      # the tag, it moves the label automatically; we own the tag, so we
+      # have to do it. Without this, the next release-please run finds a
+      # PR labelled `pending`, decides there's an outstanding untagged
+      # release, and refuses to open the next release PR.
+      - name: Mark release-please PR as tagged
+        if: env.DRY_RUN != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
+        run: |
+          pr_number=$(gh pr list \
+            --state merged \
+            --search "chore(main): release ${VERSION#v} in:title" \
+            --json number \
+            --jq '.[0].number // empty')
+          if [ -z "$pr_number" ]; then
+            echo "↪ no release-please PR found for ${VERSION} (likely a workflow_dispatch cut) — skipping label update"
+            exit 0
+          fi
+          gh pr edit "$pr_number" \
+            --remove-label "autorelease: pending" \
+            --add-label "autorelease: tagged"
+          echo "✓ PR #${pr_number} relabelled: pending → tagged"


### PR DESCRIPTION
## Summary

Two small workflow fixes uncovered by the v0.8.2 → v0.8.3 transition:

### 1. Auto-relabel the release-please PR after a successful release

release-please tracks the lifecycle of its own release PRs via two labels:

- \`autorelease: pending\` — PR merged, tag not yet created
- \`autorelease: tagged\` — release complete

When release-please owns the tag, it moves the label automatically. We own the tag (via the staged dance with \`skip-github-release: true\`), so we have to do it ourselves. Without this, every successful release leaves a \`pending\`-labelled PR that blocks the next release-please run with \`There are untagged, merged release PRs outstanding\`.

PR #56 hit exactly this — release-please refused to open a v0.8.3 PR for several days because PR #56 was stuck at \`pending\`. Manually relabelling unblocked it (PR #59 opened immediately after).

This change adds a final step at the end of the \`release\` job that finds the release-please PR by title and relabels it. It runs only on real releases (skipped in dry-run) and after every publish step has succeeded.

### 2. Tighten the \`workflow_dispatch\` gate

The release job currently fires on \`github.event_name == 'workflow_dispatch'\` unconditionally. That means a bare \`workflow_dispatch\` (no \`version\` input) tries to release \"nothing\" and errors at the version-determination step. The visible noise is harmless but misleading — and we *do* want \`workflow_dispatch\` to be useful for re-firing the maintainer-side release-please job without forcing a release.

Change the condition to require a non-empty \`version\` input:

\`\`\`yaml
(github.event_name == 'workflow_dispatch' && github.event.inputs.version != '')
\`\`\`

Empty dispatches now just run the release-please job (which maintains the open release PR) and skip the release job cleanly.

## Test plan

- [ ] \`workflow_dispatch\` with no \`version\` runs release-please only, no failure
- [ ] \`workflow_dispatch\` with \`version: v0.8.3\` \`dry_run: true\` exercises the full path (relabel step skipped)
- [ ] After v0.8.3 ships (real release): PR #59's labels should flip from \`autorelease: pending\` → \`autorelease: tagged\` automatically
- [ ] The push following v0.8.3's release opens the v0.8.4 release PR (if any qualifying commits land)

🤖 Generated with [Claude Code](https://claude.com/claude-code)