### PR TITLE
Fix relabel step to match release-please PR titles literally

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -325,13 +325,20 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN }}
         run: |
+          # gh's --search uses GitHub's search syntax, which tokenises on
+          # parentheses — `chore(main):` doesn't match as a phrase. Fetch the
+          # latest merged release-please PRs and filter locally on the exact
+          # title for a clean equality check.
+          expected_title="chore(main): release ${VERSION#v}"
           pr_number=$(gh pr list \
             --state merged \
-            --search "chore(main): release ${VERSION#v} in:title" \
-            --json number \
-            --jq '.[0].number // empty')
+            --label "autorelease: pending" \
+            --limit 20 \
+            --json number,title \
+            --jq ".[] | select(.title == \"${expected_title}\") | .number" \
+            | head -n 1)
           if [ -z "$pr_number" ]; then
-            echo "↪ no release-please PR found for ${VERSION} (likely a workflow_dispatch cut) — skipping label update"
+            echo "↪ no release-please PR found with title '${expected_title}' (likely a workflow_dispatch cut) — skipping label update"
             exit 0
           fi
           gh pr edit "$pr_number" \


### PR DESCRIPTION
## Summary

The relabel step landed in PR #60 used \`gh pr list --search\` to find the release-please PR by title. \`--search\` uses GitHub's search query syntax, which tokenises on parentheses — so \`chore(main):\` doesn't match as a single phrase. The query returned zero results for v0.8.3, the relabel was skipped, and PR #59 stayed at \`autorelease: pending\` (had to relabel by hand).

Switch to fetching the most recent merged PRs that still carry \`autorelease: pending\` and filtering locally on the exact title — sidesteps the search-syntax mismatch and incidentally narrows the candidate set to just unfinished releases.

\`\`\`yaml
expected_title="chore(main): release ${VERSION#v}"
pr_number=$(gh pr list \
  --state merged \
  --label "autorelease: pending" \
  --limit 20 \
  --json number,title \
  --jq ".[] | select(.title == \"${expected_title}\") | .number" \
  | head -n 1)
\`\`\`

## Test plan

- [ ] Once landed: the v0.8.4 release will exercise the relabel automatically. Watch for the new label transition rather than the manual workaround used for v0.8.3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)