### PR TITLE
perf(sqlgen): list cross-type TTU objects subject-first

### DIFF
--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -308,7 +308,12 @@ func splitBlocksByPropagation(relations []string, propagatable map[string]bool, 
 }
 
 // buildCrossTypeTTUBlocks builds blocks for cross-type TTU patterns.
-// These are non-recursive and use check_permission_internal.
+// When the parent relation has a non-recursive list_objects function, it uses a
+// subject-first path: list accessible parents for the subject, then join child
+// linking tuples. This avoids scanning every child candidate and calling
+// check_permission_internal for each one. Recursive parent list functions can
+// form cross-type list cycles, so those keep the check_permission_internal
+// fallback.
 func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelationData) []TypedQueryBlock {
 	var blocks []TypedQueryBlock
 
@@ -326,36 +331,140 @@ func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelation
 			SubjectID,
 		)
 
-		q := Tuples(plan.DatabaseSchema, "child").
-			ObjectType(plan.ObjectType).
-			Relations(parent.LinkingRelation).
-			Where(
-				In{Expr: Col{Table: "child", Column: "subject_type"}, Values: crossTypes},
-				CheckPermission{
-					Schema:   plan.DatabaseSchema,
-					Subject:  SubjectParams(),
-					Relation: parent.Relation,
-					Object: ObjectRef{
-						Type: Col{Table: "child", Column: "subject_type"},
-						ID:   Col{Table: "child", Column: "subject_id"},
-					},
-					ExpectAllow: true,
-				},
-			).
-			SelectCol("object_id").
-			Distinct()
-
-		for _, pred := range crossExclusions.BuildPredicates() {
-			q.Where(pred)
+		var fallbackTypes []string
+		for _, parentType := range crossTypes {
+			if canUseSubjectFirstTTU(plan, parent, parentType) {
+				blocks = append(blocks, buildSubjectFirstCrossTypeTTUBlock(plan, parent, parentType, crossExclusions))
+			} else {
+				fallbackTypes = append(fallbackTypes, parentType)
+			}
 		}
 
-		blocks = append(blocks, TypedQueryBlock{
-			Comments: []string{fmt.Sprintf("-- Cross-type TTU: %s -> %s", parent.LinkingRelation, parent.Relation)},
-			Query:    q.Build(),
-		})
+		if len(fallbackTypes) > 0 {
+			blocks = append(blocks, buildCheckPermissionCrossTypeTTUBlock(plan, parent, fallbackTypes, crossExclusions))
+		}
 	}
 
 	return blocks
