### PR TITLE
Switch npm publish to OIDC trusted publisher; fix release gate for merge commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,6 +18,10 @@ permissions:
   contents: write
   pull-requests: write
   packages: write
+  # Required for OIDC trusted publishing to npm — pnpm fetches a GitHub-issued
+  # ID token at publish time and exchanges it with npm for an ephemeral
+  # publishing credential. No static NPM_TOKEN needed.
+  id-token: write
 
 jobs:
   release-please:
@@ -52,7 +56,7 @@ jobs:
     if: |
       needs.release-please.outputs.release_created == 'true' ||
       (github.event_name == 'workflow_dispatch' && github.event.inputs.version != '') ||
-      (github.event_name == 'push' && startsWith(github.event.head_commit.message, 'chore(main): release '))
+      (github.event_name == 'push' && contains(github.event.head_commit.message, 'chore(main): release '))
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -244,21 +248,20 @@ jobs:
             goreleaser release --clean --release-notes "$RELEASE_NOTES_PATH"
           fi
 
+      # Publishes via OIDC trusted publisher (configured on npmjs.com against
+      # this repo + workflow file). No static NPM_TOKEN involved — pnpm fetches
+      # an ID token from GitHub at publish time and exchanges it with npm for
+      # an ephemeral credential. Requires `id-token: write` at the job level.
       - name: Publish to npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd clients/typescript
           pnpm install --frozen-lockfile
           pnpm build
-          npm config set //registry.npmjs.org/:_authToken "$NODE_AUTH_TOKEN"
           if [ "$DRY_RUN" = "true" ]; then
             # `pnpm publish --dry-run` still hits the registry's version-collision
             # check, which fails because dry-runs don't bump package.json. Pack
-            # the tarball locally instead, and use `npm whoami` to confirm the
-            # auth token is valid.
-            echo "↪ dry-run: verifying npm auth..."
-            npm whoami
+            # the tarball locally instead — exercises the build + files glob
+            # without any registry interaction.
             echo "↪ dry-run: building and packing tarball..."
             pnpm pack
             echo "↪ dry-run: tarball created at clients/typescript/$(ls -1t *.tgz | head -1)"


### PR DESCRIPTION
## Summary

Two fixes for issues uncovered by the v0.8.3 release attempt:

### 1. Switch npm publish to OIDC trusted publishing

The v0.8.3 release reached the \`Publish to npm\` step and failed:

\`\`\`
[WARN] Skipped OIDC: ERR_PNPM_ID_TOKEN_GITHUB_WORKFLOW_INCORRECT_PERMISSIONS
[E404] 404 Not Found - PUT https://registry.npmjs.org/@pthm%2fmelange - Not found
\`\`\`

pnpm 11 (now what mise installs for \`pnpm = \"latest\"\`) attempts OIDC publishing first, falls back to \`NODE_AUTH_TOKEN\`. The OIDC attempt failed because the workflow lacked \`id-token: write\`. The fallback then 404'd because the static \`NPM_TOKEN\` had expired (npm Automation tokens default to 30-day life since late 2024 — v0.8.2 shipped April 30, the secret was created earlier).

Trusted publishers solve this permanently:
- npmjs.com has been configured to trust this workflow file (\`.github/workflows/release.yml\` in \`pthm/melange\`)
- pnpm exchanges a short-lived GitHub OIDC token for an ephemeral npm publishing credential at publish time
- No \`NPM_TOKEN\` secret in CI, no token rotation, no expiry

Changes:
- Add \`id-token: write\` to the job permissions block
- Drop \`NODE_AUTH_TOKEN\` env from the npm publish step
- Drop the \`npm config set ... :_authToken\` line — OIDC is per-publish, not session-scoped
- Drop the \`npm whoami\` check from the dry-run path — same reason; \`pnpm pack\` still validates the build + files glob

After this lands, the \`NPM_TOKEN\` repo secret is no longer used and can be deleted (separately).

### 2. Fix release gate for non-squash merges

PR #59 (\`chore(main): release 0.8.3\`) was merged with **\"Create a merge commit\"** rather than squash. The merge commit message looks like:

\`\`\`
Merge pull request #59 from pthm/release-please--branches--main--components--melange

chore(main): release 0.8.3
\`\`\`

The gate condition \`startsWith(github.event.head_commit.message, 'chore(main): release ')\` only matches squash-merge commits (which use the PR title as the first line). The merge-commit form has \`chore(main): release 0.8.3\` on the *second* line, so \`startsWith\` returned false and the release job skipped — even though v0.8.3 was a legitimate release.

Change to \`contains(...)\`. Handles both styles. The pattern (\`'chore(main): release '\` with the trailing space) is specific enough that false positives are vanishingly unlikely.

## Test plan

- [ ] After merge: re-fire \`workflow_dispatch\` with \`version: v0.8.3\` \`dry_run: false\` to ship the remainder of v0.8.3 (npm + cmd/melange tag + PR #59 relabel). Goreleaser will re-publish the GitHub release with \`mode: replace\` (same 11 artifacts, same SHAs) — minor churn.
- [ ] Subsequent release-please PR merges should auto-fire the release job whether merged via squash or merge-commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)