+}
+
+func canUseSubjectFirstTTU(plan ListPlan, parent ListParentRelationData, parentType string) bool {
+	if plan.AnalysisLookup == nil {
+		return false
+	}
+
+	parentAnalysis, ok := plan.AnalysisLookup[parentType+"."+parent.Relation]
+	if !ok || !parentAnalysis.Capabilities.ListAllowed {
+		return false
+	}
+
+	// Avoid introducing cross-type list recursion. The permission-check fallback
+	// carries p_visited and remains the safe path for recursive/composed list
+	// strategies; direct/userset/intersection parents have no TTU list calls.
+	switch parentAnalysis.ListStrategy {
+	case ListStrategyDirect, ListStrategyUserset, ListStrategyIntersection:
+		return true
+	default:
+		return false
+	}
+}
+
+func buildSubjectFirstCrossTypeTTUBlock(plan ListPlan, parent ListParentRelationData, parentType string, exclusions ExclusionConfig) TypedQueryBlock {
+	conditions := exclusions.BuildPredicates()
+	if sourceRelationNeedsVerification(plan, parent) {
+		conditions = append(conditions, sourceRelationCheck(plan, parent))
+	}
+
+	stmt := SelectStmt{
+		Distinct:    true,
+		ColumnExprs: []Expr{Col{Table: "child", Column: "object_id"}},
+		FromExpr: FunctionCallExpr{
+			Schema: plan.DatabaseSchema,
+			Name:   ListObjectsFunctionName(parentType, parent.Relation),
+			Args:   []Expr{SubjectType, SubjectID, Null{}, Null{}},
+			Alias:  "parent_obj",
+		},
+		Joins: []JoinClause{
+			{
+				Type:  "INNER",
+				Table: "melange_tuples",
+				Alias: "child",
+				On: And(
+					Eq{Left: Col{Table: "child", Column: "object_type"}, Right: Lit(plan.ObjectType)},
+					Eq{Left: Col{Table: "child", Column: "relation"}, Right: Lit(parent.LinkingRelation)},
+					Eq{Left: Col{Table: "child", Column: "subject_type"}, Right: Lit(parentType)},
+					Eq{Left: Col{Table: "child", Column: "subject_id"}, Right: Col{Table: "parent_obj", Column: "object_id"}},
+				),
+			},
+		},
+		Where: buildWhereFromPredicates(conditions),
+	}
+
+	return TypedQueryBlock{
+		Comments: []string{fmt.Sprintf("-- Cross-type TTU subject-first: %s -> %s.%s", parent.LinkingRelation, parentType, parent.Relation)},
+		Query:    stmt,
+	}
+}
+
+func sourceRelationNeedsVerification(plan ListPlan, parent ListParentRelationData) bool {
+	if !parent.IsClosurePattern || parent.SourceRelation == "" {
+		return false
+	}
+	if plan.AnalysisLookup == nil {
+		return true
+	}
+
+	sourceAnalysis, ok := plan.AnalysisLookup[plan.ObjectType+"."+parent.SourceRelation]
+	if !ok {
+		return true
+	}
+
+	return sourceAnalysis.Features.HasExclusion || sourceAnalysis.Features.HasIntersection
+}
+
+func sourceRelationCheck(plan ListPlan, parent ListParentRelationData) Expr {
+	return CheckPermission{
+		Schema:      plan.DatabaseSchema,
+		Subject:     SubjectParams(),
+		Relation:    parent.SourceRelation,
+		Object:      LiteralObject(plan.ObjectType, Col{Table: "child", Column: "object_id"}),
+		ExpectAllow: true,
+	}
+}
+
+func buildCheckPermissionCrossTypeTTUBlock(plan ListPlan, parent ListParentRelationData, crossTypes []string, exclusions ExclusionConfig) TypedQueryBlock {
+	accessCheck := Expr(CheckPermission{
+		Schema:   plan.DatabaseSchema,
+		Subject:  SubjectParams(),
+		Relation: parent.Relation,
+		Object: ObjectRef{
+			Type: Col{Table: "child", Column: "subject_type"},
+			ID:   Col{Table: "child", Column: "subject_id"},
+		},
+		ExpectAllow: true,
+	})
+	if sourceRelationNeedsVerification(plan, parent) {
+		accessCheck = sourceRelationCheck(plan, parent)
+	}
+
+	q := Tuples(plan.DatabaseSchema, "child").
+		ObjectType(plan.ObjectType).
+		Relations(parent.LinkingRelation).
+		Where(
+			In{Expr: Col{Table: "child", Column: "subject_type"}, Values: crossTypes},
+			accessCheck,
+		).
+		SelectCol("object_id").
+		Distinct()
+
+	for _, pred := range exclusions.BuildPredicates() {
+		q.Where(pred)
+	}
+
+	return TypedQueryBlock{
+		Comments: []string{fmt.Sprintf("-- Cross-type TTU fallback: %s -> %s", parent.LinkingRelation, parent.Relation)},
+		Query:    q.Build(),
+	}
 }
 
 // buildRecursiveTTUBlock builds the recursive term block for self-referential TTU.

--- a/lib/sqlgen/list_objects_blocks_recursive_test.go
+++ b/lib/sqlgen/list_objects_blocks_recursive_test.go
@@ -1,0 +1,246 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildCrossTypeTTUBlocksUsesSubjectFirstParentList(t *testing.T) {
+	parentAnalysis := RelationAnalysis{
+		ObjectType: "namespace",
+		Relation:   "admin",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyUserset,
+	}
+
+	plan := ListPlan{
+		ObjectType: "channel",
+		Relation:   "can_read",
+		Analysis: RelationAnalysis{
+			ObjectType: "channel",
+			Relation:   "can_read",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"namespace.admin": &parentAnalysis,
+		},
+	}
+
+	blocks := buildCrossTypeTTUBlocks(plan, []ListParentRelationData{{
+		Relation:              "admin",
+		LinkingRelation:       "namespace",
+		CrossTypeLinkingTypes: "'namespace'",
+		HasCrossTypeLinks:     true,
+	}})
+
+	if len(blocks) != 1 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	}
+
+	sql := blocks[0].Query.SQL()
+	assertContains(t, sql, "FROM list_namespace_admin_obj(p_subject_type, p_subject_id, NULL, NULL) AS parent_obj")
+	assertContains(t, sql, "INNER JOIN melange_tuples AS child ON")
+	assertContains(t, sql, "child.object_type = 'channel'")
+	assertContains(t, sql, "child.relation = 'namespace'")
+	assertContains(t, sql, "child.subject_type = 'namespace'")
+	assertContains(t, sql, "child.subject_id = parent_obj.object_id")
+	assertNotContains(t, sql, "check_permission_internal")
+}
+
+func TestBuildCrossTypeTTUBlocksFallsBackForRecursiveParentList(t *testing.T) {
+	parentAnalysis := RelationAnalysis{
+		ObjectType: "folder",
+		Relation:   "viewer",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyRecursive,
+	}
+
+	plan := ListPlan{
+		ObjectType: "document",
+		Relation:   "viewer",
+		Analysis: RelationAnalysis{
+			ObjectType: "document",
+			Relation:   "viewer",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"folder.viewer": &parentAnalysis,
+		},
+	}
+
+	blocks := buildCrossTypeTTUBlocks(plan, []ListParentRelationData{{
+		Relation:              "viewer",
+		LinkingRelation:       "parent",
+		CrossTypeLinkingTypes: "'folder'",
+		HasCrossTypeLinks:     true,
+	}})
+
+	if len(blocks) != 1 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	}
+
+	sql := blocks[0].Query.SQL()
+	assertContains(t, sql, "FROM melange_tuples AS child")
+	assertContains(t, sql, "child.subject_type IN ('folder')")
+	assertContains(t, sql, "check_permission_internal")
+	assertNotContains(t, sql, "list_folder_viewer_obj")
+}
+
+func TestBuildCrossTypeTTUBlocksVerifiesClosureSourceRelationWhenConstrained(t *testing.T) {
+	parentAnalysis := RelationAnalysis{
+		ObjectType: "namespace",
+		Relation:   "admin",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyDirect,
+	}
+	sourceAnalysis := RelationAnalysis{
+		ObjectType: "channel",
+		Relation:   "reader",
+		Features: RelationFeatures{
+			HasExclusion: true,
+		},
+	}
+
+	plan := ListPlan{
+		ObjectType: "channel",
+		Relation:   "can_read",
+		Analysis: RelationAnalysis{
+			ObjectType: "channel",
+			Relation:   "can_read",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"namespace.admin": &parentAnalysis,
+			"channel.reader":  &sourceAnalysis,
+		},
+	}
+
+	blocks := buildCrossTypeTTUBlocks(plan, []ListParentRelationData{{
+		Relation:              "admin",
+		LinkingRelation:       "namespace",
+		CrossTypeLinkingTypes: "'namespace'",
+		HasCrossTypeLinks:     true,
+		IsClosurePattern:      true,
+		SourceRelation:        "reader",
+	}})
+
+	if len(blocks) != 1 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	}
+
+	sql := blocks[0].Query.SQL()
+	assertContains(t, sql, "FROM list_namespace_admin_obj(p_subject_type, p_subject_id, NULL, NULL) AS parent_obj")
+	assertContains(t, sql, "check_permission_internal(p_subject_type, p_subject_id, 'reader', 'channel', child.object_id, ARRAY[]::TEXT[]) = 1")
+}
+
+func TestBuildCrossTypeTTUBlocksSkipsClosureSourceCheckWhenUnconstrained(t *testing.T) {
+	parentAnalysis := RelationAnalysis{
+		ObjectType: "namespace",
+		Relation:   "admin",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyDirect,
+	}
+	sourceAnalysis := RelationAnalysis{
+		ObjectType: "channel",
+		Relation:   "reader",
+	}
+
+	plan := ListPlan{
+		ObjectType: "channel",
+		Relation:   "can_read",
+		Analysis: RelationAnalysis{
+			ObjectType: "channel",
+			Relation:   "can_read",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"namespace.admin": &parentAnalysis,
+			"channel.reader":  &sourceAnalysis,
+		},
+	}
+
+	blocks := buildCrossTypeTTUBlocks(plan, []ListParentRelationData{{
+		Relation:              "admin",
+		LinkingRelation:       "namespace",
+		CrossTypeLinkingTypes: "'namespace'",
+		HasCrossTypeLinks:     true,
+		IsClosurePattern:      true,
+		SourceRelation:        "reader",
+	}})
+
+	if len(blocks) != 1 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	}
+
+	sql := blocks[0].Query.SQL()
+	assertContains(t, sql, "FROM list_namespace_admin_obj(p_subject_type, p_subject_id, NULL, NULL) AS parent_obj")
+	assertNotContains(t, sql, "check_permission_internal")
+}
+
+func TestBuildCrossTypeTTUBlocksFallbackVerifiesClosureSourceRelation(t *testing.T) {
+	parentAnalysis := RelationAnalysis{
+		ObjectType: "folder",
+		Relation:   "viewer",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyRecursive,
+	}
+	sourceAnalysis := RelationAnalysis{
+		ObjectType: "document",
+		Relation:   "reader",
+		Features: RelationFeatures{
+			HasIntersection: true,
+		},
+	}
+
+	plan := ListPlan{
+		ObjectType: "document",
+		Relation:   "can_read",
+		Analysis: RelationAnalysis{
+			ObjectType: "document",
+			Relation:   "can_read",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"folder.viewer":   &parentAnalysis,
+			"document.reader": &sourceAnalysis,
+		},
+	}
+
+	blocks := buildCrossTypeTTUBlocks(plan, []ListParentRelationData{{
+		Relation:              "viewer",
+		LinkingRelation:       "parent",
+		CrossTypeLinkingTypes: "'folder'",
+		HasCrossTypeLinks:     true,
+		IsClosurePattern:      true,
+		SourceRelation:        "reader",
+	}})
+
+	if len(blocks) != 1 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	}
+
+	sql := blocks[0].Query.SQL()
+	assertContains(t, sql, "FROM melange_tuples AS child")
+	assertContains(t, sql, "child.subject_type IN ('folder')")
+	assertContains(t, sql, "check_permission_internal(p_subject_type, p_subject_id, 'reader', 'document', child.object_id, ARRAY[]::TEXT[]) = 1")
+	assertNotContains(t, sql, "list_folder_viewer_obj")
+}
+
+func assertContains(t *testing.T, got, want string) {
+	t.Helper()
+	if !strings.Contains(got, want) {
+		t.Fatalf("SQL missing %q:\n%s", want, got)
+	}
+}
+
+func assertNotContains(t *testing.T, got, unwanted string) {
+	t.Helper()
+	if strings.Contains(got, unwanted) {
+		t.Fatalf("SQL unexpectedly contains %q:\n%s", unwanted, got)
+	}
+}


### PR DESCRIPTION
## Summary

Generated `list_objects` SQL for cross-type TTU paths could start from every child candidate and call `check_permission_internal` for each row. At larger tuple counts that made otherwise simple list queries scale with the child corpus instead of with the subject's accessible parents.

This changes those paths to seed from the parent list function first, then join back to child tuples. Recursive and unsafe cases keep the existing fallback, and closure-inherited relations still verify the source relation when exclusions or intersections require it.

## Benchmark deltas

Focused `BenchmarkListObjects`, before vs after, `-count=5`:

| Benchmark | Before | After | Delta |
|---|---:|---:|---:|
| geomean | 23.88ms | 2.087ms | **-91.26%** |
| `1K/ListAccessibleRepos_Page10` | 7.681ms | 1.104ms | **-85.63%** |
| `10K/ListAccessibleRepos_Page10` | 66.788ms | 1.173ms | **-98.24%** |
| `100K/ListAccessibleRepos_Page10` | 260.475ms | 1.486ms | **-99.43%** |
| `1M/ListAccessibleRepos_Page10` | 1286.639ms | 2.718ms | **-99.79%** |
| `100K/ListAccessiblePRs_Page10` | 268.87ms | 16.21ms | **-93.97%** |
| `1M/ListAccessiblePRs_Page10` | 1409.1ms | 136.6ms | **-90.31%** |

Additional "channel" authorization repro benchmark: https://github.com/baszalmstra/melange-authz-bench

This models a listing workload with organization-owned namespaces, direct members, public entries, and platform admins. At 10,300 entries, all visibility counts matched and `melange_list_count` now lands in the ~5-29ms range depending on subject.

## Test plan

- [x] `go test ./lib/sqlgen ./lib/sqlgen/analysis ./lib/sqlgen/sqldsl ./lib/sqlgen/tuples`
- [x] `just build-dev`
- [x] `just test-unit`
- [x] `just bench`
- [x] `just bench-openfga`
- [x] Focused before/after `BenchmarkListObjects` comparison with `benchstat`
- [x] Additional "channel" authorization repro benchmark with count validation
