### PR TITLE
perf: schema-independent dispatch + set-oriented list composition (#67)

### DIFF
--- a/cmd/melange/version.go
+++ b/cmd/melange/version.go
@@ -2,35 +2,10 @@ package main
 
 import (
 	"fmt"
-	"runtime/debug"
 
 	"github.com/pthm/melange/lib/version"
 	"github.com/spf13/cobra"
 )
-
-func init() {
-	// If version wasn't set via ldflags, try to get it from Go module info.
-	// This works when installed via "go install github.com/pthm/melange/cmd/melange@version".
-	if version.Version == "dev" {
-		if info, ok := debug.ReadBuildInfo(); ok {
-			if info.Main.Version != "" && info.Main.Version != "(devel)" {
-				version.Version = info.Main.Version
-			}
-			for _, setting := range info.Settings {
-				switch setting.Key {
-				case "vcs.revision":
-					if len(setting.Value) >= 7 {
-						version.Commit = setting.Value[:7]
-					} else {
-						version.Commit = setting.Value
-					}
-				case "vcs.time":
-					version.Date = setting.Value
-				}
-			}
-		}
-	}
-}
 
 var versionCmd = &cobra.Command{
 	Use:   "version",

--- a/docs/content/docs/guides/migrations.md
+++ b/docs/content/docs/guides/migrations.md
@@ -237,11 +237,10 @@ BEGIN
     IF array_length(p_visited, 1) >= 25 THEN
         RAISE EXCEPTION 'resolution too complex' USING ERRCODE = 'M2002';
     END IF;
-    RETURN (SELECT CASE
-        WHEN (p_object_type = 'document' AND p_relation = 'viewer')
-            THEN check_document_viewer(p_subject_type, p_subject_id, p_object_id, p_visited)
-        ELSE 0
-    END);
+    IF (p_object_type = 'document' AND p_relation = 'viewer') THEN
+        RETURN check_document_viewer(p_subject_type, p_subject_id, p_object_id, p_visited);
+    END IF;
+    RETURN 0;
 END;
 $$ LANGUAGE plpgsql STABLE;
 
@@ -318,19 +317,19 @@ CREATE OR REPLACE FUNCTION check_document_editor_no_wildcard(
 -- Check Dispatchers
 -- ============================================================
 
--- Dispatchers are always regenerated to include the new CASE branch
+-- Dispatchers are always regenerated to include the new routing branch
 CREATE OR REPLACE FUNCTION check_permission_internal(
     /* ... */
 ) RETURNS INTEGER AS $$
 BEGIN
     /* ... */
-    RETURN (SELECT CASE
-        WHEN (p_object_type = 'document' AND p_relation = 'editor')
-            THEN check_document_editor(p_subject_type, p_subject_id, p_object_id, p_visited)
-        WHEN (p_object_type = 'document' AND p_relation = 'viewer')
-            THEN check_document_viewer(p_subject_type, p_subject_id, p_object_id, p_visited)
-        ELSE 0
-    END);
+    IF (p_object_type = 'document' AND p_relation = 'editor') THEN
+        RETURN check_document_editor(p_subject_type, p_subject_id, p_object_id, p_visited);
+    END IF;
+    IF (p_object_type = 'document' AND p_relation = 'viewer') THEN
+        RETURN check_document_viewer(p_subject_type, p_subject_id, p_object_id, p_visited);
+    END IF;
+    RETURN 0;
 END;
 $$ LANGUAGE plpgsql STABLE;
 

--- a/lib/sqlgen/check_blocks.go
+++ b/lib/sqlgen/check_blocks.go
@@ -301,18 +301,28 @@ func orExprs(exprs []Expr) Expr {
 	}
 }
 
+// usersetSelfSatisfyingExpr folds the userset self-check closure lookup — "is
+// the subject a userset on THIS object type whose relation satisfies
+// plan.Relation?" — to a compile-time IN-list. object_type and relation are
+// constants (plan.ObjectType, plan.Relation), so the closure's
+// satisfying_relation set for that (type, relation) is statically known:
+// plan.Analysis.SatisfyingRelations (populated directly from the same closure
+// rows in analyzeRelation). This replaces a VALUES scan over the whole model's
+// closure with substring(subject_id ...) IN ('rel', ...), so the emitted SQL no
+// longer embeds the closure table and its size is independent of unrelated
+// relations. Empty SatisfyingRelations → `... IN ()` renders FALSE, matching the
+// VALUES scan (which also never matches when the (type, relation) has no rows).
+func usersetSelfSatisfyingExpr(plan CheckPlan, subjectID Expr) Expr {
+	return In{Expr: SubstringUsersetRelation{Source: subjectID}, Values: plan.Analysis.SatisfyingRelations}
+}
+
 func buildUsersetSubjectChecks(plan CheckPlan) (selfCheck, computedCheck SelectStmt) {
 	closureTable := ClosureTable(plan.Inline.ClosureRows, "c")
 
 	selfCheck = SelectStmt{
 		ColumnExprs: []Expr{Int(1)},
-		FromExpr:    closureTable,
-		Where: And(
-			Eq{Left: Col{Table: "c", Column: "object_type"}, Right: Lit(plan.ObjectType)},
-			Eq{Left: Col{Table: "c", Column: "relation"}, Right: Lit(plan.Relation)},
-			Eq{Left: Col{Table: "c", Column: "satisfying_relation"}, Right: SubstringUsersetRelation{Source: SubjectID}},
-		),
-		Limit: 1,
+		Where:       usersetSelfSatisfyingExpr(plan, SubjectID),
+		Limit:       1,
 	}
 
 	computedCheck = SelectStmt{

--- a/lib/sqlgen/check_blocks.go
+++ b/lib/sqlgen/check_blocks.go
@@ -303,17 +303,23 @@ func orExprs(exprs []Expr) Expr {
 
 // usersetSelfSatisfyingExpr folds the userset self-check closure lookup — "is
 // the subject a userset on THIS object type whose relation satisfies
-// plan.Relation?" — to a compile-time IN-list. object_type and relation are
-// constants (plan.ObjectType, plan.Relation), so the closure's
-// satisfying_relation set for that (type, relation) is statically known:
-// plan.Analysis.SatisfyingRelations (populated directly from the same closure
-// rows in analyzeRelation). This replaces a VALUES scan over the whole model's
-// closure with substring(subject_id ...) IN ('rel', ...), so the emitted SQL no
-// longer embeds the closure table and its size is independent of unrelated
-// relations. Empty SatisfyingRelations → `... IN ()` renders FALSE, matching the
-// VALUES scan (which also never matches when the (type, relation) has no rows).
-func usersetSelfSatisfyingExpr(plan CheckPlan, subjectID Expr) Expr {
-	return In{Expr: SubstringUsersetRelation{Source: subjectID}, Values: plan.Analysis.SatisfyingRelations}
+// a.Relation?" — to a compile-time IN-list. object_type and relation are
+// constants (a.ObjectType, a.Relation), so the closure's satisfying_relation
+// set for that (type, relation) is statically known: a.SatisfyingRelations
+// (populated directly from the same closure rows in analyzeRelation). This
+// replaces a VALUES scan over the whole model's closure with
+// substring(subject_id ...) IN ('rel', ...), so the emitted SQL no longer
+// embeds the closure table and its size is independent of unrelated relations.
+// Empty SatisfyingRelations → `... IN ()` renders FALSE, matching the VALUES
+// scan (which also never matches when the (type, relation) has no rows).
+//
+// Shared by the check self-check (buildUsersetSubjectChecks) and the
+// list_objects self-candidate blocks (buildListObjectsSelfCandidateBlock,
+// buildComposedObjectsSelfBlock): all three key the same constant (object_type,
+// relation) on substring(subject_id ...) against the same closure rows, so they
+// fold to the identical IN-list.
+func usersetSelfSatisfyingExpr(a RelationAnalysis) Expr {
+	return In{Expr: SubstringUsersetRelation{Source: SubjectID}, Values: a.SatisfyingRelations}
 }
 
 func buildUsersetSubjectChecks(plan CheckPlan) (selfCheck, computedCheck SelectStmt) {
@@ -321,7 +327,7 @@ func buildUsersetSubjectChecks(plan CheckPlan) (selfCheck, computedCheck SelectS
 
 	selfCheck = SelectStmt{
 		ColumnExprs: []Expr{Int(1)},
-		Where:       usersetSelfSatisfyingExpr(plan, SubjectID),
+		Where:       usersetSelfSatisfyingExpr(plan.Analysis),
 		Limit:       1,
 	}
 

--- a/lib/sqlgen/check_functions.go
+++ b/lib/sqlgen/check_functions.go
@@ -58,24 +58,24 @@ func isInlineable(f RelationFeatures) bool {
 }
 
 func renderDispatcherWithCases(databaseSchema, fnName string, cases []DispatcherCase) string {
-	caseExpr := buildDispatcherCaseExpr(cases)
-
 	internalName := fnName + "_internal"
+
+	body := []Stmt{
+		Comment{Text: "Depth limit check: prevent excessively deep permission resolution chains"},
+		Comment{Text: "This catches both recursive TTU patterns and long userset chains"},
+		If{
+			Cond: Gte{Left: ArrayLength{Array: Visited}, Right: Int(25)},
+			Then: []Stmt{Raise{Message: "resolution too complex", ErrCode: "M2002"}},
+		},
+	}
+	body = append(body, dispatchIfChain(cases, checkDispatchCall, Int(0))...)
 
 	internalFn := PlpgsqlFunction{
 		Schema:  databaseSchema,
 		Name:    internalName,
 		Args:    dispatcherInternalArgs(),
 		Returns: "INTEGER",
-		Body: []Stmt{
-			Comment{Text: "Depth limit check: prevent excessively deep permission resolution chains"},
-			Comment{Text: "This catches both recursive TTU patterns and long userset chains"},
-			If{
-				Cond: Gte{Left: ArrayLength{Array: Visited}, Right: Int(25)},
-				Then: []Stmt{Raise{Message: "resolution too complex", ErrCode: "M2002"}},
-			},
-			ReturnValue{Value: Raw("(SELECT " + caseExpr.SQL() + ")")},
-		},
+		Body:    body,
 		Header: []string{
 			"Generated internal dispatcher for " + internalName,
 			"Routes to specialized functions with p_visited for cycle detection in TTU patterns",
@@ -322,21 +322,68 @@ func functionNameForDispatcher(a RelationAnalysis, noWildcard bool) string {
 	return functionName(a.ObjectType, a.Relation)
 }
 
-func buildDispatcherCaseExpr(cases []DispatcherCase) CaseExpr {
-	whens := make([]CaseWhen, 0, len(cases))
+// dispatchIfChain renders a routing dispatcher as an IF-chain nested by object
+// type: one outer `IF (p_object_type = 'x') THEN ... END IF;` per type, each
+// containing one inner `IF (p_relation = 'y') THEN RETURN result(c); END IF;`
+// per relation of that type, then `RETURN <elseValue>`. result maps a case to
+// the specialized function call for its arm; elseValue is returned when no
+// pair matches (unknown relation for a known type, or unknown type).
+//
+// The IF-chain beats the equivalent `RETURN CASE ... END`: each matched branch
+// executes a single-function-call RETURN — a trivial simple expression, O(1)
+// to initialize — whereas the CASE is one N-arm expression whose ExecInitExpr
+// setup is O(#relations) on every evaluation. Both avoid the scalar-subquery
+// sublink that disqualified the original `RETURN (SELECT CASE ...)` from
+// PL/pgSQL's simple-expression fast path.
+//
+// Nesting by object type makes a matched call cost O(#types +
+// #relations-of-matched-type) instead of O(#all-relations): a check on one
+// type no longer walks the arms of unrelated types. Unrelated schema growth
+// (relations on other types) stops degrading every query. The dispatcher runs
+// as a per-row predicate inside list/check bodies, so this per-call walk is
+// paid per candidate row.
+//
+// Measured on the issue #67 workload across PostgreSQL 15/16/18:
+// RETURN (SELECT CASE) ~8.0s, RETURN CASE ~4.5s, flat IF-chain ~2.6s. Nesting
+// removes the residual +32% seen when 200 unrelated relations sort ahead of
+// the target in the flat chain.
+func dispatchIfChain(cases []DispatcherCase, result func(DispatcherCase) Expr, elseValue Expr) []Stmt {
+	var typeOrder []string
+	byType := make(map[string][]DispatcherCase)
 	for _, c := range cases {
-		cond := AndExpr{Exprs: []Expr{
-			Eq{Left: ObjectType, Right: Lit(c.ObjectType)},
-			Eq{Left: Raw("p_relation"), Right: Lit(c.Relation)},
-		}}
-		result := Func{
-			Schema: c.DatabaseSchema,
-			Name:   c.CheckFunctionName,
-			Args:   []Expr{SubjectType, SubjectID, ObjectID, Visited},
+		if _, seen := byType[c.ObjectType]; !seen {
+			typeOrder = append(typeOrder, c.ObjectType)
 		}
-		whens = append(whens, CaseWhen{Cond: cond, Result: result})
+		byType[c.ObjectType] = append(byType[c.ObjectType], c)
 	}
-	return CaseExpr{Whens: whens, Else: Int(0)}
+
+	stmts := make([]Stmt, 0, len(typeOrder)+1)
+	for _, ot := range typeOrder {
+		inner := make([]Stmt, 0, len(byType[ot])+1)
+		for _, c := range byType[ot] {
+			inner = append(inner, If{
+				Cond: Eq{Left: Raw("p_relation"), Right: Lit(c.Relation)},
+				Then: []Stmt{ReturnValue{Value: result(c)}},
+			})
+		}
+		// Known type, unknown relation → elseValue (matches the flat chain,
+		// which would fall through every remaining arm to the same result).
+		inner = append(inner, ReturnValue{Value: elseValue})
+		stmts = append(stmts, If{
+			Cond: Eq{Left: ObjectType, Right: Lit(ot)},
+			Then: inner,
+		})
+	}
+	return append(stmts, ReturnValue{Value: elseValue})
+}
+
+// checkDispatchCall is the specialized check_<type>_<rel> call for one arm.
+func checkDispatchCall(c DispatcherCase) Expr {
+	return Func{
+		Schema: c.DatabaseSchema,
+		Name:   c.CheckFunctionName,
+		Args:   []Expr{SubjectType, SubjectID, ObjectID, Visited},
+	}
 }
 
 func bulkDispatcherArgs() []FuncArg {

--- a/lib/sqlgen/check_functions.go
+++ b/lib/sqlgen/check_functions.go
@@ -60,15 +60,14 @@ func isInlineable(f RelationFeatures) bool {
 func renderDispatcherWithCases(databaseSchema, fnName string, cases []DispatcherCase) string {
 	internalName := fnName + "_internal"
 
-	body := []Stmt{
+	body := append([]Stmt{
 		Comment{Text: "Depth limit check: prevent excessively deep permission resolution chains"},
 		Comment{Text: "This catches both recursive TTU patterns and long userset chains"},
 		If{
 			Cond: Gte{Left: ArrayLength{Array: Visited}, Right: Int(25)},
 			Then: []Stmt{Raise{Message: "resolution too complex", ErrCode: "M2002"}},
 		},
-	}
-	body = append(body, dispatchIfChain(cases, checkDispatchCall, Int(0))...)
+	}, dispatchIfChain(cases, checkDispatchCall, Int(0))...)
 
 	internalFn := PlpgsqlFunction{
 		Schema:  databaseSchema,

--- a/lib/sqlgen/check_functions.go
+++ b/lib/sqlgen/check_functions.go
@@ -8,7 +8,7 @@ import (
 )
 
 func generateCheckFunction(a RelationAnalysis, inline InlineSQLData, databaseSchema string, noWildcard bool, complexityByRelation map[string]map[string]int) (string, error) {
-	plan := BuildCheckPlanWithOrdering(a, inline, databaseSchema, noWildcard, complexityByRelation)
+	plan := BuildCheckPlanWithOrdering(a, filterInlineForCheck(inline, a), databaseSchema, noWildcard, complexityByRelation)
 	blocks, err := BuildCheckBlocks(plan)
 	if err != nil {
 		return "", fmt.Errorf("building check blocks for %s.%s: %w", a.ObjectType, a.Relation, err)

--- a/lib/sqlgen/check_functions.go
+++ b/lib/sqlgen/check_functions.go
@@ -86,6 +86,9 @@ func renderDispatcherWithCases(databaseSchema, fnName string, cases []Dispatcher
 		// via TTU or complex usersets. Mark it as expensive so the planner prefers
 		// cheaper EXISTS branches when both appear in an OR/AND chain.
 		Cost: recursiveCheckCost,
+		// Body references only schema-qualified check_{type}_{rel} calls, no
+		// unqualified melange_tuples — search_path is unnecessary here.
+		NoSearchPath: true,
 	}
 
 	publicFn := SqlFunction{
@@ -98,6 +101,9 @@ func renderDispatcherWithCases(databaseSchema, fnName string, cases []Dispatcher
 			"Generated dispatcher for " + fnName,
 			"Routes to specialized functions for all known type/relation pairs",
 		},
+		// Calls only the schema-qualified internal dispatcher. Omitting SET
+		// lets the planner inline this LANGUAGE sql wrapper.
+		NoSearchPath: true,
 	}
 
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"
@@ -114,14 +120,16 @@ func renderEmptyDispatcher(databaseSchema, fnName string) string {
 			"Generated dispatcher for " + fnName + " (no relations defined)",
 			"Returns 0 (deny) for all requests",
 		},
+		NoSearchPath: true,
 	}
 
 	publicFn := SqlFunction{
-		Schema:  databaseSchema,
-		Name:    fnName,
-		Args:    dispatcherPublicArgs(),
-		Returns: "INTEGER",
-		Body:    Raw("SELECT 0"),
+		Schema:       databaseSchema,
+		Name:         fnName,
+		Args:         dispatcherPublicArgs(),
+		Returns:      "INTEGER",
+		Body:         Raw("SELECT 0"),
+		NoSearchPath: true,
 	}
 
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"

--- a/lib/sqlgen/compile.go
+++ b/lib/sqlgen/compile.go
@@ -278,8 +278,9 @@ type NamedFunction struct {
 }
 
 // CollectNamedFunctions returns all specialized functions paired with their SQL.
-// Dispatchers are excluded — they always change when any relation changes and
-// should be unconditionally included in migrations.
+// Dispatchers are excluded here; the migrator checksums them separately via
+// CollectDispatcherFunctions so a dispatcher-only codegen change still defeats
+// the phase-2 skip.
 //
 // The analyses slice must be the same slice, in the same order, passed to
 // GenerateSQL and GenerateListSQL that produced generatedSQL and listSQL.
@@ -337,6 +338,29 @@ func CollectNamedFunctions(
 		}
 	}
 
+	return result
+}
+
+// CollectDispatcherFunctions returns the dispatcher functions paired with their
+// SQL, named by their public entry point. Dispatchers are excluded from
+// CollectNamedFunctions, so without these entries a codegen change that only
+// alters dispatcher SQL is invisible to checksum-based skip detection.
+func CollectDispatcherFunctions(generatedSQL GeneratedSQL, listSQL ListGeneratedSQL) []NamedFunction {
+	all := []NamedFunction{
+		{Name: "check_permission", SQL: generatedSQL.Dispatcher},
+		{Name: "check_permission_nw", SQL: generatedSQL.DispatcherNoWildcard},
+		{Name: "check_permission_bulk", SQL: generatedSQL.BulkDispatcher},
+		{Name: "explain_permission", SQL: generatedSQL.ExplainDispatcher},
+		{Name: "expand_permission", SQL: generatedSQL.ExpandDispatcher},
+		{Name: "list_accessible_objects", SQL: listSQL.ListObjectsDispatcher},
+		{Name: "list_accessible_subjects", SQL: listSQL.ListSubjectsDispatcher},
+	}
+	result := make([]NamedFunction, 0, len(all))
+	for _, nf := range all {
+		if nf.SQL != "" {
+			result = append(result, nf)
+		}
+	}
 	return result
 }
 

--- a/lib/sqlgen/complex_closure_compose_test.go
+++ b/lib/sqlgen/complex_closure_compose_test.go
@@ -1,0 +1,124 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// closurePlan builds a minimal list_objects ListPlan for object type "doc"
+// relation "can_read" with a single complex-closure relation "reader", using
+// the given analysis lookup to drive composability.
+func closurePlan(lookup map[string]*RelationAnalysis) ListPlan {
+	return ListPlan{
+		ObjectType:          "doc",
+		Relation:            "can_read",
+		DatabaseSchema:      "",
+		ComplexClosure:      []string{"reader"},
+		AllowedSubjectTypes: []string{"user"},
+		AnalysisLookup:      lookup,
+	}
+}
+
+func complexClosureSQL(t *testing.T, plan ListPlan) string {
+	t.Helper()
+	blocks, err := buildTypedListObjectsComplexClosureBlocks(plan)
+	if err != nil {
+		t.Fatalf("build blocks: %v", err)
+	}
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	return blocks[0].Query.SQL()
+}
+
+func TestComplexClosure_ComposesWhenComposable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive, // complex, but acyclic below
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "admin", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.admin": {ObjectType: "org", Relation: "admin"},
+	}
+
+	sql := complexClosureSQL(t, closurePlan(lookup))
+
+	if !strings.Contains(sql, "t.object_id IN (SELECT obj.object_id FROM list_doc_reader_obj(p_subject_type, p_subject_id, NULL, NULL) obj)") {
+		t.Errorf("expected set-oriented composition against list_doc_reader_obj, got:\n%s", sql)
+	}
+	// Userset-typed subjects keep a guarded per-candidate check for parity.
+	if !strings.Contains(sql, "position('#' in p_subject_id) > 0") {
+		t.Errorf("expected userset-subject parity guard, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'reader', 'doc', t.object_id") {
+		t.Errorf("expected guarded per-candidate check for userset subjects, got:\n%s", sql)
+	}
+}
+
+func TestComplexClosure_FallsBackWhenCyclic(t *testing.T) {
+	// doc.reader reaches back into doc.can_read → composition unsafe.
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:              "doc",
+			Relation:                "reader",
+			Capabilities:            GenerationCapabilities{ListAllowed: true},
+			ListStrategy:            ListStrategyRecursive,
+			ComplexClosureRelations: []string{"can_read"},
+		},
+	}
+
+	sql := complexClosureSQL(t, closurePlan(lookup))
+
+	if strings.Contains(sql, "list_doc_reader_obj") {
+		t.Errorf("cyclic composition must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'reader', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexClosure_FallsBackWhenNotListGeneratable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: false}, // no list function
+		},
+	}
+
+	sql := complexClosureSQL(t, closurePlan(lookup))
+
+	if strings.Contains(sql, "list_doc_reader_obj") {
+		t.Errorf("non-generatable target must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+// The recursive builder shares complexClosureMembership, so it composes too.
+func TestComplexClosure_RecursiveComposes(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "admin", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.admin": {ObjectType: "org", Relation: "admin"},
+	}
+
+	block := buildRecursiveComplexClosureBlock(closurePlan(lookup), "reader")
+	sql := block.Query.SQL()
+
+	if !strings.Contains(sql, "list_doc_reader_obj(p_subject_type, p_subject_id, NULL, NULL)") {
+		t.Errorf("expected recursive block to compose against list_doc_reader_obj, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/complex_closure_compose_test.go
+++ b/lib/sqlgen/complex_closure_compose_test.go
@@ -59,6 +59,42 @@ func TestComplexClosure_ComposesWhenComposable(t *testing.T) {
 	}
 }
 
+// TestComplexClosure_AdmitsUsersetQuerySubject pins the fix for issue #10: the
+// complex-closure candidate arm must admit a userset-typed query subject
+// (e.g. group:g2#member) whose access flows through the complex relation, not
+// only plain subjects gated by AllowedSubjectTypes. Otherwise list_objects
+// under-reports objects that check_permission allows for that userset subject.
+func TestComplexClosure_AdmitsUsersetQuerySubject(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "admin", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.admin": {ObjectType: "org", Relation: "admin"},
+	}
+
+	sql := complexClosureSQL(t, closurePlan(lookup))
+
+	// Plain-subject arm: type guard AND exact subject match.
+	if !strings.Contains(sql, "p_subject_type IN ('user')") {
+		t.Errorf("expected plain-subject type guard, got:\n%s", sql)
+	}
+	// Userset-subject arm: both sides must be usersets, admitted via exact
+	// userset equality (OR closure). Gated by position('#'...) so it is a no-op
+	// for plain subjects.
+	if !strings.Contains(sql, "position('#' in p_subject_id) > 0 AND position('#' in t.subject_id) > 0") {
+		t.Errorf("expected userset query-subject candidate arm, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "t.subject_id = p_subject_id") {
+		t.Errorf("expected exact userset equality in candidate arm, got:\n%s", sql)
+	}
+}
+
 func TestComplexClosure_FallsBackWhenCyclic(t *testing.T) {
 	// doc.reader reaches back into doc.can_read → composition unsafe.
 	lookup := map[string]*RelationAnalysis{

--- a/lib/sqlgen/complex_closure_compose_test.go
+++ b/lib/sqlgen/complex_closure_compose_test.go
@@ -100,6 +100,124 @@ func TestComplexClosure_FallsBackWhenNotListGeneratable(t *testing.T) {
 	}
 }
 
+// closureSubjectsPlan builds a minimal recursive list_subjects ListPlan for
+// object type "doc" relation "can_read" with a single complex-closure relation
+// "reader", using the given analysis lookup to drive composability.
+func closureSubjectsPlan(lookup map[string]*RelationAnalysis, self RelationFeatures) ListPlan {
+	return ListPlan{
+		ObjectType:          "doc",
+		Relation:            "can_read",
+		DatabaseSchema:      "",
+		ComplexClosure:      []string{"reader"},
+		AllowedSubjectTypes: []string{"user"},
+		AnalysisLookup:      lookup,
+		Analysis:            RelationAnalysis{ObjectType: "doc", Relation: "can_read", Features: self},
+	}
+}
+
+func complexClosureSubjectsSQL(t *testing.T, plan ListPlan) string {
+	t.Helper()
+	blocks := buildListSubjectsRecursiveComplexClosureBlocks(plan)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(blocks))
+	}
+	return blocks[0].Query.SQL()
+}
+
+func TestComplexClosureSubjects_ComposesWhenComposable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "admin", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.admin": {ObjectType: "org", Relation: "admin"},
+	}
+
+	sql := complexClosureSubjectsSQL(t, closureSubjectsPlan(lookup, RelationFeatures{}))
+
+	if !strings.Contains(sql, "t.subject_id IN (SELECT sub.subject_id FROM list_doc_reader_sub(p_object_id, p_subject_type) sub)") {
+		t.Errorf("expected set-oriented composition against list_doc_reader_sub, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("composed block must not keep a per-candidate check, got:\n%s", sql)
+	}
+}
+
+func TestComplexClosureSubjects_FallsBackWhenCyclic(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:              "doc",
+			Relation:                "reader",
+			Capabilities:            GenerationCapabilities{ListAllowed: true},
+			ListStrategy:            ListStrategyRecursive,
+			ComplexClosureRelations: []string{"can_read"},
+		},
+	}
+
+	sql := complexClosureSubjectsSQL(t, closureSubjectsPlan(lookup, RelationFeatures{}))
+
+	if strings.Contains(sql, "list_doc_reader_sub") {
+		t.Errorf("cyclic composition must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, t.subject_id, 'reader', 'doc', p_object_id") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexClosureSubjects_FallsBackWhenTargetHasWildcard(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			Features:     RelationFeatures{HasWildcard: true},
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "admin", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.admin": {ObjectType: "org", Relation: "admin"},
+	}
+
+	sql := complexClosureSubjectsSQL(t, closureSubjectsPlan(lookup, RelationFeatures{}))
+
+	if strings.Contains(sql, "list_doc_reader_sub") {
+		t.Errorf("target HasWildcard must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexClosureSubjects_FallsBackWhenSelfHasWildcard(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "admin", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.admin": {ObjectType: "org", Relation: "admin"},
+	}
+
+	sql := complexClosureSubjectsSQL(t, closureSubjectsPlan(lookup, RelationFeatures{HasWildcard: true}))
+
+	if strings.Contains(sql, "list_doc_reader_sub") {
+		t.Errorf("self HasWildcard must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
 // The recursive builder shares complexClosureMembership, so it composes too.
 func TestComplexClosure_RecursiveComposes(t *testing.T) {
 	lookup := map[string]*RelationAnalysis{

--- a/lib/sqlgen/dispatcher_fastpath_test.go
+++ b/lib/sqlgen/dispatcher_fastpath_test.go
@@ -1,0 +1,52 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// The internal dispatchers are invoked as per-row predicates inside generated
+// check/list bodies, so each dispatch branch must stay a trivial PL/pgSQL
+// simple expression. Two forms were measured on the issue #67 workload
+// (PG15/16/18): the original RETURN (SELECT CASE ...) scalar subquery (~8.0s,
+// sublink disqualifies the fast path), RETURN CASE ... END (~4.5s, one N-arm
+// expression re-initialized per call), and an IF-chain of guarded single-call
+// RETURNs (~2.6s). These tests pin the IF-chain rendering and guard against
+// regressing to either slower form.
+func TestDispatchers_SimpleExpressionFastPath(t *testing.T) {
+	analyses := []RelationAnalysis{
+		mkAnalysis("document", "viewer", RelationFeatures{HasDirect: true}, true),
+		mkAnalysis("document", "editor", RelationFeatures{HasDirect: true}, true),
+	}
+	for i := range analyses {
+		// Expand eligibility needs at least one rewrite; give the direct
+		// rewrite a subject type.
+		analyses[i].DirectSubjectTypes = []string{"user"}
+	}
+
+	checkSQL, err := generateDispatcher(analyses, "", false)
+	if err != nil {
+		t.Fatalf("generateDispatcher: %v", err)
+	}
+	explainSQL, err := generateExplainDispatcher(analyses, "", ComputeExplainEligibility(analyses))
+	if err != nil {
+		t.Fatalf("generateExplainDispatcher: %v", err)
+	}
+	expandSQL := generateExpandDispatcher(analyses, "", ComputeExpandEligibility(analyses))
+
+	for name, sql := range map[string]string{
+		"check":   checkSQL,
+		"explain": explainSQL,
+		"expand":  expandSQL,
+	} {
+		if !strings.Contains(sql, "IF p_object_type = 'document' THEN") || !strings.Contains(sql, "IF p_relation = 'viewer' THEN") {
+			t.Errorf("%s dispatcher: missing nested IF-chain dispatch (type then relation) in:\n%s", name, sql)
+		}
+		if strings.Contains(sql, "RETURN (SELECT") {
+			t.Errorf("%s dispatcher: RETURN wrapped in scalar subquery disqualifies the PL/pgSQL simple-expression fast path:\n%s", name, sql)
+		}
+		if strings.Contains(sql, "RETURN CASE") {
+			t.Errorf("%s dispatcher: RETURN CASE is ~1.7x slower than the IF-chain on the hot path (issue #67); use dispatchIfChain:\n%s", name, sql)
+		}
+	}
+}

--- a/lib/sqlgen/exclusion.go
+++ b/lib/sqlgen/exclusion.go
@@ -186,19 +186,10 @@ func (c ExclusionConfig) complexExclusionAntiJoin(rel string) Expr {
 	if !composableListTargetLookup(c.Compose.Lookup, c.Compose.FromType, c.Compose.FromRel, c.ObjectType, rel) {
 		return nil
 	}
-	membership := Or(
-		InFunctionSelect{
-			Expr:      c.ObjectIDExpr,
-			Schema:    c.DatabaseSchema,
-			FuncName:  ListObjectsFunctionName(c.ObjectType, rel),
-			Args:      []Expr{c.SubjectTypeExpr, c.SubjectIDExpr, Null{}, Null{}},
-			Alias:     "excl_obj",
-			SelectCol: "object_id",
-		},
-		And(
-			HasUserset{Source: c.SubjectIDExpr},
-			c.checkPermission(rel, c.objectRef(), true),
-		),
+	membership := composedListObjectsMembership(
+		c.DatabaseSchema, c.ObjectType, rel, c.ObjectIDExpr,
+		c.SubjectTypeExpr, c.SubjectIDExpr, "excl_obj",
+		c.checkPermission(rel, c.objectRef(), true),
 	)
 	return Not(membership)
 }

--- a/lib/sqlgen/exclusion.go
+++ b/lib/sqlgen/exclusion.go
@@ -44,6 +44,24 @@ type ExclusionConfig struct {
 
 	// ExcludedIntersection represents intersection exclusions (e.g., "but not (A and B)").
 	ExcludedIntersection []ExcludedIntersectionGroup
+
+	// Compose, when set, lets complex exclusions replace the per-candidate
+	// check_permission_internal(...) = 0 with a set-oriented anti-join against
+	// the excluded relation's list_objects function. It is only valid in a
+	// list_objects context — ObjectIDExpr must be the per-row candidate column
+	// and the subject exprs query-constant params — so only the list_objects
+	// plan builder sets it; check and list_subjects contexts leave it nil and
+	// keep the per-candidate check.
+	Compose *exclusionCompose
+}
+
+// exclusionCompose carries the compile-time context the anti-join needs: the
+// relation-reference lookup and the listing relation to run the cycle-safety
+// walk from.
+type exclusionCompose struct {
+	Lookup   map[string]*RelationAnalysis
+	FromType string
+	FromRel  string
 }
 
 // HasExclusions returns true if any exclusion rules are configured.
@@ -130,6 +148,10 @@ func (c ExclusionConfig) BuildPredicates() []Expr {
 	}
 
 	for _, rel := range c.ComplexExcludedRelations {
+		if pred := c.complexExclusionAntiJoin(rel); pred != nil {
+			predicates = append(predicates, pred)
+			continue
+		}
 		predicates = append(predicates, c.checkPermission(rel, c.objectRef(), false))
 	}
 
@@ -144,6 +166,41 @@ func (c ExclusionConfig) BuildPredicates() []Expr {
 	}
 
 	return predicates
+}
+
+// complexExclusionAntiJoin returns the set-oriented exclusion predicate for a
+// complex excluded relation, or nil when composition is unavailable/unsafe (the
+// caller then falls back to the per-candidate check).
+//
+// The object is kept ("but not rel" is satisfied) when the subject does NOT
+// hold rel on it. Membership — "subject holds rel on this object" — is the
+// excluded relation's list_objects set, plus a per-row check that only fires
+// for userset-typed subjects (`id#relation`): the list function is complete
+// for plain subjects but a Recursive/Composed target may under-report userset
+// subjects, and an under-reported exclusion is over-permissive. The predicate
+// is the negation of that membership, mirroring usersetMembership.
+func (c ExclusionConfig) complexExclusionAntiJoin(rel string) Expr {
+	if c.Compose == nil {
+		return nil
+	}
+	if !composableListTargetLookup(c.Compose.Lookup, c.Compose.FromType, c.Compose.FromRel, c.ObjectType, rel) {
+		return nil
+	}
+	membership := Or(
+		InFunctionSelect{
+			Expr:      c.ObjectIDExpr,
+			Schema:    c.DatabaseSchema,
+			FuncName:  ListObjectsFunctionName(c.ObjectType, rel),
+			Args:      []Expr{c.SubjectTypeExpr, c.SubjectIDExpr, Null{}, Null{}},
+			Alias:     "excl_obj",
+			SelectCol: "object_id",
+		},
+		And(
+			HasUserset{Source: c.SubjectIDExpr},
+			c.checkPermission(rel, c.objectRef(), true),
+		),
+	)
+	return Not(membership)
 }
 
 func (c ExclusionConfig) buildIntersectionPredicate(group ExcludedIntersectionGroup) Expr {

--- a/lib/sqlgen/exclusion.go
+++ b/lib/sqlgen/exclusion.go
@@ -267,13 +267,16 @@ func (c ExclusionConfig) BuildExclusionCTE() string {
 		return "SELECT NULL::TEXT AS subject_id WHERE FALSE"
 	}
 
-	q := Tuples(c.DatabaseSchema, "").
+	// Alias the tuples table and qualify subject_id so it cannot collide with
+	// the enclosing function's OUT parameter of the same name (which would
+	// otherwise raise "column reference subject_id is ambiguous" at runtime).
+	q := Tuples(c.DatabaseSchema, "e").
 		ObjectType(c.ObjectType).
 		Relations(c.SimpleExcludedRelations...).
 		Where(
-			Eq{Left: Col{Column: "object_id"}, Right: c.ObjectIDExpr},
+			Eq{Left: Col{Table: "e", Column: "object_id"}, Right: c.ObjectIDExpr},
 		).
-		Select("subject_id")
+		SelectCol("subject_id")
 
 	return q.Build().SQL()
 }

--- a/lib/sqlgen/exclusion_antijoin_test.go
+++ b/lib/sqlgen/exclusion_antijoin_test.go
@@ -1,0 +1,129 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// exclusionWithCompose builds a list_objects-style ExclusionConfig for a single
+// complex excluded relation, with the composition context enabled.
+func exclusionWithCompose(lookup map[string]*RelationAnalysis) ExclusionConfig {
+	return ExclusionConfig{
+		DatabaseSchema:           "",
+		ObjectType:               "doc",
+		ObjectIDExpr:             Col{Table: "t", Column: "object_id"},
+		SubjectTypeExpr:          SubjectType,
+		SubjectIDExpr:            SubjectID,
+		ComplexExcludedRelations: []string{"blocked"},
+		Compose: &exclusionCompose{
+			Lookup:   lookup,
+			FromType: "doc",
+			FromRel:  "can_read",
+		},
+	}
+}
+
+func predicatesSQL(c ExclusionConfig) string {
+	var b strings.Builder
+	for _, p := range c.BuildPredicates() {
+		b.WriteString(p.SQL())
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func TestComplexExclusion_AntiJoinWhenComposable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.blocked": {
+			ObjectType:   "doc",
+			Relation:     "blocked",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive, // complex, but acyclic below
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "blocked", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.blocked": {ObjectType: "org", Relation: "blocked"},
+	}
+
+	sql := predicatesSQL(exclusionWithCompose(lookup))
+
+	if !strings.Contains(sql, "t.object_id IN (SELECT excl_obj.object_id FROM list_doc_blocked_obj(p_subject_type, p_subject_id, NULL, NULL) excl_obj)") {
+		t.Errorf("expected set-oriented anti-join against list_doc_blocked_obj, got:\n%s", sql)
+	}
+	// Userset-typed subjects keep a guarded per-candidate check for parity.
+	if !strings.Contains(sql, "position('#' in p_subject_id) > 0") {
+		t.Errorf("expected userset-subject parity guard, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'blocked', 'doc', t.object_id") {
+		t.Errorf("expected guarded per-candidate check for userset subjects, got:\n%s", sql)
+	}
+	// The whole membership is negated: NOT ( ... IN ... OR ... ).
+	if !strings.Contains(sql, "NOT ((t.object_id IN") {
+		t.Errorf("expected negated membership, got:\n%s", sql)
+	}
+}
+
+func TestComplexExclusion_FallsBackWhenCyclic(t *testing.T) {
+	// doc.blocked reaches back into doc.can_read → composition unsafe.
+	lookup := map[string]*RelationAnalysis{
+		"doc.blocked": {
+			ObjectType:              "doc",
+			Relation:                "blocked",
+			Capabilities:            GenerationCapabilities{ListAllowed: true},
+			ListStrategy:            ListStrategyRecursive,
+			ComplexClosureRelations: []string{"can_read"},
+		},
+	}
+
+	sql := predicatesSQL(exclusionWithCompose(lookup))
+
+	if strings.Contains(sql, "list_doc_blocked_obj") {
+		t.Errorf("cyclic composition must fall back to per-candidate check, got anti-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'blocked', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexExclusion_FallsBackWhenNotListGeneratable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.blocked": {
+			ObjectType:   "doc",
+			Relation:     "blocked",
+			Capabilities: GenerationCapabilities{ListAllowed: false}, // no list function
+		},
+	}
+
+	sql := predicatesSQL(exclusionWithCompose(lookup))
+
+	if strings.Contains(sql, "list_doc_blocked_obj") {
+		t.Errorf("non-generatable target must fall back to per-candidate check, got anti-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexExclusion_CheckContextKeepsPerCandidate(t *testing.T) {
+	// No Compose (check / list_subjects context) → always per-candidate check,
+	// even with a composable lookup.
+	c := exclusionWithCompose(map[string]*RelationAnalysis{
+		"doc.blocked": {
+			ObjectType:   "doc",
+			Relation:     "blocked",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+	})
+	c.Compose = nil
+
+	sql := predicatesSQL(c)
+
+	if strings.Contains(sql, "list_doc_blocked_obj") {
+		t.Errorf("check/list_subjects context (Compose nil) must not emit anti-join, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/exclusion_antijoin_test.go
+++ b/lib/sqlgen/exclusion_antijoin_test.go
@@ -127,3 +127,24 @@ func TestComplexExclusion_CheckContextKeepsPerCandidate(t *testing.T) {
 		t.Errorf("expected per-candidate check, got:\n%s", sql)
 	}
 }
+
+// TestBuildExclusionCTEQualifiesSubjectID guards issue #11: the excluded_subjects
+// CTE must qualify subject_id with the tuples alias. An unqualified subject_id
+// collides with the enclosing list_*_sub function's OUT parameter of the same
+// name, raising "column reference subject_id is ambiguous" at query time.
+func TestBuildExclusionCTEQualifiesSubjectID(t *testing.T) {
+	c := ExclusionConfig{
+		ObjectType:              "org",
+		ObjectIDExpr:            Param("p_object_id"),
+		SimpleExcludedRelations: []string{"blocked"},
+	}
+
+	sql := c.BuildExclusionCTE()
+
+	if !strings.Contains(sql, "e.subject_id") {
+		t.Errorf("exclusion CTE must qualify subject_id (e.subject_id), got:\n%s", sql)
+	}
+	if strings.Contains(sql, "SELECT subject_id") {
+		t.Errorf("exclusion CTE must not select unqualified subject_id, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/expand_functions.go
+++ b/lib/sqlgen/expand_functions.go
@@ -97,6 +97,9 @@ func renderExpandDispatcherWithCases(databaseSchema string, cases []DispatcherCa
 			"Callers that need to distinguish 'no one has access' from 'expand",
 			"not supported for this relation' should compare against Check.",
 		},
+		// Routes only to schema-qualified expand_{type}_{rel} calls, no
+		// unqualified melange_tuples.
+		NoSearchPath: true,
 	}
 
 	publicFn := SqlFunction{
@@ -113,6 +116,7 @@ func renderExpandDispatcherWithCases(databaseSchema string, cases []DispatcherCa
 			"Shallow by default: computed/TTU rewrites surface as unresolved",
 			"pointers (use Checker.ExpandRecursive client-side to chase).",
 		},
+		NoSearchPath: true,
 	}
 
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"
@@ -134,14 +138,16 @@ func renderEmptyExpandDispatcher(databaseSchema string) string {
 			"Generated empty dispatcher for expand_permission",
 			"(no eligible relations — every request returns an empty tree)",
 		},
+		NoSearchPath: true,
 	}
 
 	publicFn := SqlFunction{
-		Schema:  databaseSchema,
-		Name:    "expand_permission",
-		Args:    expandDispatcherPublicArgs(),
-		Returns: "JSONB",
-		Body:    Raw(body),
+		Schema:       databaseSchema,
+		Name:         "expand_permission",
+		Args:         expandDispatcherPublicArgs(),
+		Returns:      "JSONB",
+		Body:         Raw(body),
+		NoSearchPath: true,
 	}
 
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"

--- a/lib/sqlgen/expand_functions.go
+++ b/lib/sqlgen/expand_functions.go
@@ -81,16 +81,14 @@ func buildExpandDispatcherCases(analyses []RelationAnalysis, databaseSchema stri
 }
 
 func renderExpandDispatcherWithCases(databaseSchema string, cases []DispatcherCase) string {
-	caseExpr := buildExpandDispatcherCaseExpr(cases)
-
 	internalFn := PlpgsqlFunction{
 		Schema:  databaseSchema,
 		Name:    "expand_permission_internal",
 		Args:    expandDispatcherInternalArgs(),
 		Returns: "JSONB",
-		Body: []Stmt{
-			ReturnValue{Value: Raw("(SELECT " + caseExpr.SQL() + ")")},
-		},
+		// IF-chain, not RETURN CASE: measurably faster on the hot path (see
+		// dispatchIfChain in check_functions.go).
+		Body: dispatchIfChain(cases, expandDispatchCall, Raw(expandNoEntrySentinelSQL())),
 		Header: []string{
 			"Generated internal dispatcher for expand_permission",
 			"Routes (object_type, relation) to specialised expand_* functions",
@@ -149,28 +147,13 @@ func renderEmptyExpandDispatcher(databaseSchema string) string {
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"
 }
 
-// buildExpandDispatcherCaseExpr routes (object_type, relation) to the
-// matching expand_<type>_<rel> function. The ELSE branch is the
-// no-entry sentinel — an empty Leaf.Users wrapped in the standard
-// UsersetTree envelope, so unknown pairs and not-yet-supported
-// relations both deserialise cleanly.
-func buildExpandDispatcherCaseExpr(cases []DispatcherCase) CaseExpr {
-	whens := make([]CaseWhen, 0, len(cases))
-	for _, c := range cases {
-		cond := AndExpr{Exprs: []Expr{
-			Eq{Left: Raw("p_object_type"), Right: Lit(c.ObjectType)},
-			Eq{Left: Raw("p_relation"), Right: Lit(c.Relation)},
-		}}
-		result := Func{
-			Schema: c.DatabaseSchema,
-			Name:   c.CheckFunctionName,
-			Args:   []Expr{Raw("p_object_id"), Raw("p_subject_type"), Raw("p_max_leaf")},
-		}
-		whens = append(whens, CaseWhen{Cond: cond, Result: result})
+// expandDispatchCall is the specialized expand_<type>_<rel> call for one arm.
+func expandDispatchCall(c DispatcherCase) Expr {
+	return Func{
+		Schema: c.DatabaseSchema,
+		Name:   c.CheckFunctionName,
+		Args:   []Expr{Raw("p_object_id"), Raw("p_subject_type"), Raw("p_max_leaf")},
 	}
-
-	noEntry := Raw(expandNoEntrySentinelSQL())
-	return CaseExpr{Whens: whens, Else: noEntry}
 }
 
 // expandNoEntrySentinelSQL emits the JSONB UsersetTree returned when

--- a/lib/sqlgen/explain_functions.go
+++ b/lib/sqlgen/explain_functions.go
@@ -126,6 +126,9 @@ func renderExplainDispatcherWithCases(databaseSchema string, cases []DispatcherC
 		// recursive bodies, so OR/AND chains should evaluate cheap branches
 		// first.
 		Cost: recursiveCheckCost,
+		// Routes only to schema-qualified explain_{type}_{rel} calls, no
+		// unqualified melange_tuples.
+		NoSearchPath: true,
 	}
 
 	publicFn := SqlFunction{
@@ -139,6 +142,7 @@ func renderExplainDispatcherWithCases(databaseSchema string, cases []DispatcherC
 			"Companion to check_permission — returns a JSONB Trace describing",
 			"why the check decision was reached",
 		},
+		NoSearchPath: true,
 	}
 
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"
@@ -160,14 +164,16 @@ func renderEmptyExplainDispatcher(databaseSchema string) string {
 			"Generated empty dispatcher for explain_permission",
 			"(no relations defined — every request returns a deny trace)",
 		},
+		NoSearchPath: true,
 	}
 
 	publicFn := SqlFunction{
-		Schema:  databaseSchema,
-		Name:    "explain_permission",
-		Args:    explainDispatcherPublicArgs(),
-		Returns: "JSONB",
-		Body:    Raw(body),
+		Schema:       databaseSchema,
+		Name:         "explain_permission",
+		Args:         explainDispatcherPublicArgs(),
+		Returns:      "JSONB",
+		Body:         Raw(body),
+		NoSearchPath: true,
 	}
 
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"

--- a/lib/sqlgen/explain_functions.go
+++ b/lib/sqlgen/explain_functions.go
@@ -98,21 +98,24 @@ func buildExplainDispatcherCases(analyses []RelationAnalysis, databaseSchema str
 }
 
 func renderExplainDispatcherWithCases(databaseSchema string, cases []DispatcherCase) string {
-	caseExpr := buildExplainDispatcherCaseExpr(cases)
+	noEntry := Raw(explainNoEntrySentinelSQL(
+		"explain not yet supported for this (object_type, relation) — no generated explain function for the requested pair. Confirm the pair exists in the migrated schema.",
+	))
 
 	internalFn := PlpgsqlFunction{
 		Schema:  databaseSchema,
 		Name:    "explain_permission_internal",
 		Args:    explainDispatcherInternalArgs(),
 		Returns: "JSONB",
-		Body: []Stmt{
+		// IF-chain, not RETURN CASE: measurably faster on the hot path (see
+		// dispatchIfChain in check_functions.go).
+		Body: append([]Stmt{
 			Comment{Text: "Depth limit check shared with check_permission_internal"},
 			If{
 				Cond: Gte{Left: ArrayLength{Array: Visited}, Right: Int(25)},
 				Then: []Stmt{Raise{Message: "resolution too complex", ErrCode: "M2002"}},
 			},
-			ReturnValue{Value: Raw("(SELECT " + caseExpr.SQL() + ")")},
-		},
+		}, dispatchIfChain(cases, explainDispatchCall, noEntry)...),
 		Header: []string{
 			"Generated internal dispatcher for explain_permission",
 			"Routes (object_type, relation) to specialised explain_* functions",
@@ -170,30 +173,13 @@ func renderEmptyExplainDispatcher(databaseSchema string) string {
 	return internalFn.SQL() + "\n\n" + publicFn.SQL() + "\n"
 }
 
-// buildExplainDispatcherCaseExpr mirrors buildDispatcherCaseExpr but with a
-// JSONB no-entry sentinel in the ELSE branch. The shape matches the empty
-// dispatcher's output so the unknown-pair handling is consistent in both
-// paths.
-func buildExplainDispatcherCaseExpr(cases []DispatcherCase) CaseExpr {
-	whens := make([]CaseWhen, 0, len(cases))
-	for _, c := range cases {
-		cond := AndExpr{Exprs: []Expr{
-			Eq{Left: ObjectType, Right: Lit(c.ObjectType)},
-			Eq{Left: Raw("p_relation"), Right: Lit(c.Relation)},
-		}}
-		result := Func{
-			Schema: c.DatabaseSchema,
-			Name:   c.CheckFunctionName,
-			Args:   []Expr{SubjectType, SubjectID, ObjectID, Visited, Raw("p_max_nodes")},
-		}
-		whens = append(whens, CaseWhen{Cond: cond, Result: result})
+// explainDispatchCall is the specialized explain_<type>_<rel> call for one arm.
+func explainDispatchCall(c DispatcherCase) Expr {
+	return Func{
+		Schema: c.DatabaseSchema,
+		Name:   c.CheckFunctionName,
+		Args:   []Expr{SubjectType, SubjectID, ObjectID, Visited, Raw("p_max_nodes")},
 	}
-
-	noEntry := Raw(explainNoEntrySentinelSQL(
-		"explain not yet supported for this (object_type, relation) — no generated explain function for the requested pair. Confirm the pair exists in the migrated schema.",
-	))
-
-	return CaseExpr{Whens: whens, Else: noEntry}
 }
 
 // explainNoEntrySentinelSQL emits the JSONB Trace returned when the

--- a/lib/sqlgen/inline_filter.go
+++ b/lib/sqlgen/inline_filter.go
@@ -1,0 +1,67 @@
+package sqlgen
+
+// filterInlineForCheck returns an InlineSQLData carrying only the closure and
+// userset VALUES rows a check function for relation a actually references,
+// instead of the whole model's rows.
+//
+// Check functions embed the inline VALUES in exactly one place — the
+// userset-subject branch (buildUsersetSubjectChecks) — with these object_type
+// constraints:
+//   - closure `c` and userset `m`: object_type = a.ObjectType (constant)
+//   - closure `subj_c`: object_type = t.subject_type, bounded at runtime to the
+//     userset patterns' subject types
+//
+// So the closure rows needed are those for a.ObjectType plus every type that
+// can appear as the userset subject t.subject_type; userset rows are those for
+// a.ObjectType.
+//
+// The subject-side types are the userset patterns' SubjectType — these are
+// load-bearing: subj_c keys on t.subject_type (e.g. "group" for a
+// [group#member] pattern), and that "group" comes ONLY from the pattern
+// loops. AllowedSubjectTypes is added as extra safety but is NOT sufficient
+// alone: it holds the types a userset resolves *to* (e.g. "user"), not the
+// userset object type itself, so removing the pattern loops would drop needed
+// closure rows and break userset-subject checks.
+//
+// Dropping the rest leaves the generated SQL semantically identical while
+// making the embedded VALUES independent of unrelated schema growth: a
+// userset-subject check no longer scans closure rows for object types it can
+// never reference.
+func filterInlineForCheck(inline InlineSQLData, a RelationAnalysis) InlineSQLData {
+	closureTypes := map[string]bool{a.ObjectType: true}
+	for _, t := range a.AllowedSubjectTypes {
+		closureTypes[t] = true
+	}
+	for _, p := range a.UsersetPatterns {
+		closureTypes[p.SubjectType] = true // load-bearing (see doc)
+	}
+	for _, p := range a.ClosureUsersetPatterns {
+		closureTypes[p.SubjectType] = true // load-bearing (see doc)
+	}
+
+	return InlineSQLData{
+		ClosureRows: filterRowsByObjectType(inline.ClosureRows, closureTypes),
+		UsersetRows: filterRowsByObjectType(inline.UsersetRows, map[string]bool{a.ObjectType: true}),
+	}
+}
+
+// filterRowsByObjectType keeps only VALUES rows whose first column (object_type,
+// a Lit) is in keep. Rows whose first column is not a plain Lit are kept
+// (conservatively) so a future non-literal row shape can never be silently
+// dropped.
+func filterRowsByObjectType(rows []ValuesRow, keep map[string]bool) []ValuesRow {
+	if len(rows) == 0 {
+		return nil
+	}
+	out := make([]ValuesRow, 0, len(rows))
+	for _, r := range rows {
+		if len(r) == 0 {
+			continue
+		}
+		lit, ok := r[0].(Lit)
+		if !ok || keep[string(lit)] {
+			out = append(out, r)
+		}
+	}
+	return out
+}

--- a/lib/sqlgen/inline_filter.go
+++ b/lib/sqlgen/inline_filter.go
@@ -1,5 +1,7 @@
 package sqlgen
 
+import "strings"
+
 // filterInlineForCheck returns an InlineSQLData carrying only the closure and
 // userset VALUES rows a check function for relation a actually references,
 // instead of the whole model's rows.
@@ -42,6 +44,48 @@ func filterInlineForCheck(inline InlineSQLData, a RelationAnalysis) InlineSQLDat
 	return InlineSQLData{
 		ClosureRows: filterRowsByObjectType(inline.ClosureRows, closureTypes),
 		UsersetRows: filterRowsByObjectType(inline.UsersetRows, map[string]bool{a.ObjectType: true}),
+	}
+}
+
+// filterInlineForList returns an InlineSQLData carrying only the closure and
+// userset VALUES rows a list function (objects or subjects) for relation a can
+// reference, instead of the whole model's rows.
+//
+// Every closure/userset VALUES lookup in the list block builders keys its
+// object_type column on one of exactly three things (verified by reading every
+// use site — grep ClosureTable/UsersetTable/TypedClosureValuesTable across
+// list_objects_blocks*.go, list_subjects_blocks*.go, list_helpers.go):
+//
+//   - Lit(plan.ObjectType) — the relation's own object type (constant).
+//   - Param("v_filter_type") / SubjectType — the subject-type filter/param. This
+//     is only ever reached under a userset guard (position('#' in subject_id) > 0
+//     / HasUserset), so the value can only be a userset subject type this
+//     relation grants to (e.g. "group" for a [group#member] pattern).
+//   - Col{link.subject_type} — a TTU parent tuple's subject type (the recursive
+//     list_subjects TTU blocks), bounded by the TTU parent AllowedLinkingTypes.
+//
+// relationReferences(&a) over-approximates every "type.relation" edge a's
+// generated functions can reference — same-type closure/implied/excluded,
+// TTU parents (direct + closure + excluded + intersection), and userset targets
+// (direct + closure + selfref + indirect-anchor). The TYPE half of that edge set
+// therefore covers every userset subject type and every TTU parent type any
+// closure/userset lookup can key on. Adding a.ObjectType and AllowedSubjectTypes
+// is extra safety. The result is a safe superset: it can only keep extra rows,
+// never drop a needed one, so the generated SQL is semantically identical while
+// the embedded VALUES stop growing with unrelated schema.
+func filterInlineForList(inline InlineSQLData, a RelationAnalysis) InlineSQLData {
+	keep := map[string]bool{a.ObjectType: true}
+	for _, t := range a.AllowedSubjectTypes {
+		keep[t] = true
+	}
+	for _, ref := range relationReferences(&a) {
+		if i := strings.IndexByte(ref, '.'); i > 0 {
+			keep[ref[:i]] = true
+		}
+	}
+	return InlineSQLData{
+		ClosureRows: filterRowsByObjectType(inline.ClosureRows, keep),
+		UsersetRows: filterRowsByObjectType(inline.UsersetRows, keep),
 	}
 }
 

--- a/lib/sqlgen/inline_filter_test.go
+++ b/lib/sqlgen/inline_filter_test.go
@@ -65,6 +65,59 @@ func TestFilterInlineForCheck_KeepsObjectAndSubjectTypes(t *testing.T) {
 	}
 }
 
+func TestFilterInlineForList_KeepsReferencedTypesDropsUnrelated(t *testing.T) {
+	inline := InlineSQLData{
+		ClosureRows: []ValuesRow{
+			closureRow("element", "view", "view"),       // own object type
+			closureRow("group", "member", "member"),      // userset subject type
+			closureRow("folder", "view", "view"),         // TTU parent linking type
+			closureRow("workspace", "view", "view"),      // allowed subject type
+			closureRow("aaa", "rel001", "rel001"),        // unrelated → drop
+			closureRow("organization", "own", "own"),     // unrelated → drop
+		},
+		UsersetRows: []ValuesRow{
+			usersetRow("element", "view", "group", "member"),
+			usersetRow("group", "member", "user", ""),          // userset subject type kept (list_objects keys on it)
+			usersetRow("aaa", "rel001", "user", ""),            // unrelated → drop
+		},
+	}
+	a := RelationAnalysis{
+		ObjectType:          "element",
+		Relation:            "view",
+		AllowedSubjectTypes: []string{"user", "workspace"},
+		UsersetPatterns: []UsersetPattern{
+			{SubjectType: "group", SubjectRelation: "member"},
+		},
+		ParentRelations: []ParentRelationInfo{
+			{Relation: "view", LinkingRelation: "parent", AllowedLinkingTypes: []string{"folder"}},
+		},
+	}
+
+	out := filterInlineForList(inline, a)
+
+	gotClosure := objectTypesOf(out.ClosureRows)
+	for _, want := range []string{"element", "group", "folder", "workspace"} {
+		if !gotClosure[want] {
+			t.Errorf("closure filter dropped needed object type %q", want)
+		}
+	}
+	for _, unwant := range []string{"aaa", "organization"} {
+		if gotClosure[unwant] {
+			t.Errorf("closure filter kept unrelated object type %q", unwant)
+		}
+	}
+
+	gotUserset := objectTypesOf(out.UsersetRows)
+	for _, want := range []string{"element", "group"} {
+		if !gotUserset[want] {
+			t.Errorf("userset filter dropped needed object type %q", want)
+		}
+	}
+	if gotUserset["aaa"] {
+		t.Errorf("userset filter kept unrelated object type %q", "aaa")
+	}
+}
+
 func TestFilterRowsByObjectType_KeepsNonLitRows(t *testing.T) {
 	// A row whose first column is not a plain Lit must be kept conservatively.
 	rows := []ValuesRow{

--- a/lib/sqlgen/inline_filter_test.go
+++ b/lib/sqlgen/inline_filter_test.go
@@ -1,0 +1,79 @@
+package sqlgen
+
+import "testing"
+
+func closureRow(objectType, relation, satisfying string) ValuesRow {
+	return ValuesRow{Lit(objectType), Lit(relation), Lit(satisfying)}
+}
+
+func usersetRow(objectType, relation, subjectType, subjectRelation string) ValuesRow {
+	return ValuesRow{Lit(objectType), Lit(relation), Lit(subjectType), Lit(subjectRelation)}
+}
+
+func objectTypesOf(rows []ValuesRow) map[string]bool {
+	got := map[string]bool{}
+	for _, r := range rows {
+		got[string(r[0].(Lit))] = true
+	}
+	return got
+}
+
+func TestFilterInlineForCheck_KeepsObjectAndSubjectTypes(t *testing.T) {
+	inline := InlineSQLData{
+		ClosureRows: []ValuesRow{
+			closureRow("element", "view", "view"),
+			closureRow("group", "member", "member"),        // userset subject type
+			closureRow("workspace", "view", "view"),        // allowed subject type
+			closureRow("aaa", "rel001", "rel001"),          // unrelated → drop
+			closureRow("organization", "manage", "manage"), // unrelated → drop
+		},
+		UsersetRows: []ValuesRow{
+			usersetRow("element", "view", "group", "member"),
+			usersetRow("workspace", "view", "organization", "view"), // other object type → drop
+		},
+	}
+	a := RelationAnalysis{
+		ObjectType:          "element",
+		Relation:            "view",
+		AllowedSubjectTypes: []string{"user", "group", "workspace"},
+		UsersetPatterns: []UsersetPattern{
+			{SubjectType: "group", SubjectRelation: "member"},
+			{SubjectType: "workspace", SubjectRelation: "view"},
+		},
+	}
+
+	out := filterInlineForCheck(inline, a)
+
+	gotClosure := objectTypesOf(out.ClosureRows)
+	for _, want := range []string{"element", "group", "workspace"} {
+		if !gotClosure[want] {
+			t.Errorf("closure filter dropped needed object type %q", want)
+		}
+	}
+	for _, unwant := range []string{"aaa", "organization"} {
+		if gotClosure[unwant] {
+			t.Errorf("closure filter kept unrelated object type %q", unwant)
+		}
+	}
+
+	gotUserset := objectTypesOf(out.UsersetRows)
+	if !gotUserset["element"] {
+		t.Errorf("userset filter dropped the object type's own rows")
+	}
+	if gotUserset["workspace"] {
+		t.Errorf("userset filter kept another object type's rows (only object side needed)")
+	}
+}
+
+func TestFilterRowsByObjectType_KeepsNonLitRows(t *testing.T) {
+	// A row whose first column is not a plain Lit must be kept conservatively.
+	rows := []ValuesRow{
+		{Raw("something_dynamic"), Lit("r"), Lit("s")},
+		closureRow("keep", "r", "s"),
+		closureRow("drop", "r", "s"),
+	}
+	out := filterRowsByObjectType(rows, map[string]bool{"keep": true})
+	if len(out) != 2 {
+		t.Fatalf("expected 2 rows (non-Lit + keep), got %d", len(out))
+	}
+}

--- a/lib/sqlgen/inline_filter_test.go
+++ b/lib/sqlgen/inline_filter_test.go
@@ -68,17 +68,17 @@ func TestFilterInlineForCheck_KeepsObjectAndSubjectTypes(t *testing.T) {
 func TestFilterInlineForList_KeepsReferencedTypesDropsUnrelated(t *testing.T) {
 	inline := InlineSQLData{
 		ClosureRows: []ValuesRow{
-			closureRow("element", "view", "view"),       // own object type
-			closureRow("group", "member", "member"),      // userset subject type
-			closureRow("folder", "view", "view"),         // TTU parent linking type
-			closureRow("workspace", "view", "view"),      // allowed subject type
-			closureRow("aaa", "rel001", "rel001"),        // unrelated → drop
-			closureRow("organization", "own", "own"),     // unrelated → drop
+			closureRow("element", "view", "view"),    // own object type
+			closureRow("group", "member", "member"),  // userset subject type
+			closureRow("folder", "view", "view"),     // TTU parent linking type
+			closureRow("workspace", "view", "view"),  // allowed subject type
+			closureRow("aaa", "rel001", "rel001"),    // unrelated → drop
+			closureRow("organization", "own", "own"), // unrelated → drop
 		},
 		UsersetRows: []ValuesRow{
 			usersetRow("element", "view", "group", "member"),
-			usersetRow("group", "member", "user", ""),          // userset subject type kept (list_objects keys on it)
-			usersetRow("aaa", "rel001", "user", ""),            // unrelated → drop
+			usersetRow("group", "member", "user", ""), // userset subject type kept (list_objects keys on it)
+			usersetRow("aaa", "rel001", "user", ""),   // unrelated → drop
 		},
 	}
 	a := RelationAnalysis{

--- a/lib/sqlgen/intersection_group_compose_test.go
+++ b/lib/sqlgen/intersection_group_compose_test.go
@@ -1,0 +1,182 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// planWithIntersectionGroup builds a minimal list_objects ListPlan whose
+// relation "can_edit" is an intersection of a positive part "editor" and a
+// part "owner but not banned", driving buildIntersectionGroupBlock.
+func planWithIntersectionGroup(lookup map[string]*RelationAnalysis) ListPlan {
+	group := IntersectionGroupInfo{Parts: []IntersectionPart{
+		{Relation: "editor"},
+		{Relation: "owner", ExcludedRelation: "banned"},
+	}}
+	return ListPlan{
+		DatabaseSchema: "",
+		ObjectType:     "doc",
+		Relation:       "can_edit",
+		Analysis: RelationAnalysis{
+			IntersectionGroups: []IntersectionGroupInfo{group},
+		},
+		AnalysisLookup: lookup,
+	}
+}
+
+func groupBlockSQL(t *testing.T, plan ListPlan) string {
+	t.Helper()
+	block, err := buildIntersectionGroupBlock(plan, 0, plan.Analysis.IntersectionGroups[0])
+	if err != nil {
+		t.Fatalf("buildIntersectionGroupBlock: %v", err)
+	}
+	return block.Query.SQL()
+}
+
+func composableLookup() map[string]*RelationAnalysis {
+	return map[string]*RelationAnalysis{
+		"doc.editor": {
+			ObjectType:   "doc",
+			Relation:     "editor",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+		"doc.owner": {
+			ObjectType:   "doc",
+			Relation:     "owner",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+		"doc.banned": {
+			ObjectType:   "doc",
+			Relation:     "banned",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+	}
+}
+
+func TestIntersectionGroup_ComposesWhenComposable(t *testing.T) {
+	sql := groupBlockSQL(t, planWithIntersectionGroup(composableLookup()))
+
+	// Positive part "editor" → semi-join against list_doc_editor_obj.
+	if !strings.Contains(sql, "t.object_id IN (SELECT obj.object_id FROM list_doc_editor_obj(p_subject_type, p_subject_id, NULL, NULL) obj)") {
+		t.Errorf("expected semi-join for positive part editor, got:\n%s", sql)
+	}
+	// Positive part keeps a userset-guarded per-candidate check for parity.
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', t.object_id") {
+		t.Errorf("expected userset-guarded check for positive part, got:\n%s", sql)
+	}
+	// Nested exclusion "but not banned" → negated anti-join against list_doc_banned_obj.
+	if !strings.Contains(sql, "NOT ((t.object_id IN (SELECT excl_obj.object_id FROM list_doc_banned_obj(") {
+		t.Errorf("expected negated anti-join for excluded relation banned, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "position('#' in p_subject_id) > 0") {
+		t.Errorf("expected userset-subject parity guard, got:\n%s", sql)
+	}
+}
+
+func TestIntersectionGroup_FallsBackWhenNotComposable(t *testing.T) {
+	// Targets are not list-generatable → keep per-candidate checks unchanged.
+	lookup := map[string]*RelationAnalysis{
+		"doc.editor": {ObjectType: "doc", Relation: "editor", Capabilities: GenerationCapabilities{ListAllowed: false}},
+		"doc.banned": {ObjectType: "doc", Relation: "banned", Capabilities: GenerationCapabilities{ListAllowed: false}},
+	}
+	sql := groupBlockSQL(t, planWithIntersectionGroup(lookup))
+
+	if strings.Contains(sql, "list_doc_editor_obj") || strings.Contains(sql, "list_doc_banned_obj") {
+		t.Errorf("non-generatable targets must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check for positive part, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'banned', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check for excluded relation, got:\n%s", sql)
+	}
+}
+
+func TestIntersectionGroup_FallsBackWhenTargetHasWildcard(t *testing.T) {
+	// A wildcard-bearing target under-reports concrete subjects in list_objects
+	// (a "user:*" grant is true for check but may not be enumerated), so keep the
+	// per-candidate check for that part.
+	lookup := composableLookup()
+	lookup["doc.editor"].Features.HasWildcard = true
+	sql := groupBlockSQL(t, planWithIntersectionGroup(lookup))
+
+	if strings.Contains(sql, "list_doc_editor_obj") {
+		t.Errorf("wildcard target must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check for wildcard target, got:\n%s", sql)
+	}
+	// Non-wildcard excluded relation still composes.
+	if !strings.Contains(sql, "list_doc_banned_obj") {
+		t.Errorf("expected non-wildcard excluded relation to still compose, got:\n%s", sql)
+	}
+}
+
+func TestIntersectionGroup_FallsBackWhenTargetIsRecursive(t *testing.T) {
+	// Recursive list_objects can under-report plain concrete subjects when the
+	// grant flows through a userset and then recursion. Since INTERSECT requires
+	// every part to be complete, keep that part on the per-candidate check path.
+	lookup := composableLookup()
+	lookup["doc.editor"].ListStrategy = ListStrategyRecursive
+	lookup["doc.editor"].Features = RelationFeatures{HasDirect: true, HasUserset: true, HasRecursive: true}
+	sql := groupBlockSQL(t, planWithIntersectionGroup(lookup))
+
+	if strings.Contains(sql, "list_doc_editor_obj") {
+		t.Errorf("recursive target must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check for recursive target, got:\n%s", sql)
+	}
+	// Independent direct excluded relation still composes.
+	if !strings.Contains(sql, "list_doc_banned_obj") {
+		t.Errorf("expected direct excluded relation to still compose, got:\n%s", sql)
+	}
+}
+
+func TestIntersectionGroup_FallsBackWhenTargetIsUserset(t *testing.T) {
+	// Userset strategy is not a proof-complete intersection part: it may depend
+	// on target relation behavior that differs from check_permission_internal.
+	lookup := composableLookup()
+	lookup["doc.editor"].ListStrategy = ListStrategyUserset
+	lookup["doc.editor"].Features = RelationFeatures{HasDirect: true, HasUserset: true}
+	sql := groupBlockSQL(t, planWithIntersectionGroup(lookup))
+
+	if strings.Contains(sql, "list_doc_editor_obj") {
+		t.Errorf("userset target must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check for userset target, got:\n%s", sql)
+	}
+	// Independent direct excluded relation still composes.
+	if !strings.Contains(sql, "list_doc_banned_obj") {
+		t.Errorf("expected direct excluded relation to still compose, got:\n%s", sql)
+	}
+}
+
+func TestIntersectionGroup_FallsBackWhenCyclic(t *testing.T) {
+	// doc.editor reaches back into doc.can_edit → composition unsafe for that part;
+	// doc.banned/doc.owner stay composable.
+	lookup := composableLookup()
+	lookup["doc.editor"] = &RelationAnalysis{
+		ObjectType:              "doc",
+		Relation:                "editor",
+		Capabilities:            GenerationCapabilities{ListAllowed: true},
+		ListStrategy:            ListStrategyRecursive,
+		ComplexClosureRelations: []string{"can_edit"},
+	}
+	sql := groupBlockSQL(t, planWithIntersectionGroup(lookup))
+
+	if strings.Contains(sql, "list_doc_editor_obj") {
+		t.Errorf("cyclic positive part must fall back to per-candidate check, got composition:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', t.object_id") {
+		t.Errorf("expected per-candidate check for cyclic positive part, got:\n%s", sql)
+	}
+	// The independent excluded relation still composes.
+	if !strings.Contains(sql, "list_doc_banned_obj") {
+		t.Errorf("expected excluded relation banned to still compose, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -169,6 +169,42 @@ func composableListTarget(plan ListPlan, targetType, targetRelation string) bool
 	return composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, targetType, targetRelation)
 }
 
+// complexClosureMembership returns the predicate proving the subject holds rel
+// on the candidate object t.object_id, for a complex closure relation.
+//
+// When composition is safe it replaces the per-candidate
+// check_permission_internal with a semi-join against rel's list_objects set
+// (the set of objects the subject holds rel on), keeping a check arm guarded to
+// userset-typed subjects for parity: the list function is complete for plain
+// subjects but a Recursive/Composed target may under-report userset subjects
+// ("group:eng#member"), and an under-reported positive membership drops objects
+// (under-permissive). For plain subjects the guard is false and the arm
+// short-circuits before the check. When composition is unsafe it returns the
+// per-candidate check alone. Mirrors usersetMembership / complexExclusionAntiJoin.
+func complexClosureMembership(plan ListPlan, rel string) Expr {
+	check := CheckPermission{
+		Schema:      plan.DatabaseSchema,
+		Subject:     SubjectParams(),
+		Relation:    rel,
+		Object:      LiteralObject(plan.ObjectType, Col{Table: "t", Column: "object_id"}),
+		ExpectAllow: true,
+	}
+	if !composableListTarget(plan, plan.ObjectType, rel) {
+		return check
+	}
+	return Or(
+		InFunctionSelect{
+			Expr:      Col{Table: "t", Column: "object_id"},
+			Schema:    plan.DatabaseSchema,
+			FuncName:  ListObjectsFunctionName(plan.ObjectType, rel),
+			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
+			Alias:     "obj",
+			SelectCol: "object_id",
+		},
+		And(HasUserset{Source: SubjectID}, check),
+	)
+}
+
 // usersetMembership returns the membership predicate for a complex userset
 // arm: does the subject hold pattern.SubjectRelation on the userset object?
 //

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -169,6 +169,31 @@ func composableListTarget(plan ListPlan, targetType, targetRelation string) bool
 	return composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, targetType, targetRelation)
 }
 
+// composedListObjectsMembership is the positive-membership predicate shared by
+// every list_objects composition site: "the subject holds targetRel on the
+// candidate object objectIDExpr". It semi-joins against the target relation's
+// list_objects set and keeps a check arm guarded to userset-typed subjects
+// (position('#' in subjectID) > 0) for parity — the list function is complete
+// for plain subjects but a Recursive/Composed target may under-report a userset
+// subject ("group:eng#member"), and an under-reported positive membership drops
+// objects (under-permissive); for plain subjects the guard is false and the arm
+// short-circuits. Callers gate composability first and pass the per-candidate
+// check as the fallback arm; anti-join sites negate the result. The alias only
+// affects the rendered subquery alias and must stay unique within a predicate.
+func composedListObjectsMembership(schema, targetType, targetRel string, objectIDExpr, subjectType, subjectID Expr, alias string, check Expr) Expr {
+	return Or(
+		InFunctionSelect{
+			Expr:      objectIDExpr,
+			Schema:    schema,
+			FuncName:  ListObjectsFunctionName(targetType, targetRel),
+			Args:      []Expr{subjectType, subjectID, Null{}, Null{}},
+			Alias:     alias,
+			SelectCol: "object_id",
+		},
+		And(HasUserset{Source: subjectID}, check),
+	)
+}
+
 // complexClosureMembership returns the predicate proving the subject holds rel
 // on the candidate object t.object_id, for a complex closure relation.
 //
@@ -192,17 +217,7 @@ func complexClosureMembership(plan ListPlan, rel string) Expr {
 	if !composableListTarget(plan, plan.ObjectType, rel) {
 		return check
 	}
-	return Or(
-		InFunctionSelect{
-			Expr:      Col{Table: "t", Column: "object_id"},
-			Schema:    plan.DatabaseSchema,
-			FuncName:  ListObjectsFunctionName(plan.ObjectType, rel),
-			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-			Alias:     "obj",
-			SelectCol: "object_id",
-		},
-		And(HasUserset{Source: SubjectID}, check),
-	)
+	return composedListObjectsMembership(plan.DatabaseSchema, plan.ObjectType, rel, Col{Table: "t", Column: "object_id"}, SubjectType, SubjectID, "obj", check)
 }
 
 // complexClosureSubjectMembership returns the predicate proving the candidate
@@ -288,17 +303,7 @@ func intersectionPartMembership(plan ListPlan, rel string, objectID Expr) Expr {
 	if !intersectionPartComposable(plan, rel) {
 		return check
 	}
-	return Or(
-		InFunctionSelect{
-			Expr:      objectID,
-			Schema:    plan.DatabaseSchema,
-			FuncName:  ListObjectsFunctionName(plan.ObjectType, rel),
-			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-			Alias:     "obj",
-			SelectCol: "object_id",
-		},
-		And(HasUserset{Source: SubjectID}, check),
-	)
+	return composedListObjectsMembership(plan.DatabaseSchema, plan.ObjectType, rel, objectID, SubjectType, SubjectID, "obj", check)
 }
 
 // intersectionPartExclusion returns the "but not rel" predicate for a nested
@@ -318,26 +323,14 @@ func intersectionPartExclusion(plan ListPlan, rel string, objectID Expr) Expr {
 	if !intersectionPartComposable(plan, rel) {
 		return check
 	}
-	return Not(Or(
-		InFunctionSelect{
-			Expr:      objectID,
-			Schema:    plan.DatabaseSchema,
-			FuncName:  ListObjectsFunctionName(plan.ObjectType, rel),
-			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-			Alias:     "excl_obj",
-			SelectCol: "object_id",
-		},
-		And(
-			HasUserset{Source: SubjectID},
-			CheckPermission{
-				Schema:      plan.DatabaseSchema,
-				Subject:     SubjectParams(),
-				Relation:    rel,
-				Object:      LiteralObject(plan.ObjectType, objectID),
-				ExpectAllow: true,
-			},
-		),
-	))
+	positiveCheck := CheckPermission{
+		Schema:      plan.DatabaseSchema,
+		Subject:     SubjectParams(),
+		Relation:    rel,
+		Object:      LiteralObject(plan.ObjectType, objectID),
+		ExpectAllow: true,
+	}
+	return Not(composedListObjectsMembership(plan.DatabaseSchema, plan.ObjectType, rel, objectID, SubjectType, SubjectID, "excl_obj", positiveCheck))
 }
 
 // usersetMembership returns the membership predicate for a complex userset
@@ -365,15 +358,5 @@ func usersetMembership(plan ListPlan, pattern listUsersetPatternInput) Expr {
 	if !composableListTarget(plan, pattern.SubjectType, pattern.SubjectRelation) {
 		return check
 	}
-	return Or(
-		InFunctionSelect{
-			Expr:      UsersetObjectID{Source: Col{Table: "t", Column: "subject_id"}},
-			Schema:    plan.DatabaseSchema,
-			FuncName:  ListObjectsFunctionName(pattern.SubjectType, pattern.SubjectRelation),
-			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-			Alias:     "obj",
-			SelectCol: "object_id",
-		},
-		And(HasUserset{Source: SubjectID}, check),
-	)
+	return composedListObjectsMembership(plan.DatabaseSchema, pattern.SubjectType, pattern.SubjectRelation, UsersetObjectID{Source: Col{Table: "t", Column: "subject_id"}}, SubjectType, SubjectID, "obj", check)
 }

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -146,19 +146,27 @@ func relationReferences(a *RelationAnalysis) []string {
 	return refs
 }
 
-// composableListTarget reports whether (targetType, targetRelation) has a
-// usable list_objects function this plan's function may compose with: the
-// target must be list-generatable and composition must be cycle-free and
-// unable to reach an always-raising DepthExceeded list function.
-func composableListTarget(plan ListPlan, targetType, targetRelation string) bool {
-	if plan.AnalysisLookup == nil {
+// composableListTargetLookup reports whether the list_objects function for
+// (fromType, fromRelation) may compose with the list_objects function for
+// (targetType, targetRelation): the target must be list-generatable and
+// composition must be cycle-free and unable to reach an always-raising
+// DepthExceeded list function (listCompositionSafe checks DepthExceeded on
+// every reachable node, including the target itself).
+func composableListTargetLookup(lookup map[string]*RelationAnalysis, fromType, fromRelation, targetType, targetRelation string) bool {
+	if lookup == nil {
 		return false
 	}
-	target, ok := plan.AnalysisLookup[targetType+"."+targetRelation]
+	target, ok := lookup[targetType+"."+targetRelation]
 	if !ok || !target.Capabilities.ListAllowed {
 		return false
 	}
-	return listCompositionSafe(plan.AnalysisLookup, plan.ObjectType, plan.Relation, targetType, targetRelation)
+	return listCompositionSafe(lookup, fromType, fromRelation, targetType, targetRelation)
+}
+
+// composableListTarget is the ListPlan-scoped form of
+// composableListTargetLookup, from this plan's relation to the target.
+func composableListTarget(plan ListPlan, targetType, targetRelation string) bool {
+	return composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, targetType, targetRelation)
 }
 
 // usersetMembership returns the membership predicate for a complex userset

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -250,6 +250,96 @@ func complexClosureSubjectMembership(plan ListPlan, rel string) Expr {
 	}
 }
 
+// intersectionPartComposable reports whether a list_objects intersection part
+// may compose with rel's list_objects set. INTERSECT is only sound when every
+// part is complete: if any semi-joined part under-reports, the whole object is
+// dropped. Keep this proof to direct, non-wildcard targets. Recursive/userset/
+// composed targets can make check_permission_internal true for a plain concrete
+// subject through paths their list_objects function may not enumerate; the
+// userset-parity arm cannot recover that case because its guard is false for
+// plain subjects.
+func intersectionPartComposable(plan ListPlan, rel string) bool {
+	target := plan.AnalysisLookup[plan.ObjectType+"."+rel]
+	if target == nil || target.Features.HasWildcard || target.ListStrategy != ListStrategyDirect {
+		return false
+	}
+	return composableListTarget(plan, plan.ObjectType, rel)
+}
+
+// intersectionPartMembership returns the predicate proving the subject holds
+// rel on the candidate object objectID, for one positive part of an INTERSECT
+// group in list_objects.
+//
+// When composition is safe it replaces the per-candidate check_permission_internal
+// with a semi-join against rel's list_objects set, keeping a check arm guarded to
+// userset-typed subjects for parity (a Recursive/Composed target may under-report
+// a userset subject like "group:eng#member"; an under-reported positive membership
+// drops objects that should stay in the group — under-permissive). For plain
+// subjects the guard is false and the arm short-circuits. When composition is
+// unsafe it returns the per-candidate check alone. Mirrors complexClosureMembership.
+func intersectionPartMembership(plan ListPlan, rel string, objectID Expr) Expr {
+	check := CheckPermission{
+		Schema:      plan.DatabaseSchema,
+		Subject:     SubjectParams(),
+		Relation:    rel,
+		Object:      LiteralObject(plan.ObjectType, objectID),
+		ExpectAllow: true,
+	}
+	if !intersectionPartComposable(plan, rel) {
+		return check
+	}
+	return Or(
+		InFunctionSelect{
+			Expr:      objectID,
+			Schema:    plan.DatabaseSchema,
+			FuncName:  ListObjectsFunctionName(plan.ObjectType, rel),
+			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
+			Alias:     "obj",
+			SelectCol: "object_id",
+		},
+		And(HasUserset{Source: SubjectID}, check),
+	)
+}
+
+// intersectionPartExclusion returns the "but not rel" predicate for a nested
+// exclusion inside an INTERSECT part: the object is kept when the subject does
+// NOT hold rel on it. When composition is safe it is the negation of rel's
+// list_objects membership (plus a userset-guarded check arm — an under-reported
+// exclusion is over-permissive); otherwise the per-candidate check_permission_internal
+// with ExpectAllow=false. Mirrors complexExclusionAntiJoin.
+func intersectionPartExclusion(plan ListPlan, rel string, objectID Expr) Expr {
+	check := CheckPermission{
+		Schema:      plan.DatabaseSchema,
+		Subject:     SubjectParams(),
+		Relation:    rel,
+		Object:      LiteralObject(plan.ObjectType, objectID),
+		ExpectAllow: false,
+	}
+	if !intersectionPartComposable(plan, rel) {
+		return check
+	}
+	return Not(Or(
+		InFunctionSelect{
+			Expr:      objectID,
+			Schema:    plan.DatabaseSchema,
+			FuncName:  ListObjectsFunctionName(plan.ObjectType, rel),
+			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
+			Alias:     "excl_obj",
+			SelectCol: "object_id",
+		},
+		And(
+			HasUserset{Source: SubjectID},
+			CheckPermission{
+				Schema:      plan.DatabaseSchema,
+				Subject:     SubjectParams(),
+				Relation:    rel,
+				Object:      LiteralObject(plan.ObjectType, objectID),
+				ExpectAllow: true,
+			},
+		),
+	))
+}
+
 // usersetMembership returns the membership predicate for a complex userset
 // arm: does the subject hold pattern.SubjectRelation on the userset object?
 //

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -205,6 +205,51 @@ func complexClosureMembership(plan ListPlan, rel string) Expr {
 	)
 }
 
+// complexClosureSubjectMembership returns the predicate proving the candidate
+// subject t.subject_id holds rel on the object p_object_id, for a complex
+// closure relation in list_subjects.
+//
+// When composition is safe it replaces the per-candidate
+// check_permission_internal with a semi-join against rel's list_subjects set —
+// list_{type}_{rel}_sub(p_object_id, p_subject_type) is exactly the set of
+// subjects holding rel on the object. The list_objects mirror keeps a userset-
+// guarded check arm, but list_subjects composition is gated OUT entirely when
+// wildcards are in play: list_{type}_{rel}_sub returns '*' for wildcard grants,
+// not the concrete subjects, so an IN membership would drop a concrete
+// candidate that holds rel only via a wildcard (under-report). The gate mirrors
+// buildSubjectFirstTTUSubjectBlocks: skip composition when either this
+// relation or the target relation HasWildcard.
+//
+// When composition is unsafe it returns the per-candidate check alone, which is
+// always correct. Mirrors complexClosureMembership.
+func complexClosureSubjectMembership(plan ListPlan, rel string) Expr {
+	check := CheckPermission{
+		Schema:      plan.DatabaseSchema,
+		Subject:     SubjectRef{Type: SubjectType, ID: Col{Table: "t", Column: "subject_id"}},
+		Relation:    rel,
+		Object:      LiteralObject(plan.ObjectType, ObjectID),
+		ExpectAllow: true,
+	}
+	if plan.Analysis.Features.HasWildcard {
+		return check
+	}
+	target := plan.AnalysisLookup[plan.ObjectType+"."+rel]
+	if target != nil && target.Features.HasWildcard {
+		return check
+	}
+	if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, plan.ObjectType, rel) {
+		return check
+	}
+	return InFunctionSelect{
+		Expr:      Col{Table: "t", Column: "subject_id"},
+		Schema:    plan.DatabaseSchema,
+		FuncName:  listSubjectsFunctionName(plan.ObjectType, rel),
+		Args:      []Expr{ObjectID, SubjectType},
+		Alias:     "sub",
+		SelectCol: "subject_id",
+	}
+}
+
 // usersetMembership returns the membership predicate for a complex userset
 // arm: does the subject hold pattern.SubjectRelation on the userset object?
 //

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -146,6 +146,48 @@ func relationReferences(a *RelationAnalysis) []string {
 	return refs
 }
 
+// reachesWildcard reports whether the list_subjects function for
+// (targetType, targetRelation) can surface a wildcard token ('*') — either the
+// relation itself HasWildcard, or it transitively reaches a wildcard relation
+// through its TTU parents / closure / userset reference edges. list_*_sub
+// returns '*' for such grants, not the concrete subjects, so an IN/LATERAL
+// membership composed against it would drop concrete candidates that hold the
+// relation only via the wildcard (under-report).
+//
+// Features.HasWildcard is NOT propagated across TTU parent edges by the
+// analyzer: e.g. folder.viewer = "[user, group#member] or viewer from org"
+// with org.viewer = [user:*] has folder.viewer.HasWildcard=false, yet
+// list_folder_viewer_sub returns '*' from the parent. This walk (over the same
+// over-approximating edge set as relationReferences, so a "reaches" verdict is
+// sound) closes that gap. Callers skip composition and keep the subject_pool /
+// per-candidate fallback, which resolves wildcards correctly.
+func reachesWildcard(lookup map[string]*RelationAnalysis, targetType, targetRelation string) bool {
+	if lookup == nil {
+		return true // no analysis: assume unsafe
+	}
+	start := targetType + "." + targetRelation
+	visited := map[string]bool{start: true}
+	queue := []string{start}
+	for len(queue) > 0 {
+		key := queue[0]
+		queue = queue[1:]
+		a, ok := lookup[key]
+		if !ok {
+			continue
+		}
+		if a.Features.HasWildcard {
+			return true
+		}
+		for _, next := range relationReferences(a) {
+			if !visited[next] {
+				visited[next] = true
+				queue = append(queue, next)
+			}
+		}
+	}
+	return false
+}
+
 // composableListTargetLookup reports whether the list_objects function for
 // (fromType, fromRelation) may compose with the list_objects function for
 // (targetType, targetRelation): the target must be list-generatable and
@@ -232,8 +274,9 @@ func complexClosureMembership(plan ListPlan, rel string) Expr {
 // wildcards are in play: list_{type}_{rel}_sub returns '*' for wildcard grants,
 // not the concrete subjects, so an IN membership would drop a concrete
 // candidate that holds rel only via a wildcard (under-report). The gate mirrors
-// buildSubjectFirstTTUSubjectBlocks: skip composition when either this
-// relation or the target relation HasWildcard.
+// buildSubjectFirstTTUSubjectBlocks: skip composition when this relation
+// HasWildcard or the target relation can surface '*' (own or transitively
+// reachable via TTU parents — reachesWildcard).
 //
 // When composition is unsafe it returns the per-candidate check alone, which is
 // always correct. Mirrors complexClosureMembership.
@@ -248,8 +291,7 @@ func complexClosureSubjectMembership(plan ListPlan, rel string) Expr {
 	if plan.Analysis.Features.HasWildcard {
 		return check
 	}
-	target := plan.AnalysisLookup[plan.ObjectType+"."+rel]
-	if target != nil && target.Features.HasWildcard {
+	if reachesWildcard(plan.AnalysisLookup, plan.ObjectType, rel) {
 		return check
 	}
 	if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, plan.ObjectType, rel) {

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -1,0 +1,200 @@
+package sqlgen
+
+// listCompositionSafe reports whether the list function for
+// (fromType, fromRelation) may compose with — i.e. call — the list function
+// for (targetType, targetRelation) without risking infinite recursion or an
+// unconditional depth-limit raise.
+//
+// List functions carry no p_visited cycle guard (unlike check functions), so
+// a list→list call is only safe when the callee can never call back into the
+// caller. That is decided at compile time by walking the relation-reference
+// graph from the target: if (fromType, fromRelation) is unreachable, no chain
+// of generated functions starting at the target can re-enter the caller.
+//
+// Every list→list call the renderers emit is itself gated by this function
+// (or corresponds to a reference edge below), so pairwise gating composes:
+// any cycle of emitted calls would need one gated edge whose walk sees the
+// rest of the cycle as reference edges and refuses it.
+//
+// The walk also refuses compositions that can reach a DepthExceeded relation:
+// its list function raises unconditionally, and that raise would surface
+// through the composition where the per-candidate check fallback used to
+// resolve the query (check functions carry their own depth guard).
+//
+// The edge set (relationReferences) over-approximates the calls generated SQL
+// can make, so a "safe" verdict is sound; an "unsafe" verdict merely keeps the
+// per-candidate check_permission_internal fallback, which is always correct.
+func listCompositionSafe(lookup map[string]*RelationAnalysis, fromType, fromRelation, targetType, targetRelation string) bool {
+	if lookup == nil {
+		return false
+	}
+	from := fromType + "." + fromRelation
+	start := targetType + "." + targetRelation
+	if start == from {
+		return false
+	}
+
+	visited := map[string]bool{start: true}
+	queue := []string{start}
+	for len(queue) > 0 {
+		key := queue[0]
+		queue = queue[1:]
+		a, ok := lookup[key]
+		if !ok {
+			continue
+		}
+		if a.ListStrategy == ListStrategyDepthExceeded {
+			return false
+		}
+		for _, next := range relationReferences(a) {
+			if next == from {
+				return false
+			}
+			if !visited[next] {
+				visited[next] = true
+				queue = append(queue, next)
+			}
+		}
+	}
+	return true
+}
+
+// relationReferences returns every "type.relation" key the generated functions
+// for a may reference — same-type closure/implied/excluded relations, TTU
+// parents, and userset targets, both direct and inherited through closure.
+// Deliberately over-inclusive: extra edges can only make listCompositionSafe
+// more conservative, never incorrect.
+//
+// MAINTENANCE: this must cover every reference-carrying field of
+// RelationAnalysis; a missed edge means listCompositionSafe can approve a
+// cyclic composition, which recurses infinitely at query time. A companion
+// reflection test (TestRelationReferencesFieldCoverage) fails when
+// RelationAnalysis gains a new field that has not been reviewed for edges.
+// analysis/analysis_types.go's sortByDependency walks a related (narrower)
+// edge set for ordering; keep both in mind when adding reference kinds.
+func relationReferences(a *RelationAnalysis) []string {
+	var refs []string
+	sameType := func(rels ...string) {
+		for _, r := range rels {
+			if r != "" {
+				refs = append(refs, a.ObjectType+"."+r)
+			}
+		}
+	}
+	parents := func(infos ...ParentRelationInfo) {
+		for _, p := range infos {
+			for _, t := range p.AllowedLinkingTypes {
+				refs = append(refs, t+"."+p.Relation)
+			}
+		}
+	}
+
+	sameType(a.SatisfyingRelations...)
+	sameType(a.DirectImpliedBy...)
+	sameType(a.SimpleClosureRelations...)
+	sameType(a.ComplexClosureRelations...)
+	sameType(a.IntersectionClosureRelations...)
+	sameType(a.ExcludedRelations...)
+	sameType(a.SimpleExcludedRelations...)
+	sameType(a.ComplexExcludedRelations...)
+	sameType(a.ClosureExcludedRelations...)
+
+	parents(a.ParentRelations...)
+	parents(a.ClosureParentRelations...)
+	parents(a.ExcludedParentRelations...)
+
+	for _, u := range a.UsersetPatterns {
+		refs = append(refs, u.SubjectType+"."+u.SubjectRelation)
+	}
+	for _, u := range a.ClosureUsersetPatterns {
+		refs = append(refs, u.SubjectType+"."+u.SubjectRelation)
+	}
+	for _, u := range a.SelfReferentialUsersets {
+		refs = append(refs, u.SubjectType+"."+u.SubjectRelation)
+	}
+
+	groups := func(gs ...IntersectionGroupInfo) {
+		for _, g := range gs {
+			for _, p := range g.Parts {
+				sameType(p.Relation, p.ExcludedRelation)
+				if p.ParentRelation != nil {
+					parents(*p.ParentRelation)
+				}
+			}
+		}
+	}
+	groups(a.IntersectionGroups...)
+	groups(a.ExcludedIntersectionGroups...)
+
+	if a.IndirectAnchor != nil {
+		refs = append(refs, a.IndirectAnchor.AnchorType+"."+a.IndirectAnchor.AnchorRelation)
+		for _, step := range a.IndirectAnchor.Path {
+			switch step.Type {
+			case "ttu":
+				for _, t := range step.AllTargetTypes {
+					refs = append(refs, t+"."+step.TargetRelation)
+				}
+				for _, t := range step.RecursiveTypes {
+					refs = append(refs, t+"."+step.TargetRelation)
+				}
+			case "userset":
+				refs = append(refs, step.SubjectType+"."+step.SubjectRelation)
+			}
+		}
+	}
+
+	return refs
+}
+
+// composableListTarget reports whether (targetType, targetRelation) has a
+// usable list_objects function this plan's function may compose with: the
+// target must be list-generatable and composition must be cycle-free and
+// unable to reach an always-raising DepthExceeded list function.
+func composableListTarget(plan ListPlan, targetType, targetRelation string) bool {
+	if plan.AnalysisLookup == nil {
+		return false
+	}
+	target, ok := plan.AnalysisLookup[targetType+"."+targetRelation]
+	if !ok || !target.Capabilities.ListAllowed {
+		return false
+	}
+	return listCompositionSafe(plan.AnalysisLookup, plan.ObjectType, plan.Relation, targetType, targetRelation)
+}
+
+// usersetMembership returns the membership predicate for a complex userset
+// arm: does the subject hold pattern.SubjectRelation on the userset object?
+//
+// When composition is safe it semi-joins against the userset relation's list
+// function — the set-oriented replacement for a per-candidate check — but
+// keeps a check_permission_internal arm guarded to userset-typed subjects:
+// check functions can prove membership for subjects like "group:eng#member"
+// through closure arms that not every list strategy enumerates. For plain
+// subjects the guard is false and the arm short-circuits before the check.
+//
+// When composition is not possible it returns the per-candidate check alone.
+func usersetMembership(plan ListPlan, pattern listUsersetPatternInput) Expr {
+	check := CheckPermission{
+		Schema:   plan.DatabaseSchema,
+		Subject:  SubjectParams(),
+		Relation: pattern.SubjectRelation,
+		Object: ObjectRef{
+			Type: Lit(pattern.SubjectType),
+			ID:   UsersetObjectID{Source: Col{Table: "t", Column: "subject_id"}},
+		},
+		ExpectAllow: true,
+	}
+	if !composableListTarget(plan, pattern.SubjectType, pattern.SubjectRelation) {
+		return check
+	}
+	return Or(
+		InFunctionSelect{
+			Expr:      UsersetObjectID{Source: Col{Table: "t", Column: "subject_id"}},
+			Schema:    plan.DatabaseSchema,
+			FuncName:  ListObjectsFunctionName(pattern.SubjectType, pattern.SubjectRelation),
+			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
+			Alias:     "obj",
+			SelectCol: "object_id",
+		},
+		And(HasUserset{Source: SubjectID}, check),
+	)
+}

--- a/lib/sqlgen/list_composition.go
+++ b/lib/sqlgen/list_composition.go
@@ -211,6 +211,23 @@ func composableListTarget(plan ListPlan, targetType, targetRelation string) bool
 	return composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, targetType, targetRelation)
 }
 
+// composableListSubjectsTarget reports whether this plan's list_subjects
+// function may compose against the target's list_{targetType}_{targetRelation}_sub
+// function. It is composableListTarget plus the list_subjects-only wildcard skip:
+// list_*_sub emits '*' for wildcard grants rather than the concrete subjects, so
+// an IN/LATERAL membership against a wildcard-reachable target would drop
+// concrete subjects that hold the relation only via a wildcard. This is the one
+// gate shared by every subject-first composition site (complex closure, complex
+// userset, TTU subject-first direct + closure patterns). Callers still apply the
+// caller-side plan.Analysis.Features.HasWildcard guard separately, since that
+// concerns the CALLER relation's own wildcards, not the target's.
+func composableListSubjectsTarget(plan ListPlan, targetType, targetRelation string) bool {
+	if reachesWildcard(plan.AnalysisLookup, targetType, targetRelation) {
+		return false
+	}
+	return composableListTarget(plan, targetType, targetRelation)
+}
+
 // composedListObjectsMembership is the positive-membership predicate shared by
 // every list_objects composition site: "the subject holds targetRel on the
 // candidate object objectIDExpr". It semi-joins against the target relation's
@@ -291,10 +308,7 @@ func complexClosureSubjectMembership(plan ListPlan, rel string) Expr {
 	if plan.Analysis.Features.HasWildcard {
 		return check
 	}
-	if reachesWildcard(plan.AnalysisLookup, plan.ObjectType, rel) {
-		return check
-	}
-	if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, plan.ObjectType, rel) {
+	if !composableListSubjectsTarget(plan, plan.ObjectType, rel) {
 		return check
 	}
 	return InFunctionSelect{

--- a/lib/sqlgen/list_composition_test.go
+++ b/lib/sqlgen/list_composition_test.go
@@ -1,0 +1,130 @@
+package sqlgen
+
+import (
+	"reflect"
+	"testing"
+)
+
+// relationReferencesReviewedFields lists every RelationAnalysis field that has
+// been reviewed for relation-reference edges. Fields carrying references MUST
+// be walked by relationReferences: a missed edge lets listCompositionSafe
+// approve a cyclic composition, and generated list functions have no runtime
+// cycle guard — the result is infinite recursion at query time.
+//
+// When RelationAnalysis gains a field, this test fails. Decide whether the
+// field carries (type, relation) references; if so, add it to
+// relationReferences, then record it here either way.
+var relationReferencesReviewedFields = map[string]bool{
+	// Carries references — walked by relationReferences:
+	"SatisfyingRelations":          true,
+	"DirectImpliedBy":              true,
+	"SimpleClosureRelations":       true,
+	"ComplexClosureRelations":      true,
+	"IntersectionClosureRelations": true,
+	"ExcludedRelations":            true,
+	"SimpleExcludedRelations":      true,
+	"ComplexExcludedRelations":     true,
+	"ClosureExcludedRelations":     true,
+	"ParentRelations":              true,
+	"ClosureParentRelations":       true,
+	"ExcludedParentRelations":      true,
+	"UsersetPatterns":              true,
+	"ClosureUsersetPatterns":       true,
+	"IntersectionGroups":           true,
+	"ExcludedIntersectionGroups":   true,
+	"IndirectAnchor":               true,
+	"SelfReferentialUsersets":      true,
+
+	// Reviewed: no relation references.
+	"ObjectType":                true,
+	"Relation":                  true,
+	"Features":                  true,
+	"Capabilities":              true,
+	"ListStrategy":              true,
+	"HasComplexUsersetPatterns": true,
+	"DirectSubjectTypes":        true,
+	"AllowedSubjectTypes":       true,
+	"MaxUsersetDepth":           true,
+	"ExceedsDepthLimit":         true,
+	"HasSelfReferentialUserset": true,
+}
+
+func TestRelationReferencesFieldCoverage(t *testing.T) {
+	typ := reflect.TypeFor[RelationAnalysis]()
+	for i := 0; i < typ.NumField(); i++ {
+		name := typ.Field(i).Name
+		if !relationReferencesReviewedFields[name] {
+			t.Errorf("RelationAnalysis.%s has not been reviewed for relation-reference edges; "+
+				"decide whether relationReferences must walk it, then add it to relationReferencesReviewedFields", name)
+		}
+	}
+	for name := range relationReferencesReviewedFields {
+		if _, ok := typ.FieldByName(name); !ok {
+			t.Errorf("relationReferencesReviewedFields lists %s, which no longer exists on RelationAnalysis", name)
+		}
+	}
+}
+
+func TestRelationReferencesEdgeExtraction(t *testing.T) {
+	a := &RelationAnalysis{
+		ObjectType:                   "doc",
+		Relation:                     "view",
+		SatisfyingRelations:          []string{"view", "edit"},
+		DirectImpliedBy:              []string{"edit"},
+		SimpleClosureRelations:       []string{"simple"},
+		ComplexClosureRelations:      []string{"complex"},
+		IntersectionClosureRelations: []string{"inter"},
+		ExcludedRelations:            []string{"banned"},
+		SimpleExcludedRelations:      []string{"sbanned"},
+		ComplexExcludedRelations:     []string{"cbanned"},
+		ClosureExcludedRelations:     []string{"clbanned"},
+		ParentRelations: []ParentRelationInfo{{
+			Relation: "view", AllowedLinkingTypes: []string{"folder"},
+		}},
+		ClosureParentRelations: []ParentRelationInfo{{
+			Relation: "admin", AllowedLinkingTypes: []string{"org"},
+		}},
+		ExcludedParentRelations: []ParentRelationInfo{{
+			Relation: "blocked", AllowedLinkingTypes: []string{"org"},
+		}},
+		UsersetPatterns: []UsersetPattern{{
+			SubjectType: "group", SubjectRelation: "member",
+		}},
+		ClosureUsersetPatterns: []UsersetPattern{{
+			SubjectType: "team", SubjectRelation: "member",
+		}},
+		IntersectionGroups: []IntersectionGroupInfo{{
+			Parts: []IntersectionPart{{
+				Relation:         "writer",
+				ExcludedRelation: "frozen",
+				ParentRelation:   &ParentRelationInfo{Relation: "owner", AllowedLinkingTypes: []string{"repo"}},
+			}},
+		}},
+		IndirectAnchor: &IndirectAnchorInfo{
+			AnchorType:     "space",
+			AnchorRelation: "viewer",
+			Path: []AnchorPathStep{{
+				Type: "userset", SubjectType: "guild", SubjectRelation: "member",
+			}},
+		},
+	}
+
+	got := make(map[string]bool)
+	for _, ref := range relationReferences(a) {
+		got[ref] = true
+	}
+
+	want := []string{
+		"doc.view", "doc.edit", "doc.simple", "doc.complex", "doc.inter",
+		"doc.banned", "doc.sbanned", "doc.cbanned", "doc.clbanned",
+		"folder.view", "org.admin", "org.blocked",
+		"group.member", "team.member",
+		"doc.writer", "doc.frozen", "repo.owner",
+		"space.viewer", "guild.member",
+	}
+	for _, w := range want {
+		if !got[w] {
+			t.Errorf("relationReferences missing edge %q", w)
+		}
+	}
+}

--- a/lib/sqlgen/list_functions.go
+++ b/lib/sqlgen/list_functions.go
@@ -53,8 +53,13 @@ func GenerateListSQLWithOptions(analyses []RelationAnalysis, inline InlineSQLDat
 			continue
 		}
 
+		// Filter the whole-model VALUES down to the object types this relation's
+		// functions can reference once (both list_objects and list_subjects share
+		// the same filtered set), instead of re-walking + re-filtering per call.
+		relInline := filterInlineForList(inline, a)
+
 		// Generate list_objects function
-		objFn, err := generateListObjectsFunctionWithLookup(a, inline, databaseSchema, analysisLookup, opts)
+		objFn, err := generateListObjectsFunctionWithLookup(a, relInline, databaseSchema, analysisLookup, opts)
 		if err != nil {
 			return ListGeneratedSQL{}, fmt.Errorf("generating list_objects function for %s.%s: %w",
 				a.ObjectType, a.Relation, err)
@@ -62,7 +67,7 @@ func GenerateListSQLWithOptions(analyses []RelationAnalysis, inline InlineSQLDat
 		result.ListObjectsFunctions = append(result.ListObjectsFunctions, objFn)
 
 		// Generate list_subjects function
-		subjFn, err := generateListSubjectsFunctionWithLookup(a, inline, databaseSchema, analysisLookup, opts)
+		subjFn, err := generateListSubjectsFunctionWithLookup(a, relInline, databaseSchema, analysisLookup, opts)
 		if err != nil {
 			return ListGeneratedSQL{}, fmt.Errorf("generating list_subjects function for %s.%s: %w",
 				a.ObjectType, a.Relation, err)
@@ -105,10 +110,8 @@ func listSubjectsFunctionName(objectType, relation string) string {
 
 // generateListObjectsFunctionWithLookup generates a list_objects function with analysis lookup for TTU optimization.
 func generateListObjectsFunctionWithLookup(a RelationAnalysis, inline InlineSQLData, databaseSchema string, lookup map[string]*RelationAnalysis, opts GenerateSQLOptions) (string, error) {
-	// Filter the whole-model VALUES down to the object types this function can
-	// reference, so the embedded closure/userset tables stop growing with
-	// unrelated schema (see filterInlineForList).
-	inline = filterInlineForList(inline, a)
+	// inline is pre-filtered by the caller (filterInlineForList) so the embedded
+	// closure/userset tables stop growing with unrelated schema.
 	// Route to appropriate generator based on ListStrategy
 	plan := BuildListObjectsPlanWithLookup(a, inline, databaseSchema, lookup)
 	plan.EnableMaterializedCTEs = opts.EnableMaterializedCTEs
@@ -152,10 +155,8 @@ func generateListObjectsFunctionWithLookup(a RelationAnalysis, inline InlineSQLD
 
 // generateListSubjectsFunctionWithLookup generates a list_subjects function with analysis lookup for TTU optimization.
 func generateListSubjectsFunctionWithLookup(a RelationAnalysis, inline InlineSQLData, databaseSchema string, lookup map[string]*RelationAnalysis, opts GenerateSQLOptions) (string, error) {
-	// Filter the whole-model VALUES down to the object types this function can
-	// reference, so the embedded closure/userset tables stop growing with
-	// unrelated schema (see filterInlineForList).
-	inline = filterInlineForList(inline, a)
+	// inline is pre-filtered by the caller (filterInlineForList) so the embedded
+	// closure/userset tables stop growing with unrelated schema.
 	// Route to appropriate generator based on ListStrategy
 	plan := BuildListSubjectsPlanWithLookup(a, inline, databaseSchema, lookup)
 	plan.EnableMaterializedCTEs = opts.EnableMaterializedCTEs

--- a/lib/sqlgen/list_functions.go
+++ b/lib/sqlgen/list_functions.go
@@ -105,6 +105,10 @@ func listSubjectsFunctionName(objectType, relation string) string {
 
 // generateListObjectsFunctionWithLookup generates a list_objects function with analysis lookup for TTU optimization.
 func generateListObjectsFunctionWithLookup(a RelationAnalysis, inline InlineSQLData, databaseSchema string, lookup map[string]*RelationAnalysis, opts GenerateSQLOptions) (string, error) {
+	// Filter the whole-model VALUES down to the object types this function can
+	// reference, so the embedded closure/userset tables stop growing with
+	// unrelated schema (see filterInlineForList).
+	inline = filterInlineForList(inline, a)
 	// Route to appropriate generator based on ListStrategy
 	plan := BuildListObjectsPlanWithLookup(a, inline, databaseSchema, lookup)
 	plan.EnableMaterializedCTEs = opts.EnableMaterializedCTEs
@@ -148,6 +152,10 @@ func generateListObjectsFunctionWithLookup(a RelationAnalysis, inline InlineSQLD
 
 // generateListSubjectsFunctionWithLookup generates a list_subjects function with analysis lookup for TTU optimization.
 func generateListSubjectsFunctionWithLookup(a RelationAnalysis, inline InlineSQLData, databaseSchema string, lookup map[string]*RelationAnalysis, opts GenerateSQLOptions) (string, error) {
+	// Filter the whole-model VALUES down to the object types this function can
+	// reference, so the embedded closure/userset tables stop growing with
+	// unrelated schema (see filterInlineForList).
+	inline = filterInlineForList(inline, a)
 	// Route to appropriate generator based on ListStrategy
 	plan := BuildListSubjectsPlanWithLookup(a, inline, databaseSchema, lookup)
 	plan.EnableMaterializedCTEs = opts.EnableMaterializedCTEs

--- a/lib/sqlgen/list_helpers.go
+++ b/lib/sqlgen/list_helpers.go
@@ -255,6 +255,9 @@ func generateListObjectsDispatcher(analyses []RelationAnalysis, databaseSchema s
 			"Routes to specialized functions for all type/relation pairs",
 		},
 		Body: buildDispatcherBody(cases, "p_subject_type, p_subject_id, p_limit, p_after"),
+		// Routes only to schema-qualified list_{type}_{rel}_obj calls, no
+		// unqualified melange_tuples.
+		NoSearchPath: true,
 	}
 	return fn.SQL(), nil
 }
@@ -273,6 +276,9 @@ func generateListSubjectsDispatcher(analyses []RelationAnalysis, databaseSchema 
 			"Routes to specialized functions for all type/relation pairs",
 		},
 		Body: buildDispatcherBody(cases, "p_object_id, p_subject_type, p_limit, p_after"),
+		// Routes only to schema-qualified list_{type}_{rel}_sub calls, no
+		// unqualified melange_tuples.
+		NoSearchPath: true,
 	}
 	return fn.SQL(), nil
 }

--- a/lib/sqlgen/list_objects_blocks.go
+++ b/lib/sqlgen/list_objects_blocks.go
@@ -164,13 +164,7 @@ func buildTypedListObjectsComplexClosureBlocks(plan ListPlan) ([]TypedQueryBlock
 				Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
 				In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
 				SubjectIDMatch(Col{Table: "t", Column: "subject_id"}, SubjectID, plan.AllowWildcard),
-				CheckPermission{
-					Schema:      plan.DatabaseSchema,
-					Subject:     SubjectParams(),
-					Relation:    rel,
-					Object:      LiteralObject(plan.ObjectType, Col{Table: "t", Column: "object_id"}),
-					ExpectAllow: true,
-				},
+				complexClosureMembership(plan, rel),
 			).
 			SelectCol("object_id").
 			Distinct()
@@ -182,7 +176,7 @@ func buildTypedListObjectsComplexClosureBlocks(plan ListPlan) ([]TypedQueryBlock
 
 		blocks = append(blocks, TypedQueryBlock{
 			Comments: []string{
-				"-- Complex closure relations: find candidates via tuples, validate via check_permission_internal",
+				"-- Complex closure relations: find candidates via tuples, validate via list composition (or check_permission_internal fallback)",
 				"-- These relations have exclusions or other complex features that require full permission check",
 			},
 			Query: q.Build(),

--- a/lib/sqlgen/list_objects_blocks.go
+++ b/lib/sqlgen/list_objects_blocks.go
@@ -398,6 +398,9 @@ func buildListObjectsUsersetPatternBlocks(plan ListPlan) ([]TypedQueryBlock, err
 }
 
 // buildListObjectsComplexUsersetBlock builds a block for complex userset patterns.
+// Membership comes from usersetMembership: a semi-join against the userset
+// relation's list function when composition is safe, or a per-candidate
+// check_permission_internal call otherwise.
 func buildListObjectsComplexUsersetBlock(plan ListPlan, pattern listUsersetPatternInput) (TypedQueryBlock, error) {
 	q := Tuples(plan.DatabaseSchema, "t").
 		ObjectType(plan.ObjectType).
@@ -409,16 +412,7 @@ func buildListObjectsComplexUsersetBlock(plan ListPlan, pattern listUsersetPatte
 				Left:  UsersetRelation{Source: Col{Table: "t", Column: "subject_id"}},
 				Right: Lit(pattern.SubjectRelation),
 			},
-			CheckPermission{
-				Schema:   plan.DatabaseSchema,
-				Subject:  SubjectParams(),
-				Relation: pattern.SubjectRelation,
-				Object: ObjectRef{
-					Type: Lit(pattern.SubjectType),
-					ID:   UsersetObjectID{Source: Col{Table: "t", Column: "subject_id"}},
-				},
-				ExpectAllow: true,
-			},
+			usersetMembership(plan, pattern),
 		).
 		SelectCol("object_id").
 		Distinct()

--- a/lib/sqlgen/list_objects_blocks.go
+++ b/lib/sqlgen/list_objects_blocks.go
@@ -339,24 +339,12 @@ func buildIntersectionPartQuery(plan ListPlan, part IntersectionPart) SelectStmt
 		q = Tuples(plan.DatabaseSchema, alias).
 			ObjectType(plan.ObjectType).
 			SelectCol("object_id").
-			Where(CheckPermission{
-				Schema:      plan.DatabaseSchema,
-				Subject:     SubjectParams(),
-				Relation:    part.Relation,
-				Object:      LiteralObject(plan.ObjectType, Col{Table: alias, Column: "object_id"}),
-				ExpectAllow: true,
-			}).
+			Where(intersectionPartMembership(plan, part.Relation, Col{Table: alias, Column: "object_id"})).
 			Distinct()
 	}
 
 	if part.ExcludedRelation != "" {
-		q.Where(CheckPermission{
-			Schema:      plan.DatabaseSchema,
-			Subject:     SubjectParams(),
-			Relation:    part.ExcludedRelation,
-			Object:      LiteralObject(plan.ObjectType, Col{Table: alias, Column: "object_id"}),
-			ExpectAllow: false,
-		})
+		q.Where(intersectionPartExclusion(plan, part.ExcludedRelation, Col{Table: alias, Column: "object_id"}))
 	}
 
 	return q.Build()

--- a/lib/sqlgen/list_objects_blocks.go
+++ b/lib/sqlgen/list_objects_blocks.go
@@ -98,9 +98,14 @@ func buildListObjectsDirectBlock(plan ListPlan) (TypedQueryBlock, error) {
 	}, nil
 }
 
-// buildListObjectsUsersetSubjectBlock builds the userset subject matching block.
-func buildListObjectsUsersetSubjectBlock(plan ListPlan) (TypedQueryBlock, error) {
-	// Build the closure EXISTS subquery
+// usersetSubjectCandidateMatch returns the predicate matching tuples whose
+// subject_id names the userset query subject p_subject_id directly (exact
+// userset equality) or via a closure-equivalent relation. It gates on both the
+// query subject and the tuple subject being usersets, so it is a no-op for
+// plain subjects. Shared by the userset-subject block and the complex-closure
+// candidate arm so a userset query subject is admitted as a candidate wherever
+// a plain subject would be.
+func usersetSubjectCandidateMatch(plan ListPlan) Expr {
 	closureExistsStmt := SelectStmt{
 		ColumnExprs: []Expr{Int(1)},
 		FromExpr:    ClosureTable(plan.Inline.ClosureRows, "c"),
@@ -123,14 +128,37 @@ func buildListObjectsUsersetSubjectBlock(plan ListPlan) (TypedQueryBlock, error)
 		),
 	)
 
+	return And(
+		HasUserset{Source: SubjectID},
+		HasUserset{Source: Col{Table: "t", Column: "subject_id"}},
+		subjectMatch,
+	)
+}
+
+// complexClosureCandidateMatch admits a tuple as a list_objects candidate for a
+// complex-closure relation: a plain subject via the type-guarded exact/wildcard
+// match, or a userset query subject via userset closure equality. Without the
+// userset arm a userset query subject (e.g. group:g2#member) named directly on a
+// candidate-relation tuple is dropped, under-reporting objects that
+// check_permission allows (issue #10).
+func complexClosureCandidateMatch(plan ListPlan) Expr {
+	return Or(
+		And(
+			In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
+			SubjectIDMatch(Col{Table: "t", Column: "subject_id"}, SubjectID, plan.AllowWildcard),
+		),
+		usersetSubjectCandidateMatch(plan),
+	)
+}
+
+// buildListObjectsUsersetSubjectBlock builds the userset subject matching block.
+func buildListObjectsUsersetSubjectBlock(plan ListPlan) (TypedQueryBlock, error) {
 	q := Tuples(plan.DatabaseSchema, "t").
 		ObjectType(plan.ObjectType).
 		Relations(plan.RelationList...).
 		Where(
 			Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
-			HasUserset{Source: SubjectID},
-			HasUserset{Source: Col{Table: "t", Column: "subject_id"}},
-			subjectMatch,
+			usersetSubjectCandidateMatch(plan),
 		).
 		SelectCol("object_id").
 		Distinct()
@@ -162,8 +190,7 @@ func buildTypedListObjectsComplexClosureBlocks(plan ListPlan) ([]TypedQueryBlock
 			Relations(rel).
 			Where(
 				Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
-				In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
-				SubjectIDMatch(Col{Table: "t", Column: "subject_id"}, SubjectID, plan.AllowWildcard),
+				complexClosureCandidateMatch(plan),
 				complexClosureMembership(plan, rel),
 			).
 			SelectCol("object_id").

--- a/lib/sqlgen/list_objects_blocks.go
+++ b/lib/sqlgen/list_objects_blocks.go
@@ -449,18 +449,6 @@ func buildListObjectsSimpleUsersetBlock(plan ListPlan, pattern listUsersetPatter
 	}, nil
 }
 
-// listSelfSatisfyingExpr folds the self-candidate closure lookup to a
-// compile-time IN-list, mirroring usersetSelfSatisfyingExpr for check
-// functions. The self-candidate predicate keys the closure on the constant
-// (plan.ObjectType, plan.Relation) with satisfying_relation =
-// substring(subject_id ...); that satisfying set is statically known as
-// plan.Analysis.SatisfyingRelations (same relation, same closure rows), so the
-// whole-model closure VALUES scan folds to substring(...) IN (...). Empty set →
-// FALSE, matching the empty VALUES scan.
-func listSelfSatisfyingExpr(plan ListPlan) Expr {
-	return In{Expr: SubstringUsersetRelation{Source: SubjectID}, Values: plan.Analysis.SatisfyingRelations}
-}
-
 // buildListObjectsSelfCandidateBlock builds the self-candidate block for when
 // the subject is a userset on the same object type (e.g., document:1#writer).
 func buildListObjectsSelfCandidateBlock(plan ListPlan) *TypedQueryBlock {
@@ -470,7 +458,7 @@ func buildListObjectsSelfCandidateBlock(plan ListPlan) *TypedQueryBlock {
 		Where: And(
 			HasUserset{Source: SubjectID},
 			Eq{Left: SubjectType, Right: Lit(plan.ObjectType)},
-			listSelfSatisfyingExpr(plan),
+			usersetSelfSatisfyingExpr(plan.Analysis),
 		),
 	}
 

--- a/lib/sqlgen/list_objects_blocks.go
+++ b/lib/sqlgen/list_objects_blocks.go
@@ -449,26 +449,28 @@ func buildListObjectsSimpleUsersetBlock(plan ListPlan, pattern listUsersetPatter
 	}, nil
 }
 
+// listSelfSatisfyingExpr folds the self-candidate closure lookup to a
+// compile-time IN-list, mirroring usersetSelfSatisfyingExpr for check
+// functions. The self-candidate predicate keys the closure on the constant
+// (plan.ObjectType, plan.Relation) with satisfying_relation =
+// substring(subject_id ...); that satisfying set is statically known as
+// plan.Analysis.SatisfyingRelations (same relation, same closure rows), so the
+// whole-model closure VALUES scan folds to substring(...) IN (...). Empty set →
+// FALSE, matching the empty VALUES scan.
+func listSelfSatisfyingExpr(plan ListPlan) Expr {
+	return In{Expr: SubstringUsersetRelation{Source: SubjectID}, Values: plan.Analysis.SatisfyingRelations}
+}
+
 // buildListObjectsSelfCandidateBlock builds the self-candidate block for when
 // the subject is a userset on the same object type (e.g., document:1#writer).
 func buildListObjectsSelfCandidateBlock(plan ListPlan) *TypedQueryBlock {
-	closureStmt := SelectStmt{
-		ColumnExprs: []Expr{Int(1)},
-		FromExpr:    ClosureTable(plan.Inline.ClosureRows, "c"),
-		Where: And(
-			Eq{Left: Col{Table: "c", Column: "object_type"}, Right: Lit(plan.ObjectType)},
-			Eq{Left: Col{Table: "c", Column: "relation"}, Right: Lit(plan.Relation)},
-			Eq{Left: Col{Table: "c", Column: "satisfying_relation"}, Right: SubstringUsersetRelation{Source: SubjectID}},
-		),
-	}
-
 	stmt := SelectStmt{
 		ColumnExprs: []Expr{UsersetObjectID{Source: SubjectID}},
 		Alias:       "object_id",
 		Where: And(
 			HasUserset{Source: SubjectID},
 			Eq{Left: SubjectType, Right: Lit(plan.ObjectType)},
-			Raw(closureStmt.Exists()),
+			listSelfSatisfyingExpr(plan),
 		),
 	}
 

--- a/lib/sqlgen/list_objects_blocks_composed.go
+++ b/lib/sqlgen/list_objects_blocks_composed.go
@@ -174,7 +174,7 @@ func buildComposedRecursiveTTUObjectsBlock(plan ListPlan, anchor *IndirectAnchor
 	targetRel := anchor.Path[0].TargetRelation
 	check := CheckPermissionInternalExpr(plan.DatabaseSchema, SubjectParams(), targetRel, ObjectRef{Type: Lit(recursiveType), ID: Col{Table: "t", Column: "subject_id"}}, true)
 
-	var membership Expr = check
+	membership := check
 	if composableListTarget(plan, recursiveType, targetRel) {
 		membership = composedListObjectsMembership(plan.DatabaseSchema, recursiveType, targetRel, Col{Table: "t", Column: "subject_id"}, SubjectType, SubjectID, "obj", check)
 	}
@@ -223,7 +223,7 @@ func buildComposedUsersetObjectsBlock(plan ListPlan, firstStep AnchorPathStep, e
 	usersetObjectID := Raw("split_part(t.subject_id, '#', 1)")
 	check := CheckPermissionInternalExpr(plan.DatabaseSchema, SubjectParams(), firstStep.SubjectRelation, ObjectRef{Type: Lit(firstStep.SubjectType), ID: usersetObjectID}, true)
 
-	var membership Expr = check
+	membership := check
 	if composableListTarget(plan, firstStep.SubjectType, firstStep.SubjectRelation) {
 		membership = composedListObjectsMembership(plan.DatabaseSchema, firstStep.SubjectType, firstStep.SubjectRelation, usersetObjectID, SubjectType, SubjectID, "obj", check)
 	}

--- a/lib/sqlgen/list_objects_blocks_composed.go
+++ b/lib/sqlgen/list_objects_blocks_composed.go
@@ -166,15 +166,45 @@ func buildComposedTTUObjectsBlock(plan ListPlan, anchor *IndirectAnchorInfo, tar
 }
 
 // buildComposedRecursiveTTUObjectsBlock builds a recursive TTU composition block.
+//
+// The linking tuples are scanned and each parent object t.subject_id validated
+// against anchor's target relation. When composition is safe
+// (composableListTarget), the per-candidate check_permission_internal is
+// replaced by a semi-join against the parent relation's list_objects set — the
+// set of parent objects the subject holds the target relation on — mirroring
+// buildComposedTTUObjectsBlock. A check arm guarded to userset-typed subjects is
+// kept for parity: the list function is complete for plain subjects but a
+// Recursive/Composed target may under-report a userset-typed query subject
+// ("group:eng#member"), and an under-reported positive membership drops objects.
+// When composition is unsafe (the recursive parent chain is self-referential/
+// cyclic, so the gate refuses) it keeps the per-candidate check alone.
 func buildComposedRecursiveTTUObjectsBlock(plan ListPlan, anchor *IndirectAnchorInfo, recursiveType string, exclusions ExclusionConfig) (*TypedQueryBlock, error) {
 	exclusionPreds := exclusions.BuildPredicates()
+
+	targetRel := anchor.Path[0].TargetRelation
+	check := CheckPermissionInternalExpr(plan.DatabaseSchema, SubjectParams(), targetRel, ObjectRef{Type: Lit(recursiveType), ID: Col{Table: "t", Column: "subject_id"}}, true)
+
+	var membership Expr = check
+	if composableListTarget(plan, recursiveType, targetRel) {
+		membership = Or(
+			InFunctionSelect{
+				Expr:      Col{Table: "t", Column: "subject_id"},
+				Schema:    plan.DatabaseSchema,
+				FuncName:  ListObjectsFunctionName(recursiveType, targetRel),
+				Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
+				Alias:     "obj",
+				SelectCol: "object_id",
+			},
+			And(HasUserset{Source: SubjectID}, check),
+		)
+	}
 
 	conditions := make([]Expr, 0, 4+len(exclusionPreds))
 	conditions = append(conditions,
 		Eq{Left: Col{Table: "t", Column: "object_type"}, Right: Lit(plan.ObjectType)},
 		Eq{Left: Col{Table: "t", Column: "relation"}, Right: Lit(anchor.Path[0].LinkingRelation)},
 		Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: Lit(recursiveType)},
-		CheckPermissionInternalExpr(plan.DatabaseSchema, SubjectParams(), anchor.Path[0].TargetRelation, ObjectRef{Type: Lit(recursiveType), ID: Col{Table: "t", Column: "subject_id"}}, true),
+		membership,
 	)
 	conditions = append(conditions, exclusionPreds...)
 

--- a/lib/sqlgen/list_objects_blocks_composed.go
+++ b/lib/sqlgen/list_objects_blocks_composed.go
@@ -105,7 +105,7 @@ func buildComposedObjectsSelfBlock(plan ListPlan) (*TypedQueryBlock, error) {
 		Where: And(
 			Eq{Left: SubjectType, Right: Lit(plan.ObjectType)},
 			HasUserset{Source: SubjectID},
-			listSelfSatisfyingExpr(plan),
+			usersetSelfSatisfyingExpr(plan.Analysis),
 		),
 	}
 

--- a/lib/sqlgen/list_objects_blocks_composed.go
+++ b/lib/sqlgen/list_objects_blocks_composed.go
@@ -224,19 +224,38 @@ func buildComposedRecursiveTTUObjectsBlock(plan ListPlan, anchor *IndirectAnchor
 }
 
 // buildComposedUsersetObjectsBlock builds a userset composition block.
+//
+// The block finds grant tuples whose subject is a userset (X:id#rel) and keeps
+// the candidate object when the query subject holds rel on X:id. When
+// composition is safe (composableListTarget) that membership is a semi-join
+// against the userset relation's list_objects set, with a check arm guarded to
+// userset-typed query subjects for parity: the list function is complete for
+// plain subjects but a Recursive/Composed target may under-report a userset
+// query subject ("group:eng#member"), and an under-reported positive membership
+// drops objects. The guard (position('#' in p_subject_id) > 0) means plain
+// subjects skip the per-row check entirely — the fan-out this block used to pay
+// on every subject. When composition is unsafe it keeps the per-candidate check
+// alone. Mirrors usersetMembership / buildComposedRecursiveTTUObjectsBlock.
 func buildComposedUsersetObjectsBlock(plan ListPlan, firstStep AnchorPathStep, exclusions ExclusionConfig) (*TypedQueryBlock, error) {
 	exclusionPreds := exclusions.BuildPredicates()
 
-	// Build subquery for list function call using typed DSL
 	// split_part(t.subject_id, '#', 1) extracts the object_id from the userset
 	usersetObjectID := Raw("split_part(t.subject_id, '#', 1)")
-	inSubquery := InFunctionSelect{
-		Expr:      usersetObjectID,
-		Schema:    plan.DatabaseSchema,
-		FuncName:  ListObjectsFunctionName(firstStep.SubjectType, firstStep.SubjectRelation),
-		Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-		Alias:     "obj",
-		SelectCol: "object_id",
+	check := CheckPermissionInternalExpr(plan.DatabaseSchema, SubjectParams(), firstStep.SubjectRelation, ObjectRef{Type: Lit(firstStep.SubjectType), ID: usersetObjectID}, true)
+
+	var membership Expr = check
+	if composableListTarget(plan, firstStep.SubjectType, firstStep.SubjectRelation) {
+		membership = Or(
+			InFunctionSelect{
+				Expr:      usersetObjectID,
+				Schema:    plan.DatabaseSchema,
+				FuncName:  ListObjectsFunctionName(firstStep.SubjectType, firstStep.SubjectRelation),
+				Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
+				Alias:     "obj",
+				SelectCol: "object_id",
+			},
+			And(HasUserset{Source: SubjectID}, check),
+		)
 	}
 
 	conditions := make([]Expr, 0, 6+len(exclusionPreds))
@@ -246,10 +265,7 @@ func buildComposedUsersetObjectsBlock(plan ListPlan, firstStep AnchorPathStep, e
 		Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: Lit(firstStep.SubjectType)},
 		HasUserset{Source: Col{Table: "t", Column: "subject_id"}},
 		Eq{Left: UsersetRelation{Source: Col{Table: "t", Column: "subject_id"}}, Right: Lit(firstStep.SubjectRelation)},
-		Or(
-			inSubquery,
-			CheckPermissionInternalExpr(plan.DatabaseSchema, SubjectParams(), firstStep.SubjectRelation, ObjectRef{Type: Lit(firstStep.SubjectType), ID: usersetObjectID}, true),
-		),
+		membership,
 	)
 	conditions = append(conditions, exclusionPreds...)
 

--- a/lib/sqlgen/list_objects_blocks_composed.go
+++ b/lib/sqlgen/list_objects_blocks_composed.go
@@ -186,17 +186,7 @@ func buildComposedRecursiveTTUObjectsBlock(plan ListPlan, anchor *IndirectAnchor
 
 	var membership Expr = check
 	if composableListTarget(plan, recursiveType, targetRel) {
-		membership = Or(
-			InFunctionSelect{
-				Expr:      Col{Table: "t", Column: "subject_id"},
-				Schema:    plan.DatabaseSchema,
-				FuncName:  ListObjectsFunctionName(recursiveType, targetRel),
-				Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-				Alias:     "obj",
-				SelectCol: "object_id",
-			},
-			And(HasUserset{Source: SubjectID}, check),
-		)
+		membership = composedListObjectsMembership(plan.DatabaseSchema, recursiveType, targetRel, Col{Table: "t", Column: "subject_id"}, SubjectType, SubjectID, "obj", check)
 	}
 
 	conditions := make([]Expr, 0, 4+len(exclusionPreds))
@@ -245,17 +235,7 @@ func buildComposedUsersetObjectsBlock(plan ListPlan, firstStep AnchorPathStep, e
 
 	var membership Expr = check
 	if composableListTarget(plan, firstStep.SubjectType, firstStep.SubjectRelation) {
-		membership = Or(
-			InFunctionSelect{
-				Expr:      usersetObjectID,
-				Schema:    plan.DatabaseSchema,
-				FuncName:  ListObjectsFunctionName(firstStep.SubjectType, firstStep.SubjectRelation),
-				Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-				Alias:     "obj",
-				SelectCol: "object_id",
-			},
-			And(HasUserset{Source: SubjectID}, check),
-		)
+		membership = composedListObjectsMembership(plan.DatabaseSchema, firstStep.SubjectType, firstStep.SubjectRelation, usersetObjectID, SubjectType, SubjectID, "obj", check)
 	}
 
 	conditions := make([]Expr, 0, 6+len(exclusionPreds))

--- a/lib/sqlgen/list_objects_blocks_composed.go
+++ b/lib/sqlgen/list_objects_blocks_composed.go
@@ -100,22 +100,12 @@ func BuildListObjectsComposedBlocks(plan ListPlan) (ComposedObjectsBlockSet, err
 
 // buildComposedObjectsSelfBlock builds the self-candidate check block.
 func buildComposedObjectsSelfBlock(plan ListPlan) (*TypedQueryBlock, error) {
-	closureStmt := SelectStmt{
-		ColumnExprs: []Expr{Int(1)},
-		FromExpr:    ClosureTable(plan.Inline.ClosureRows, "c"),
-		Where: And(
-			Eq{Left: Col{Table: "c", Column: "object_type"}, Right: Lit(plan.ObjectType)},
-			Eq{Left: Col{Table: "c", Column: "relation"}, Right: Lit(plan.Relation)},
-			Eq{Left: Col{Table: "c", Column: "satisfying_relation"}, Right: SubstringUsersetRelation{Source: SubjectID}},
-		),
-	}
-
 	stmt := SelectStmt{
 		ColumnExprs: []Expr{SelectAs(UsersetObjectID{Source: SubjectID}, "object_id")},
 		Where: And(
 			Eq{Left: SubjectType, Right: Lit(plan.ObjectType)},
 			HasUserset{Source: SubjectID},
-			Raw(closureStmt.Exists()),
+			listSelfSatisfyingExpr(plan),
 		),
 	}
 

--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -151,13 +151,7 @@ func buildRecursiveComplexClosureBlock(plan ListPlan, rel string) TypedQueryBloc
 			Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
 			In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
 			SubjectIDMatch(Col{Table: "t", Column: "subject_id"}, SubjectID, plan.AllowWildcard),
-			CheckPermission{
-				Schema:      plan.DatabaseSchema,
-				Subject:     SubjectParams(),
-				Relation:    rel,
-				Object:      LiteralObject(plan.ObjectType, Col{Table: "t", Column: "object_id"}),
-				ExpectAllow: true,
-			},
+			complexClosureMembership(plan, rel),
 		).
 		SelectCol("object_id").
 		Distinct()

--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -149,8 +149,7 @@ func buildRecursiveComplexClosureBlock(plan ListPlan, rel string) TypedQueryBloc
 		Relations(rel).
 		Where(
 			Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
-			In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
-			SubjectIDMatch(Col{Table: "t", Column: "subject_id"}, SubjectID, plan.AllowWildcard),
+			complexClosureCandidateMatch(plan),
 			complexClosureMembership(plan, rel),
 		).
 		SelectCol("object_id").

--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -192,6 +192,9 @@ func buildRecursiveIntersectionClosureBlock(plan ListPlan, rel string) TypedQuer
 }
 
 // buildRecursiveComplexUsersetBlock builds a block for complex userset patterns.
+// Membership comes from usersetMembership: a semi-join against the userset
+// relation's list function when composition is safe, or a per-candidate
+// check_permission_internal call otherwise.
 func buildRecursiveComplexUsersetBlock(plan ListPlan, pattern listUsersetPatternInput) TypedQueryBlock {
 	q := Tuples(plan.DatabaseSchema, "t").
 		ObjectType(plan.ObjectType).
@@ -203,16 +206,7 @@ func buildRecursiveComplexUsersetBlock(plan ListPlan, pattern listUsersetPattern
 				Left:  UsersetRelation{Source: Col{Table: "t", Column: "subject_id"}},
 				Right: Lit(pattern.SubjectRelation),
 			},
-			CheckPermission{
-				Schema:   plan.DatabaseSchema,
-				Subject:  SubjectParams(),
-				Relation: pattern.SubjectRelation,
-				Object: ObjectRef{
-					Type: Lit(pattern.SubjectType),
-					ID:   UsersetObjectID{Source: Col{Table: "t", Column: "subject_id"}},
-				},
-				ExpectAllow: true,
-			},
+			usersetMembership(plan, pattern),
 		).
 		SelectCol("object_id").
 		Distinct()
@@ -335,38 +329,34 @@ func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelation
 		for _, parentType := range crossTypes {
 			if canUseSubjectFirstTTU(plan, parent, parentType) {
 				blocks = append(blocks, buildSubjectFirstCrossTypeTTUBlock(plan, parent, parentType, crossExclusions))
+				// Userset-typed subjects (e.g. "group:eng#member") can be
+				// provable by the parent's check function through closure arms
+				// its list function does not enumerate; keep a per-candidate
+				// check arm for exactly that case. The guard is false for
+				// plain subjects, so the check never runs on the hot path.
+				blocks = append(blocks, buildCheckPermissionCrossTypeTTUBlock(plan, parent, []string{parentType}, crossExclusions, true))
 			} else {
 				fallbackTypes = append(fallbackTypes, parentType)
 			}
 		}
 
 		if len(fallbackTypes) > 0 {
-			blocks = append(blocks, buildCheckPermissionCrossTypeTTUBlock(plan, parent, fallbackTypes, crossExclusions))
+			blocks = append(blocks, buildCheckPermissionCrossTypeTTUBlock(plan, parent, fallbackTypes, crossExclusions, false))
 		}
 	}
 
 	return blocks
 }
 
+// canUseSubjectFirstTTU decides whether the parent relation's list function
+// can be composed with (subject-first path) instead of checking every child
+// linking tuple. All strategies route through the same reachability gate:
+// list functions carry no p_visited guard, so composition is allowed only
+// when the relation-reference graph proves the parent can never call back
+// into this function (and cannot reach an always-raising DepthExceeded list
+// function). Cyclic schemas keep the per-candidate permission-check fallback.
 func canUseSubjectFirstTTU(plan ListPlan, parent ListParentRelationData, parentType string) bool {
-	if plan.AnalysisLookup == nil {
-		return false
-	}
-
-	parentAnalysis, ok := plan.AnalysisLookup[parentType+"."+parent.Relation]
-	if !ok || !parentAnalysis.Capabilities.ListAllowed {
-		return false
-	}
-
-	// Avoid introducing cross-type list recursion. The permission-check fallback
-	// carries p_visited and remains the safe path for recursive/composed list
-	// strategies; direct/userset/intersection parents have no TTU list calls.
-	switch parentAnalysis.ListStrategy {
-	case ListStrategyDirect, ListStrategyUserset, ListStrategyIntersection:
-		return true
-	default:
-		return false
-	}
+	return composableListTarget(plan, parentType, parent.Relation)
 }
 
 func buildSubjectFirstCrossTypeTTUBlock(plan ListPlan, parent ListParentRelationData, parentType string, exclusions ExclusionConfig) TypedQueryBlock {
@@ -432,7 +422,11 @@ func sourceRelationCheck(plan ListPlan, parent ListParentRelationData) Expr {
 	}
 }
 
-func buildCheckPermissionCrossTypeTTUBlock(plan ListPlan, parent ListParentRelationData, crossTypes []string, exclusions ExclusionConfig) TypedQueryBlock {
+// buildCheckPermissionCrossTypeTTUBlock builds the per-candidate check block
+// for cross-type TTU. With usersetSubjectsOnly it additionally guards on the
+// subject being a userset, serving as the parity companion to a subject-first
+// composition block (the guard short-circuits for plain subjects).
+func buildCheckPermissionCrossTypeTTUBlock(plan ListPlan, parent ListParentRelationData, crossTypes []string, exclusions ExclusionConfig, usersetSubjectsOnly bool) TypedQueryBlock {
 	accessCheck := Expr(CheckPermission{
 		Schema:   plan.DatabaseSchema,
 		Subject:  SubjectParams(),
@@ -450,10 +444,14 @@ func buildCheckPermissionCrossTypeTTUBlock(plan ListPlan, parent ListParentRelat
 	q := Tuples(plan.DatabaseSchema, "child").
 		ObjectType(plan.ObjectType).
 		Relations(parent.LinkingRelation).
-		Where(
-			In{Expr: Col{Table: "child", Column: "subject_type"}, Values: crossTypes},
-			accessCheck,
-		).
+		Where(In{Expr: Col{Table: "child", Column: "subject_type"}, Values: crossTypes})
+
+	comment := fmt.Sprintf("-- Cross-type TTU fallback: %s -> %s", parent.LinkingRelation, parent.Relation)
+	if usersetSubjectsOnly {
+		q.Where(HasUserset{Source: SubjectID})
+		comment = fmt.Sprintf("-- Cross-type TTU userset-subject parity: %s -> %s", parent.LinkingRelation, parent.Relation)
+	}
+	q.Where(accessCheck).
 		SelectCol("object_id").
 		Distinct()
 
@@ -462,7 +460,7 @@ func buildCheckPermissionCrossTypeTTUBlock(plan ListPlan, parent ListParentRelat
 	}
 
 	return TypedQueryBlock{
-		Comments: []string{fmt.Sprintf("-- Cross-type TTU fallback: %s -> %s", parent.LinkingRelation, parent.Relation)},
+		Comments: []string{comment},
 		Query:    q.Build(),
 	}
 }

--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -406,14 +406,38 @@ func sourceRelationNeedsVerification(plan ListPlan, parent ListParentRelationDat
 	return sourceAnalysis.Features.HasExclusion || sourceAnalysis.Features.HasIntersection
 }
 
+// sourceRelationCheck proves the subject holds the closure-pattern TTU's source
+// relation on the child object. When composition is safe it replaces the
+// per-candidate check_permission_internal with a semi-join against the source
+// relation's list_objects set (the set of objects the subject holds SourceRelation
+// on), keeping a check arm guarded to userset-typed subjects for parity: the list
+// function is complete for plain subjects but a Recursive/Composed target may
+// under-report userset subjects ("group:eng#member"), and an under-reported
+// positive membership drops objects (under-permissive). For plain subjects the
+// guard is false and the arm short-circuits. When composition is unsafe it returns
+// the per-candidate check alone. Mirrors complexClosureMembership.
 func sourceRelationCheck(plan ListPlan, parent ListParentRelationData) Expr {
-	return CheckPermission{
+	check := CheckPermission{
 		Schema:      plan.DatabaseSchema,
 		Subject:     SubjectParams(),
 		Relation:    parent.SourceRelation,
 		Object:      LiteralObject(plan.ObjectType, Col{Table: "child", Column: "object_id"}),
 		ExpectAllow: true,
 	}
+	if !composableListTarget(plan, plan.ObjectType, parent.SourceRelation) {
+		return check
+	}
+	return Or(
+		InFunctionSelect{
+			Expr:      Col{Table: "child", Column: "object_id"},
+			Schema:    plan.DatabaseSchema,
+			FuncName:  ListObjectsFunctionName(plan.ObjectType, parent.SourceRelation),
+			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
+			Alias:     "src_obj",
+			SelectCol: "object_id",
+		},
+		And(HasUserset{Source: SubjectID}, check),
+	)
 }
 
 // buildCheckPermissionCrossTypeTTUBlock builds the per-candidate check block

--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -427,17 +427,7 @@ func sourceRelationCheck(plan ListPlan, parent ListParentRelationData) Expr {
 	if !composableListTarget(plan, plan.ObjectType, parent.SourceRelation) {
 		return check
 	}
-	return Or(
-		InFunctionSelect{
-			Expr:      Col{Table: "child", Column: "object_id"},
-			Schema:    plan.DatabaseSchema,
-			FuncName:  ListObjectsFunctionName(plan.ObjectType, parent.SourceRelation),
-			Args:      []Expr{SubjectType, SubjectID, Null{}, Null{}},
-			Alias:     "src_obj",
-			SelectCol: "object_id",
-		},
-		And(HasUserset{Source: SubjectID}, check),
-	)
+	return composedListObjectsMembership(plan.DatabaseSchema, plan.ObjectType, parent.SourceRelation, Col{Table: "child", Column: "object_id"}, SubjectType, SubjectID, "src_obj", check)
 }
 
 // buildCheckPermissionCrossTypeTTUBlock builds the per-candidate check block

--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -321,13 +321,14 @@ func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelation
 		var fallbackTypes []string
 		for _, parentType := range crossTypes {
 			if canUseSubjectFirstTTU(plan, parent, parentType) {
-				blocks = append(blocks, buildSubjectFirstCrossTypeTTUBlock(plan, parent, parentType, crossExclusions))
 				// Userset-typed subjects (e.g. "group:eng#member") can be
 				// provable by the parent's check function through closure arms
 				// its list function does not enumerate; keep a per-candidate
 				// check arm for exactly that case. The guard is false for
 				// plain subjects, so the check never runs on the hot path.
-				blocks = append(blocks, buildCheckPermissionCrossTypeTTUBlock(plan, parent, []string{parentType}, crossExclusions, true))
+				blocks = append(blocks,
+					buildSubjectFirstCrossTypeTTUBlock(plan, parent, parentType, crossExclusions),
+					buildCheckPermissionCrossTypeTTUBlock(plan, parent, []string{parentType}, crossExclusions, true))
 			} else {
 				fallbackTypes = append(fallbackTypes, parentType)
 			}

--- a/lib/sqlgen/list_objects_blocks_recursive_test.go
+++ b/lib/sqlgen/list_objects_blocks_recursive_test.go
@@ -34,8 +34,8 @@ func TestBuildCrossTypeTTUBlocksUsesSubjectFirstParentList(t *testing.T) {
 		HasCrossTypeLinks:     true,
 	}})
 
-	if len(blocks) != 1 {
-		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	if len(blocks) != 2 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))
 	}
 
 	sql := blocks[0].Query.SQL()
@@ -46,9 +46,16 @@ func TestBuildCrossTypeTTUBlocksUsesSubjectFirstParentList(t *testing.T) {
 	assertContains(t, sql, "child.subject_type = 'namespace'")
 	assertContains(t, sql, "child.subject_id = parent_obj.object_id")
 	assertNotContains(t, sql, "check_permission_internal")
+
+	// Parity companion: per-candidate check, guarded to userset-typed subjects.
+	parity := blocks[1].Query.SQL()
+	assertContains(t, parity, "position('#' in p_subject_id) > 0")
+	assertContains(t, parity, "check_permission_internal")
 }
 
 func TestBuildCrossTypeTTUBlocksFallsBackForRecursiveParentList(t *testing.T) {
+	// folder.viewer reaches back into document.viewer (mutual cross-type TTU),
+	// so composing list functions would recurse infinitely — must fall back.
 	parentAnalysis := RelationAnalysis{
 		ObjectType: "folder",
 		Relation:   "viewer",
@@ -56,6 +63,11 @@ func TestBuildCrossTypeTTUBlocksFallsBackForRecursiveParentList(t *testing.T) {
 			ListAllowed: true,
 		},
 		ListStrategy: ListStrategyRecursive,
+		ParentRelations: []ParentRelationInfo{{
+			Relation:            "viewer",
+			LinkingRelation:     "parent",
+			AllowedLinkingTypes: []string{"document"},
+		}},
 	}
 
 	plan := ListPlan{
@@ -127,8 +139,8 @@ func TestBuildCrossTypeTTUBlocksVerifiesClosureSourceRelationWhenConstrained(t *
 		SourceRelation:        "reader",
 	}})
 
-	if len(blocks) != 1 {
-		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	if len(blocks) != 2 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))
 	}
 
 	sql := blocks[0].Query.SQL()
@@ -172,8 +184,8 @@ func TestBuildCrossTypeTTUBlocksSkipsClosureSourceCheckWhenUnconstrained(t *test
 		SourceRelation:        "reader",
 	}})
 
-	if len(blocks) != 1 {
-		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
+	if len(blocks) != 2 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))
 	}
 
 	sql := blocks[0].Query.SQL()
@@ -182,6 +194,8 @@ func TestBuildCrossTypeTTUBlocksSkipsClosureSourceCheckWhenUnconstrained(t *test
 }
 
 func TestBuildCrossTypeTTUBlocksFallbackVerifiesClosureSourceRelation(t *testing.T) {
+	// folder.viewer reaches back into document.can_read, so composition is
+	// unsafe and the fallback must carry the closure-source verification.
 	parentAnalysis := RelationAnalysis{
 		ObjectType: "folder",
 		Relation:   "viewer",
@@ -189,6 +203,11 @@ func TestBuildCrossTypeTTUBlocksFallbackVerifiesClosureSourceRelation(t *testing
 			ListAllowed: true,
 		},
 		ListStrategy: ListStrategyRecursive,
+		ParentRelations: []ParentRelationInfo{{
+			Relation:            "can_read",
+			LinkingRelation:     "parent",
+			AllowedLinkingTypes: []string{"document"},
+		}},
 	}
 	sourceAnalysis := RelationAnalysis{
 		ObjectType: "document",
@@ -229,6 +248,162 @@ func TestBuildCrossTypeTTUBlocksFallbackVerifiesClosureSourceRelation(t *testing
 	assertContains(t, sql, "child.subject_type IN ('folder')")
 	assertContains(t, sql, "check_permission_internal(p_subject_type, p_subject_id, 'reader', 'document', child.object_id, ARRAY[]::TEXT[]) = 1")
 	assertNotContains(t, sql, "list_folder_viewer_obj")
+}
+
+func TestBuildCrossTypeTTUBlocksComposesAcyclicRecursiveParent(t *testing.T) {
+	// workspace.manage is Recursive but only reaches upward (organization),
+	// never back into element — composing with its list function is safe.
+	parentAnalysis := RelationAnalysis{
+		ObjectType: "workspace",
+		Relation:   "manage",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyRecursive,
+		ParentRelations: []ParentRelationInfo{{
+			Relation:            "manage",
+			LinkingRelation:     "organization",
+			AllowedLinkingTypes: []string{"organization"},
+		}},
+	}
+
+	plan := ListPlan{
+		ObjectType: "element",
+		Relation:   "view",
+		Analysis: RelationAnalysis{
+			ObjectType: "element",
+			Relation:   "view",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"workspace.manage": &parentAnalysis,
+		},
+	}
+
+	blocks := buildCrossTypeTTUBlocks(plan, []ListParentRelationData{{
+		Relation:              "manage",
+		LinkingRelation:       "workspace",
+		CrossTypeLinkingTypes: "'workspace'",
+		HasCrossTypeLinks:     true,
+	}})
+
+	if len(blocks) != 2 {
+		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))
+	}
+
+	sql := blocks[0].Query.SQL()
+	assertContains(t, sql, "FROM list_workspace_manage_obj(p_subject_type, p_subject_id, NULL, NULL) AS parent_obj")
+	assertNotContains(t, sql, "check_permission_internal")
+
+	parity := blocks[1].Query.SQL()
+	assertContains(t, parity, "position('#' in p_subject_id) > 0")
+	assertContains(t, parity, "check_permission_internal")
+}
+
+func TestBuildRecursiveComplexUsersetBlockComposesWhenSafe(t *testing.T) {
+	// workspace.view is complex (has its own TTU) but never reaches back into
+	// element — membership resolves via semi-join on its list function.
+	targetAnalysis := RelationAnalysis{
+		ObjectType: "workspace",
+		Relation:   "view",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyRecursive,
+		ParentRelations: []ParentRelationInfo{{
+			Relation:            "manage",
+			LinkingRelation:     "organization",
+			AllowedLinkingTypes: []string{"organization"},
+		}},
+	}
+
+	plan := ListPlan{
+		ObjectType:     "element",
+		Relation:       "view",
+		DatabaseSchema: "",
+		Analysis: RelationAnalysis{
+			ObjectType: "element",
+			Relation:   "view",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"workspace.view": &targetAnalysis,
+		},
+	}
+
+	pattern := listUsersetPatternInput{
+		SubjectType:     "workspace",
+		SubjectRelation: "view",
+		SourceRelations: []string{"view"},
+		IsComplex:       true,
+	}
+
+	sql := buildRecursiveComplexUsersetBlock(plan, pattern).Query.SQL()
+	assertContains(t, sql, "IN (SELECT obj.object_id FROM list_workspace_view_obj(p_subject_type, p_subject_id, NULL, NULL) obj)")
+	// Userset-typed subjects keep a guarded per-candidate check arm.
+	assertContains(t, sql, "position('#' in p_subject_id) > 0")
+	assertContains(t, sql, "check_permission_internal")
+}
+
+func TestBuildRecursiveComplexUsersetBlockFallsBackWhenCyclic(t *testing.T) {
+	// group.member holds a userset of element.view — composing would recurse.
+	targetAnalysis := RelationAnalysis{
+		ObjectType: "group",
+		Relation:   "member",
+		Capabilities: GenerationCapabilities{
+			ListAllowed: true,
+		},
+		ListStrategy: ListStrategyRecursive,
+		UsersetPatterns: []UsersetPattern{{
+			SubjectType:     "element",
+			SubjectRelation: "view",
+		}},
+	}
+
+	plan := ListPlan{
+		ObjectType: "element",
+		Relation:   "view",
+		Analysis: RelationAnalysis{
+			ObjectType: "element",
+			Relation:   "view",
+		},
+		AnalysisLookup: map[string]*RelationAnalysis{
+			"group.member": &targetAnalysis,
+		},
+	}
+
+	pattern := listUsersetPatternInput{
+		SubjectType:     "group",
+		SubjectRelation: "member",
+		SourceRelations: []string{"view"},
+		IsComplex:       true,
+	}
+
+	sql := buildRecursiveComplexUsersetBlock(plan, pattern).Query.SQL()
+	assertContains(t, sql, "check_permission_internal")
+	assertNotContains(t, sql, "list_group_member_obj")
+}
+
+func TestListCompositionSafeSelfAndTransitive(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"b.rel": {ObjectType: "b", Relation: "rel", ParentRelations: []ParentRelationInfo{{
+			Relation: "rel", LinkingRelation: "link", AllowedLinkingTypes: []string{"c"},
+		}}},
+		"c.rel": {ObjectType: "c", Relation: "rel", UsersetPatterns: []UsersetPattern{{
+			SubjectType: "a", SubjectRelation: "rel",
+		}}},
+	}
+
+	if listCompositionSafe(lookup, "a", "rel", "a", "rel") {
+		t.Error("self-composition must be unsafe")
+	}
+	if listCompositionSafe(lookup, "a", "rel", "b", "rel") {
+		t.Error("transitive cycle a->b->c->a must be unsafe")
+	}
+	if !listCompositionSafe(lookup, "x", "rel", "b", "rel") {
+		t.Error("unreachable relation must be safe")
+	}
+	if listCompositionSafe(nil, "x", "rel", "b", "rel") {
+		t.Error("nil lookup must be unsafe (no analysis available)")
+	}
 }
 
 func assertContains(t *testing.T, got, want string) {

--- a/lib/sqlgen/list_objects_composed_recursive_ttu_test.go
+++ b/lib/sqlgen/list_objects_composed_recursive_ttu_test.go
@@ -1,0 +1,111 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// composedRecursiveTTUPlan builds a minimal list_objects plan for a pure-TTU
+// relation (folder.viewer: viewer from parent) reaching a recursive same-type
+// anchor. The AnalysisLookup entry for the parent (target) relation controls
+// whether the recursive TTU composition is safe.
+func composedRecursiveTTUPlan(lookup map[string]*RelationAnalysis) ListPlan {
+	return ListPlan{
+		ObjectType:     "folder",
+		Relation:       "can_view",
+		DatabaseSchema: "",
+		AnalysisLookup: lookup,
+	}
+}
+
+func composedRecursiveTTUAnchor() *IndirectAnchorInfo {
+	return &IndirectAnchorInfo{
+		AnchorType:     "folder",
+		AnchorRelation: "viewer",
+		Path: []AnchorPathStep{{
+			Type:            "ttu",
+			LinkingRelation: "parent",
+			TargetRelation:  "viewer",
+			RecursiveTypes:  []string{"folder"},
+		}},
+	}
+}
+
+func composedRecursiveTTUSQL(t *testing.T, lookup map[string]*RelationAnalysis) string {
+	t.Helper()
+	plan := composedRecursiveTTUPlan(lookup)
+	anchor := composedRecursiveTTUAnchor()
+	block, err := buildComposedRecursiveTTUObjectsBlock(plan, anchor, "folder", ExclusionConfig{})
+	if err != nil {
+		t.Fatalf("buildComposedRecursiveTTUObjectsBlock: %v", err)
+	}
+	return block.Query.SQL()
+}
+
+func TestComposedRecursiveTTU_SemiJoinWhenComposable(t *testing.T) {
+	// folder.viewer is a plain acyclic target that does not reach back into
+	// folder.can_view, so composition is safe.
+	lookup := map[string]*RelationAnalysis{
+		"folder.viewer": {
+			ObjectType:   "folder",
+			Relation:     "viewer",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+	}
+
+	sql := composedRecursiveTTUSQL(t, lookup)
+
+	if !strings.Contains(sql, "t.subject_id IN (SELECT obj.object_id FROM list_folder_viewer_obj(p_subject_type, p_subject_id, NULL, NULL) obj)") {
+		t.Errorf("expected set-oriented semi-join against list_folder_viewer_obj, got:\n%s", sql)
+	}
+	// Userset-typed subjects keep a guarded per-candidate check for parity.
+	if !strings.Contains(sql, "position('#' in p_subject_id) > 0") {
+		t.Errorf("expected userset-subject parity guard, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'viewer', 'folder', t.subject_id") {
+		t.Errorf("expected guarded per-candidate check for userset subjects, got:\n%s", sql)
+	}
+}
+
+func TestComposedRecursiveTTU_FallsBackWhenCyclic(t *testing.T) {
+	// folder.viewer reaches back into folder.can_view → composition unsafe
+	// (the classic self-referential recursive parent chain).
+	lookup := map[string]*RelationAnalysis{
+		"folder.viewer": {
+			ObjectType:              "folder",
+			Relation:                "viewer",
+			Capabilities:            GenerationCapabilities{ListAllowed: true},
+			ListStrategy:            ListStrategyRecursive,
+			ComplexClosureRelations: []string{"can_view"},
+		},
+	}
+
+	sql := composedRecursiveTTUSQL(t, lookup)
+
+	if strings.Contains(sql, "list_folder_viewer_obj") {
+		t.Errorf("cyclic composition must fall back to per-candidate check, got semi-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'viewer', 'folder', t.subject_id") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComposedRecursiveTTU_FallsBackWhenNotListGeneratable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"folder.viewer": {
+			ObjectType:   "folder",
+			Relation:     "viewer",
+			Capabilities: GenerationCapabilities{ListAllowed: false}, // no list function
+		},
+	}
+
+	sql := composedRecursiveTTUSQL(t, lookup)
+
+	if strings.Contains(sql, "list_folder_viewer_obj") {
+		t.Errorf("non-generatable target must fall back to per-candidate check, got semi-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/list_objects_composed_userset_test.go
+++ b/lib/sqlgen/list_objects_composed_userset_test.go
@@ -1,0 +1,108 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// composedUsersetPlan builds a minimal list_objects plan whose indirect anchor
+// is a userset composition ([group#member] granted on doc). The AnalysisLookup
+// entry for group.member (the target) controls whether composition is safe.
+func composedUsersetPlan(lookup map[string]*RelationAnalysis) ListPlan {
+	return ListPlan{
+		ObjectType:     "doc",
+		Relation:       "can_view",
+		DatabaseSchema: "",
+		RelationList:   []string{"viewer"},
+		AnalysisLookup: lookup,
+	}
+}
+
+func composedUsersetStep() AnchorPathStep {
+	return AnchorPathStep{
+		Type:            "userset",
+		SubjectType:     "group",
+		SubjectRelation: "member",
+	}
+}
+
+func composedUsersetSQL(t *testing.T, lookup map[string]*RelationAnalysis) string {
+	t.Helper()
+	block, err := buildComposedUsersetObjectsBlock(composedUsersetPlan(lookup), composedUsersetStep(), ExclusionConfig{})
+	if err != nil {
+		t.Fatalf("buildComposedUsersetObjectsBlock: %v", err)
+	}
+	return block.Query.SQL()
+}
+
+func TestComposedUserset_SemiJoinWhenComposable(t *testing.T) {
+	// group.member is a plain acyclic target that does not reach back into
+	// doc.can_view, so composition is safe.
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:   "group",
+			Relation:     "member",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+	}
+
+	sql := composedUsersetSQL(t, lookup)
+
+	if !strings.Contains(sql, "split_part(t.subject_id, '#', 1) IN (SELECT obj.object_id FROM list_group_member_obj(p_subject_type, p_subject_id, NULL, NULL) obj)") {
+		t.Errorf("expected set-oriented semi-join against list_group_member_obj, got:\n%s", sql)
+	}
+	// Userset-typed query subjects keep a guarded per-candidate check for parity;
+	// plain subjects skip the check (the removed fan-out).
+	if !strings.Contains(sql, "position('#' in p_subject_id) > 0") {
+		t.Errorf("expected userset-subject parity guard, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'member', 'group', split_part(t.subject_id, '#', 1)") {
+		t.Errorf("expected guarded per-candidate check for userset subjects, got:\n%s", sql)
+	}
+}
+
+func TestComposedUserset_FallsBackWhenCyclic(t *testing.T) {
+	// group.member reaches back into doc.can_view → composition unsafe.
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:              "group",
+			Relation:                "member",
+			Capabilities:            GenerationCapabilities{ListAllowed: true},
+			ListStrategy:            ListStrategyRecursive,
+			ComplexClosureRelations: []string{"can_view"}, // doc.can_view unreachable by name, but exercise cyclic path via same relation name
+		},
+	}
+	// Make the cycle real: target reaches doc.can_view.
+	lookup["group.member"].ParentRelations = []ParentRelationInfo{{
+		Relation: "can_view", LinkingRelation: "in", AllowedLinkingTypes: []string{"doc"},
+	}}
+
+	sql := composedUsersetSQL(t, lookup)
+
+	if strings.Contains(sql, "list_group_member_obj") {
+		t.Errorf("cyclic composition must fall back to per-candidate check, got semi-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'member', 'group', split_part(t.subject_id, '#', 1)") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComposedUserset_FallsBackWhenNotListGeneratable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:   "group",
+			Relation:     "member",
+			Capabilities: GenerationCapabilities{ListAllowed: false}, // no list function
+		},
+	}
+
+	sql := composedUsersetSQL(t, lookup)
+
+	if strings.Contains(sql, "list_group_member_obj") {
+		t.Errorf("non-generatable target must fall back to per-candidate check, got semi-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/list_plan.go
+++ b/lib/sqlgen/list_plan.go
@@ -19,7 +19,7 @@ type ListPlan struct {
 	ComplexClosure         []string // Complex closure relations (excluding intersection)
 
 	// Feature configuration
-	AllowWildcard bool            // Whether wildcards are allowed (list_objects)
+	AllowWildcard bool            // Whether the relation can surface '*' (direct or TTU-reachable)
 	Exclusions    ExclusionConfig // Exclusion rules configuration
 
 	// Feature flags (derived from analysis)
@@ -135,7 +135,14 @@ func buildBasePlan(a RelationAnalysis, inline InlineSQLData, databaseSchema, fun
 		AllowedSubjectTypes:    buildAllowedSubjectTypesList(a),
 		ComplexClosure:         filterComplexClosureRelations(a),
 
-		AllowWildcard: a.Features.HasWildcard,
+		// A relation surfaces '*' either directly (Features.HasWildcard) or
+		// through a TTU parent / closure whose target relation is wildcard-
+		// granted — the analyzer does not propagate HasWildcard across those
+		// edges, so walk the reference graph. Without this, list_*_sub for a
+		// relation like folder.viewer ("... or viewer from org", org.viewer=
+		// [user:*]) drops the wildcard granted on the parent (ExcludeWildcard
+		// filters '*' from the parent-closure scan and the tail never expands).
+		AllowWildcard: a.Features.HasWildcard || reachesWildcard(lookup, a.ObjectType, a.Relation),
 
 		HasUserset:      a.Features.HasUserset,
 		HasExclusion:    a.Features.HasExclusion,

--- a/lib/sqlgen/list_plan.go
+++ b/lib/sqlgen/list_plan.go
@@ -90,6 +90,15 @@ func BuildListObjectsPlanWithLookup(a RelationAnalysis, inline InlineSQLData, da
 			SubjectType,
 			SubjectID,
 		)
+		// list_objects context: object_id is the per-row candidate column and
+		// the subject exprs are query-constant params, so complex exclusions
+		// may use a set-oriented anti-join against the excluded relation's
+		// list_objects function instead of a per-candidate check.
+		plan.Exclusions.Compose = &exclusionCompose{
+			Lookup:   lookup,
+			FromType: a.ObjectType,
+			FromRel:  a.Relation,
+		}
 	}
 	return plan
 }

--- a/lib/sqlgen/list_subjects_blocks.go
+++ b/lib/sqlgen/list_subjects_blocks.go
@@ -101,13 +101,12 @@ func buildListSubjectsUsersetFilterDirectBlock(plan ListPlan) TypedQueryBlock {
 				Eq{Left: SubstringUsersetRelation{Source: Col{Table: "t", Column: "subject_id"}}, Right: Param("v_filter_relation")},
 				ExistsExpr(closureExistsStmt),
 			),
-			CheckPermissionCall{
-				Schema:       plan.DatabaseSchema,
-				FunctionName: "check_permission",
-				Subject:      SubjectRef{Type: Param("v_filter_type"), ID: Col{Table: "t", Column: "subject_id"}},
-				Relation:     plan.Relation,
-				Object:       LiteralObject(plan.ObjectType, ObjectID),
-				ExpectAllow:  true,
+			CheckPermission{
+				Schema:      plan.DatabaseSchema,
+				Subject:     SubjectRef{Type: Param("v_filter_type"), ID: Col{Table: "t", Column: "subject_id"}},
+				Relation:    plan.Relation,
+				Object:      LiteralObject(plan.ObjectType, ObjectID),
+				ExpectAllow: true,
 			},
 		),
 	}
@@ -268,13 +267,12 @@ func buildListSubjectsIntersectionClosureBlocks(plan ListPlan, subjectTypeExpr, 
 
 		if validate && checkSubjectTypeExpr != "" {
 			stmt.Distinct = true
-			stmt.Where = CheckPermissionCall{
-				Schema:       plan.DatabaseSchema,
-				FunctionName: "check_permission",
-				Subject:      SubjectRef{Type: Raw(checkSubjectTypeExpr), ID: Col{Table: "ics", Column: "subject_id"}},
-				Relation:     plan.Relation,
-				Object:       LiteralObject(plan.ObjectType, ObjectID),
-				ExpectAllow:  true,
+			stmt.Where = CheckPermission{
+				Schema:      plan.DatabaseSchema,
+				Subject:     SubjectRef{Type: Raw(checkSubjectTypeExpr), ID: Col{Table: "ics", Column: "subject_id"}},
+				Relation:    plan.Relation,
+				Object:      LiteralObject(plan.ObjectType, ObjectID),
+				ExpectAllow: true,
 			}
 		}
 

--- a/lib/sqlgen/list_subjects_blocks_recursive.go
+++ b/lib/sqlgen/list_subjects_blocks_recursive.go
@@ -384,6 +384,9 @@ func nestedParentForcesSubjectPool(pr ParentRelationInfo, targetObjectType, curr
 // dedicated wildcard block is needed today.
 func buildListSubjectsRecursiveTTUBlock(plan ListPlan, parent ListParentRelationData) []TypedQueryBlock {
 	if classifyParentRelation(plan, parent) == parentStrategySubjectPool {
+		if blocks := buildSubjectFirstTTUSubjectBlocks(plan, parent); blocks != nil {
+			return blocks
+		}
 		return []TypedQueryBlock{buildListSubjectsRecursiveTTUBlockSubjectPool(plan, parent)}
 	}
 
@@ -576,6 +579,82 @@ func buildListSubjectsRecursiveTTUBlockParentClosureUsersetPattern(plan ListPlan
 
 	return TypedQueryBlock{
 		Comments: []string{fmt.Sprintf("-- TTU userset: subjects via %s -> %s -> %s#%s (parent closure)", parent.LinkingRelation, parent.Relation, pattern.SubjectType, pattern.SubjectRelation)},
+		Query:    stmt,
+	}
+}
+
+// buildSubjectFirstTTUSubjectBlocks returns set-oriented TTU blocks that
+// compose with the parent relation's list_subjects function instead of
+// scanning every candidate subject (subject_pool) and calling
+// check_permission_internal per (subject, link) pair. It is the list_subjects
+// mirror of the list_objects subject-first TTU path.
+//
+// The subject_pool block computes {s ∈ all-subjects-of-type :
+// check(s, parentRel, parentObj) = 1}; list_{ptype}_{parentRel}_sub(parentObj,
+// type) is exactly that set, so the transform is a faithful equivalence — for
+// each link, enumerate the parent object's subjects directly.
+//
+// Returns nil (keep the subject_pool path) unless every case is cleanly
+// handled: direct parent pattern only, no wildcards on the current or target
+// relation (subject-side '*' needs the subject_pool wildcard handling), and
+// every allowed parent type has a composable, cycle-safe list_subjects
+// function.
+func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationData) []TypedQueryBlock {
+	if parent.IsClosurePattern || plan.Analysis.Features.HasWildcard || plan.AnalysisLookup == nil {
+		return nil
+	}
+	types := parent.AllowedLinkingTypesSlice
+	if len(types) == 0 {
+		return nil
+	}
+	for _, ptype := range types {
+		target := plan.AnalysisLookup[ptype+"."+parent.Relation]
+		if target == nil || target.Features.HasWildcard {
+			return nil
+		}
+		// ListAllowed gates both list_objects and list_subjects generation and
+		// the reference graph (TTU parent edges) is shared, so the list_objects
+		// composability check covers the list_subjects call too.
+		if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, ptype, parent.Relation) {
+			return nil
+		}
+	}
+
+	blocks := make([]TypedQueryBlock, 0, len(types))
+	for _, ptype := range types {
+		blocks = append(blocks, buildSubjectFirstTTUSubjectBlock(plan, parent, ptype))
+	}
+	return blocks
+}
+
+// buildSubjectFirstTTUSubjectBlock builds one subject-first TTU block for a
+// single parent type: for each linking tuple to a parent object of that type,
+// enumerate the subjects holding parent.Relation on it via the parent's
+// list_subjects function.
+func buildSubjectFirstTTUSubjectBlock(plan ListPlan, parent ListParentRelationData, parentType string) TypedQueryBlock {
+	stmt := SelectStmt{
+		Distinct:    true,
+		ColumnExprs: []Expr{Col{Table: "sub", Column: "subject_id"}},
+		FromExpr:    TableAs("", "melange_tuples", "link"),
+		Joins: []JoinClause{{
+			Type: "CROSS",
+			TableExpr: LateralFunction{
+				Schema: plan.DatabaseSchema,
+				Name:   listSubjectsFunctionName(parentType, parent.Relation),
+				Args:   []Expr{Col{Table: "link", Column: "subject_id"}, SubjectType},
+				Alias:  "sub",
+			},
+		}},
+		Where: And(
+			Eq{Left: Col{Table: "link", Column: "object_type"}, Right: Lit(plan.ObjectType)},
+			Eq{Left: Col{Table: "link", Column: "object_id"}, Right: ObjectID},
+			Eq{Left: Col{Table: "link", Column: "relation"}, Right: Lit(parent.LinkingRelation)},
+			Eq{Left: Col{Table: "link", Column: "subject_type"}, Right: Lit(parentType)},
+		),
+	}
+
+	return TypedQueryBlock{
+		Comments: []string{fmt.Sprintf("-- TTU subject-first: subjects via %s -> %s.%s (compose list_subjects)", parent.LinkingRelation, parentType, parent.Relation)},
 		Query:    stmt,
 	}
 }

--- a/lib/sqlgen/list_subjects_blocks_recursive.go
+++ b/lib/sqlgen/list_subjects_blocks_recursive.go
@@ -223,8 +223,7 @@ func composableSubjectFirstUserset(plan ListPlan, pattern listUsersetPatternInpu
 	if plan.Analysis.Features.HasWildcard {
 		return false
 	}
-	target := plan.AnalysisLookup[pattern.SubjectType+"."+pattern.SubjectRelation]
-	if target != nil && target.Features.HasWildcard {
+	if reachesWildcard(plan.AnalysisLookup, pattern.SubjectType, pattern.SubjectRelation) {
 		return false
 	}
 	return composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, pattern.SubjectType, pattern.SubjectRelation)
@@ -694,7 +693,7 @@ func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationD
 	}
 	for _, ptype := range types {
 		target := plan.AnalysisLookup[ptype+"."+parent.Relation]
-		if target == nil || target.Features.HasWildcard {
+		if target == nil || reachesWildcard(plan.AnalysisLookup, ptype, parent.Relation) {
 			return nil
 		}
 		// ListAllowed gates both list_objects and list_subjects generation and
@@ -726,7 +725,7 @@ func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationD
 // not apply plan.Exclusions, so neither does this replacement.
 func buildSubjectFirstTTUClosureSubjectBlocks(plan ListPlan, parent ListParentRelationData) []TypedQueryBlock {
 	target := plan.AnalysisLookup[plan.ObjectType+"."+parent.SourceRelation]
-	if target == nil || target.Features.HasWildcard {
+	if target == nil || reachesWildcard(plan.AnalysisLookup, plan.ObjectType, parent.SourceRelation) {
 		return nil
 	}
 	if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, plan.ObjectType, parent.SourceRelation) {

--- a/lib/sqlgen/list_subjects_blocks_recursive.go
+++ b/lib/sqlgen/list_subjects_blocks_recursive.go
@@ -96,16 +96,7 @@ func buildListSubjectsRecursiveComplexClosureBlocks(plan ListPlan) []TypedQueryB
 				Eq{Left: Col{Table: "t", Column: "object_id"}, Right: ObjectID},
 				Eq{Left: Col{Table: "t", Column: "subject_type"}, Right: SubjectType},
 				NoUserset{Source: Col{Table: "t", Column: "subject_id"}},
-				CheckPermission{
-					Schema: plan.DatabaseSchema,
-					Subject: SubjectRef{
-						Type: SubjectType,
-						ID:   Col{Table: "t", Column: "subject_id"},
-					},
-					Relation:    rel,
-					Object:      LiteralObject(plan.ObjectType, ObjectID),
-					ExpectAllow: true,
-				},
+				complexClosureSubjectMembership(plan, rel),
 			).
 			SelectCol("subject_id").
 			Distinct()

--- a/lib/sqlgen/list_subjects_blocks_recursive.go
+++ b/lib/sqlgen/list_subjects_blocks_recursive.go
@@ -223,10 +223,7 @@ func composableSubjectFirstUserset(plan ListPlan, pattern listUsersetPatternInpu
 	if plan.Analysis.Features.HasWildcard {
 		return false
 	}
-	if reachesWildcard(plan.AnalysisLookup, pattern.SubjectType, pattern.SubjectRelation) {
-		return false
-	}
-	return composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, pattern.SubjectType, pattern.SubjectRelation)
+	return composableListSubjectsTarget(plan, pattern.SubjectType, pattern.SubjectRelation)
 }
 
 // buildListSubjectsRecursiveComplexUsersetBlockComposed is the set-oriented form
@@ -692,14 +689,10 @@ func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationD
 		return nil
 	}
 	for _, ptype := range types {
-		target := plan.AnalysisLookup[ptype+"."+parent.Relation]
-		if target == nil || reachesWildcard(plan.AnalysisLookup, ptype, parent.Relation) {
-			return nil
-		}
 		// ListAllowed gates both list_objects and list_subjects generation and
 		// the reference graph (TTU parent edges) is shared, so the list_objects
 		// composability check covers the list_subjects call too.
-		if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, ptype, parent.Relation) {
+		if !composableListSubjectsTarget(plan, ptype, parent.Relation) {
 			return nil
 		}
 	}
@@ -724,11 +717,7 @@ func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationD
 // buildSubjectFirstTTUSubjectBlocks). The closure-pattern subject_pool block does
 // not apply plan.Exclusions, so neither does this replacement.
 func buildSubjectFirstTTUClosureSubjectBlocks(plan ListPlan, parent ListParentRelationData) []TypedQueryBlock {
-	target := plan.AnalysisLookup[plan.ObjectType+"."+parent.SourceRelation]
-	if target == nil || reachesWildcard(plan.AnalysisLookup, plan.ObjectType, parent.SourceRelation) {
-		return nil
-	}
-	if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, plan.ObjectType, parent.SourceRelation) {
+	if !composableListSubjectsTarget(plan, plan.ObjectType, parent.SourceRelation) {
 		return nil
 	}
 

--- a/lib/sqlgen/list_subjects_blocks_recursive.go
+++ b/lib/sqlgen/list_subjects_blocks_recursive.go
@@ -682,8 +682,11 @@ func buildListSubjectsRecursiveTTUBlockParentClosureUsersetPattern(plan ListPlan
 // every allowed parent type has a composable, cycle-safe list_subjects
 // function.
 func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationData) []TypedQueryBlock {
-	if parent.IsClosurePattern || plan.Analysis.Features.HasWildcard || plan.AnalysisLookup == nil {
+	if plan.Analysis.Features.HasWildcard || plan.AnalysisLookup == nil {
 		return nil
+	}
+	if parent.IsClosurePattern {
+		return buildSubjectFirstTTUClosureSubjectBlocks(plan, parent)
 	}
 	types := parent.AllowedLinkingTypesSlice
 	if len(types) == 0 {
@@ -707,6 +710,44 @@ func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationD
 		blocks = append(blocks, buildSubjectFirstTTUSubjectBlock(plan, parent, ptype))
 	}
 	return blocks
+}
+
+// buildSubjectFirstTTUClosureSubjectBlocks returns the set-oriented form of the
+// closure-pattern subject_pool block. For a closure pattern the per-row check is
+// check(subject, parent.SourceRelation, plan.ObjectType, p_object_id) — the SAME
+// target object for every (subject, link) pair — so {s : check(s, sourceRel,
+// obj) = 1} is exactly list_{objType}_{sourceRel}_sub(p_object_id,
+// p_subject_type). No linking tuples are needed: the check never varies per link.
+//
+// Returns nil (keep the subject_pool path) unless list_{objType}_{sourceRel}_sub
+// is composable and cycle-safe and no wildcards are in play (subject-side '*'
+// under-reports concrete subjects through an IN-set — same gate as
+// buildSubjectFirstTTUSubjectBlocks). The closure-pattern subject_pool block does
+// not apply plan.Exclusions, so neither does this replacement.
+func buildSubjectFirstTTUClosureSubjectBlocks(plan ListPlan, parent ListParentRelationData) []TypedQueryBlock {
+	target := plan.AnalysisLookup[plan.ObjectType+"."+parent.SourceRelation]
+	if target == nil || target.Features.HasWildcard {
+		return nil
+	}
+	if !composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, plan.ObjectType, parent.SourceRelation) {
+		return nil
+	}
+
+	stmt := SelectStmt{
+		Distinct:    true,
+		ColumnExprs: []Expr{Col{Table: "sub", Column: "subject_id"}},
+		FromExpr: FunctionCallExpr{
+			Schema: plan.DatabaseSchema,
+			Name:   listSubjectsFunctionName(plan.ObjectType, parent.SourceRelation),
+			Args:   []Expr{ObjectID, SubjectType},
+			Alias:  "sub",
+		},
+	}
+
+	return []TypedQueryBlock{{
+		Comments: []string{fmt.Sprintf("-- TTU subject-first: subjects via %s -> %s (closure pattern from %s - compose list_subjects)", parent.LinkingRelation, parent.Relation, parent.SourceRelation)},
+		Query:    stmt,
+	}}
 }
 
 // buildSubjectFirstTTUSubjectBlock builds one subject-first TTU block for a

--- a/lib/sqlgen/list_subjects_blocks_recursive.go
+++ b/lib/sqlgen/list_subjects_blocks_recursive.go
@@ -133,7 +133,18 @@ func buildListSubjectsRecursiveUsersetPatternBlocks(plan ListPlan) ([]TypedQuery
 }
 
 // buildListSubjectsRecursiveComplexUsersetBlock builds a complex userset block for recursive list_subjects.
+//
+// For a userset pattern [X#rel] the block finds grant tuples (X:id#rel granted on
+// the target) then enumerates the members holding rel on X:id. Those members are
+// exactly list_{X}_{rel}_sub(X:id, p_subject_type). When composition is safe
+// (composableSubjectFirstUserset) it replaces the member tuple JOIN + per-member
+// check_permission_internal with a CROSS JOIN LATERAL on that list function.
+// Otherwise it keeps the per-candidate check unchanged.
 func buildListSubjectsRecursiveComplexUsersetBlock(plan ListPlan, pattern listUsersetPatternInput) TypedQueryBlock {
+	if composableSubjectFirstUserset(plan, pattern) {
+		return buildListSubjectsRecursiveComplexUsersetBlockComposed(plan, pattern)
+	}
+
 	const grantAlias, memberAlias = "g", "m"
 
 	memberExclusions := buildExclusionInput(plan.Analysis, plan.DatabaseSchema, ObjectID, Col{Table: memberAlias, Column: "subject_type"}, Col{Table: memberAlias, Column: "subject_id"})
@@ -195,6 +206,86 @@ func buildListSubjectsRecursiveComplexUsersetBlock(plan ListPlan, pattern listUs
 
 	return TypedQueryBlock{
 		Comments: []string{fmt.Sprintf("-- Userset: %s#%s (complex)", pattern.SubjectType, pattern.SubjectRelation)},
+		Query:    stmt,
+	}
+}
+
+// composableSubjectFirstUserset reports whether the complex-userset member JOIN
+// can be replaced by a CROSS JOIN LATERAL on list_{SubjectType}_{SubjectRelation}_sub.
+//
+// The list_subjects function is complete and exactly equal to the member set,
+// so the transform is a faithful equivalence — but only when no wildcards are in
+// play (list_..._sub returns '*' for wildcard grants, not concrete subjects, so
+// an IN/LATERAL membership would drop concrete subjects that hold the relation
+// only via a wildcard) and the target relation is list-generatable and
+// cycle-safe. Mirrors buildSubjectFirstTTUSubjectBlocks / complexClosureSubjectMembership.
+func composableSubjectFirstUserset(plan ListPlan, pattern listUsersetPatternInput) bool {
+	if plan.Analysis.Features.HasWildcard {
+		return false
+	}
+	target := plan.AnalysisLookup[pattern.SubjectType+"."+pattern.SubjectRelation]
+	if target != nil && target.Features.HasWildcard {
+		return false
+	}
+	return composableListTargetLookup(plan.AnalysisLookup, plan.ObjectType, plan.Relation, pattern.SubjectType, pattern.SubjectRelation)
+}
+
+// buildListSubjectsRecursiveComplexUsersetBlockComposed is the set-oriented form
+// of buildListSubjectsRecursiveComplexUsersetBlock: for each grant tuple g of a
+// userset X:id#rel, it enumerates the subjects holding rel on X:id via
+// list_{X}_{rel}_sub(X:id, p_subject_type) instead of joining melange_tuples
+// members and calling check_permission_internal per member. All non-check
+// predicates (member exclusions, wildcard/userset filters, closure source check,
+// allowed-subject-type guard) are preserved against the lateral's subject_id.
+func buildListSubjectsRecursiveComplexUsersetBlockComposed(plan ListPlan, pattern listUsersetPatternInput) TypedQueryBlock {
+	const grantAlias, memberAlias = "g", "m"
+
+	memberExclusions := buildExclusionInput(plan.Analysis, plan.DatabaseSchema, ObjectID, SubjectType, Col{Table: memberAlias, Column: "subject_id"})
+
+	whereConditions := []Expr{
+		Eq{Left: Col{Table: grantAlias, Column: "object_type"}, Right: Lit(plan.ObjectType)},
+		Eq{Left: Col{Table: grantAlias, Column: "object_id"}, Right: ObjectID},
+		In{Expr: Col{Table: grantAlias, Column: "relation"}, Values: pattern.SourceRelations},
+		Eq{Left: Col{Table: grantAlias, Column: "subject_type"}, Right: Lit(pattern.SubjectType)},
+		HasUserset{Source: Col{Table: grantAlias, Column: "subject_id"}},
+		Eq{Left: UsersetRelation{Source: Col{Table: grantAlias, Column: "subject_id"}}, Right: Lit(pattern.SubjectRelation)},
+		In{Expr: SubjectType, Values: plan.AllowedSubjectTypes},
+		NoUserset{Source: Col{Table: memberAlias, Column: "subject_id"}},
+	}
+
+	if plan.ExcludeWildcard() {
+		whereConditions = append(whereConditions, Ne{Left: Col{Table: memberAlias, Column: "subject_id"}, Right: Lit("*")})
+	}
+	whereConditions = append(whereConditions, memberExclusions.BuildPredicates()...)
+
+	if pattern.IsClosurePattern {
+		whereConditions = append(whereConditions, CheckPermission{
+			Schema:      plan.DatabaseSchema,
+			Subject:     SubjectRef{Type: SubjectType, ID: Col{Table: memberAlias, Column: "subject_id"}},
+			Relation:    pattern.SourceRelation,
+			Object:      LiteralObject(plan.ObjectType, ObjectID),
+			ExpectAllow: true,
+		})
+	}
+
+	stmt := SelectStmt{
+		Distinct:    true,
+		ColumnExprs: []Expr{Col{Table: memberAlias, Column: "subject_id"}},
+		FromExpr:    TableAs("", "melange_tuples", grantAlias),
+		Joins: []JoinClause{{
+			Type: "CROSS",
+			TableExpr: LateralFunction{
+				Schema: plan.DatabaseSchema,
+				Name:   listSubjectsFunctionName(pattern.SubjectType, pattern.SubjectRelation),
+				Args:   []Expr{UsersetObjectID{Source: Col{Table: grantAlias, Column: "subject_id"}}, SubjectType},
+				Alias:  memberAlias,
+			},
+		}},
+		Where: And(whereConditions...),
+	}
+
+	return TypedQueryBlock{
+		Comments: []string{fmt.Sprintf("-- Userset: %s#%s (complex, compose list_subjects)", pattern.SubjectType, pattern.SubjectRelation)},
 		Query:    stmt,
 	}
 }

--- a/lib/sqlgen/list_subjects_closure_compose_test.go
+++ b/lib/sqlgen/list_subjects_closure_compose_test.go
@@ -1,0 +1,132 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// closureTTUPlan builds a minimal list_subjects ListPlan whose relation
+// (doc.can_read) has an implied TTU that arrives as a closure pattern from the
+// source relation reader ("reader: repo_admin from owner"). p_object_id is the
+// target object; the closure-pattern subject_pool block checks reader on the
+// SAME target object per subject, so it reduces to list_doc_reader_sub.
+func closureTTUPlan(lookup map[string]*RelationAnalysis) (ListPlan, ListParentRelationData) {
+	plan := ListPlan{
+		DatabaseSchema: "",
+		ObjectType:     "doc",
+		Relation:       "can_read",
+		Analysis:       RelationAnalysis{ObjectType: "doc", Relation: "can_read"},
+		AnalysisLookup: lookup,
+	}
+	parent := ListParentRelationData{
+		Relation:                 "repo_admin",
+		LinkingRelation:          "owner",
+		AllowedLinkingTypesSlice: []string{"repo"},
+		IsClosurePattern:         true,
+		SourceRelation:           "reader",
+	}
+	return plan, parent
+}
+
+func closureBlocksSQL(plan ListPlan, parent ListParentRelationData) string {
+	var b strings.Builder
+	for _, blk := range buildListSubjectsRecursiveTTUBlock(plan, parent) {
+		b.WriteString(blk.Query.SQL())
+		b.WriteString("\n")
+	}
+	return b.String()
+}
+
+func TestClosureTTUSubjects_ComposeWhenComposable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.can_read": {ObjectType: "doc", Relation: "can_read"},
+		// reader forces subject_pool (has exclusion) and is a closure pattern.
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			Features:     RelationFeatures{HasExclusion: true},
+		},
+		// repo.repo_admin is what classifyParentRelation inspects; give it
+		// exclusion so the parent is routed to subject_pool (closure branch).
+		"repo.repo_admin": {
+			ObjectType: "repo",
+			Relation:   "repo_admin",
+			Features:   RelationFeatures{HasExclusion: true},
+		},
+	}
+	plan, parent := closureTTUPlan(lookup)
+
+	sql := closureBlocksSQL(plan, parent)
+
+	if !strings.Contains(sql, "list_doc_reader_sub(p_object_id, p_subject_type)") {
+		t.Errorf("expected composed SELECT from list_doc_reader_sub, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("composable closure TTU must not emit per-candidate check, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "subject_pool") {
+		t.Errorf("composable closure TTU must not scan subject_pool, got:\n%s", sql)
+	}
+}
+
+func TestClosureTTUSubjects_FallbackWhenNotComposable(t *testing.T) {
+	// reader is not list-generatable → keep subject_pool + per-candidate check.
+	lookup := map[string]*RelationAnalysis{
+		"doc.can_read": {ObjectType: "doc", Relation: "can_read"},
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: false},
+		},
+		"repo.repo_admin": {
+			ObjectType: "repo",
+			Relation:   "repo_admin",
+			Features:   RelationFeatures{HasExclusion: true},
+		},
+	}
+	plan, parent := closureTTUPlan(lookup)
+
+	sql := closureBlocksSQL(plan, parent)
+
+	if strings.Contains(sql, "list_doc_reader_sub") {
+		t.Errorf("non-generatable target must fall back to subject_pool, got compose:\n%s", sql)
+	}
+	if !strings.Contains(sql, "subject_pool") {
+		t.Errorf("expected subject_pool fallback, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, sp.subject_id, 'reader', 'doc', p_object_id)") {
+		t.Errorf("expected per-candidate closure check on target object, got:\n%s", sql)
+	}
+}
+
+func TestClosureTTUSubjects_FallbackWhenWildcard(t *testing.T) {
+	// Target reader HasWildcard → an IN-set drops concrete subjects granted only
+	// via '*', so composition is gated out. Keep subject_pool.
+	lookup := map[string]*RelationAnalysis{
+		"doc.can_read": {ObjectType: "doc", Relation: "can_read"},
+		"doc.reader": {
+			ObjectType:   "doc",
+			Relation:     "reader",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			Features:     RelationFeatures{HasExclusion: true, HasWildcard: true},
+		},
+		"repo.repo_admin": {
+			ObjectType: "repo",
+			Relation:   "repo_admin",
+			Features:   RelationFeatures{HasExclusion: true},
+		},
+	}
+	plan, parent := closureTTUPlan(lookup)
+
+	sql := closureBlocksSQL(plan, parent)
+
+	if strings.Contains(sql, "list_doc_reader_sub") {
+		t.Errorf("wildcard target must fall back to subject_pool, got compose:\n%s", sql)
+	}
+	if !strings.Contains(sql, "subject_pool") {
+		t.Errorf("expected subject_pool fallback for wildcard target, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/list_subjects_complex_userset_compose_test.go
+++ b/lib/sqlgen/list_subjects_complex_userset_compose_test.go
@@ -1,0 +1,142 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// The complex-userset list_subjects block should compose with the target
+// relation's list_subjects function (CROSS JOIN LATERAL list_..._sub) instead
+// of joining melange_tuples members and calling check_permission_internal per
+// member, when the target is list-generatable, cycle-safe, and wildcard-free.
+
+func subjectFirstUsersetPlan(lookup map[string]*RelationAnalysis) (ListPlan, listUsersetPatternInput) {
+	plan := ListPlan{
+		ObjectType:     "org",
+		Relation:       "view",
+		DatabaseSchema: "",
+		Analysis: RelationAnalysis{
+			ObjectType:          "org",
+			Relation:            "view",
+			AllowedSubjectTypes: []string{"user"},
+		},
+		AnalysisLookup: lookup,
+	}
+	pattern := listUsersetPatternInput{
+		SubjectType:     "group",
+		SubjectRelation: "member",
+		SourceRelations: []string{"view"},
+		IsComplex:       true,
+	}
+	return plan, pattern
+}
+
+func TestComplexUsersetSubjects_ComposesWhenSafe(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:   "group",
+			Relation:     "member",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+	}
+	plan, pattern := subjectFirstUsersetPlan(lookup)
+
+	sql := buildListSubjectsRecursiveComplexUsersetBlock(plan, pattern).Query.SQL()
+
+	if !strings.Contains(sql, "CROSS JOIN LATERAL list_group_member_sub(split_part(g.subject_id, '#', 1), p_subject_type)") {
+		t.Errorf("expected lateral compose against list_group_member_sub, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("composed block must not emit per-member check_permission_internal, got:\n%s", sql)
+	}
+}
+
+func TestComplexUsersetSubjects_FallsBackWhenCyclic(t *testing.T) {
+	// group.member reaches back into org.view -> composition unsafe.
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:   "group",
+			Relation:     "member",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive,
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "view", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+	}
+	plan, pattern := subjectFirstUsersetPlan(lookup)
+
+	sql := buildListSubjectsRecursiveComplexUsersetBlock(plan, pattern).Query.SQL()
+
+	if strings.Contains(sql, "list_group_member_sub") {
+		t.Errorf("cyclic composition must fall back to per-member check, got lateral:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-member check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexUsersetSubjects_FallsBackWhenNotListGeneratable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:   "group",
+			Relation:     "member",
+			Capabilities: GenerationCapabilities{ListAllowed: false},
+		},
+	}
+	plan, pattern := subjectFirstUsersetPlan(lookup)
+
+	sql := buildListSubjectsRecursiveComplexUsersetBlock(plan, pattern).Query.SQL()
+
+	if strings.Contains(sql, "list_group_member_sub") {
+		t.Errorf("non-generatable target must fall back to per-member check, got lateral:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-member check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexUsersetSubjects_FallsBackWhenTargetHasWildcard(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:   "group",
+			Relation:     "member",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+			Features:     RelationFeatures{HasWildcard: true},
+		},
+	}
+	plan, pattern := subjectFirstUsersetPlan(lookup)
+
+	sql := buildListSubjectsRecursiveComplexUsersetBlock(plan, pattern).Query.SQL()
+
+	if strings.Contains(sql, "list_group_member_sub") {
+		t.Errorf("wildcard target must fall back to per-member check, got lateral:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-member check fallback, got:\n%s", sql)
+	}
+}
+
+func TestComplexUsersetSubjects_FallsBackWhenPlanHasWildcard(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"group.member": {
+			ObjectType:   "group",
+			Relation:     "member",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyDirect,
+		},
+	}
+	plan, pattern := subjectFirstUsersetPlan(lookup)
+	plan.Analysis.Features.HasWildcard = true
+
+	sql := buildListSubjectsRecursiveComplexUsersetBlock(plan, pattern).Query.SQL()
+
+	if strings.Contains(sql, "list_group_member_sub") {
+		t.Errorf("wildcard plan must fall back to per-member check, got lateral:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-member check fallback, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/list_subjects_subjectfirst_test.go
+++ b/lib/sqlgen/list_subjects_subjectfirst_test.go
@@ -102,3 +102,46 @@ func TestSubjectFirstTTU_FallsBackWhenNotListGeneratable(t *testing.T) {
 		t.Errorf("non-generatable target must fall back to subject_pool")
 	}
 }
+
+// TestSubjectFirstTTU_FallsBackWhenTargetReachesWildcardTransitively pins the
+// fix: org.admin has HasWildcard=false itself but reaches org2.viewer=[user:*]
+// via a TTU parent, so list_org_admin_sub surfaces '*'. Composition against it
+// with an IN/LATERAL set would drop concrete subjects granted only via the
+// wildcard, so we must fall back to subject_pool.
+func TestSubjectFirstTTU_FallsBackWhenTargetReachesWildcardTransitively(t *testing.T) {
+	lookup := composableOrgAdmin()
+	lookup["org.admin"].ParentRelations = []ParentRelationInfo{{
+		Relation: "viewer", LinkingRelation: "parent", AllowedLinkingTypes: []string{"org2"},
+	}}
+	lookup["org2.viewer"] = &RelationAnalysis{
+		ObjectType: "org2", Relation: "viewer",
+		Features: RelationFeatures{HasWildcard: true},
+	}
+	plan, parent := subjectFirstPlan(lookup)
+
+	if blocks := buildSubjectFirstTTUSubjectBlocks(plan, parent); blocks != nil {
+		t.Errorf("transitively-wildcard-reaching target must fall back to subject_pool")
+	}
+}
+
+// TestReachesWildcard_Transitive checks reachesWildcard walks TTU/closure edges.
+func TestReachesWildcard_Transitive(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"folder.viewer": {
+			ObjectType: "folder", Relation: "viewer",
+			Features:        RelationFeatures{}, // HasWildcard false
+			ParentRelations: []ParentRelationInfo{{Relation: "viewer", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"}}},
+		},
+		"org.viewer": {ObjectType: "org", Relation: "viewer", Features: RelationFeatures{HasWildcard: true}},
+	}
+	if !reachesWildcard(lookup, "folder", "viewer") {
+		t.Error("folder.viewer must reach wildcard via org.viewer TTU parent")
+	}
+	if reachesWildcard(lookup, "org", "viewer") == false {
+		t.Error("org.viewer HasWildcard directly")
+	}
+	delete(lookup, "org.viewer")
+	if reachesWildcard(lookup, "folder", "viewer") {
+		t.Error("no wildcard reachable once org.viewer removed")
+	}
+}

--- a/lib/sqlgen/list_subjects_subjectfirst_test.go
+++ b/lib/sqlgen/list_subjects_subjectfirst_test.go
@@ -1,0 +1,104 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// subjectFirstPlan builds a list_subjects ListPlan for object type "folder",
+// relation "viewer", whose TTU parent (parentRel on parentType) forces the
+// subject_pool strategy, with the given lookup for composition gating.
+func subjectFirstPlan(lookup map[string]*RelationAnalysis) (ListPlan, ListParentRelationData) {
+	plan := ListPlan{
+		ObjectType: "folder",
+		Relation:   "viewer",
+		Analysis: RelationAnalysis{
+			ObjectType: "folder",
+			Relation:   "viewer",
+		},
+		AnalysisLookup: lookup,
+	}
+	parent := ListParentRelationData{
+		Relation:                 "admin",
+		LinkingRelation:          "org",
+		AllowedLinkingTypesSlice: []string{"org"},
+	}
+	return plan, parent
+}
+
+func composableOrgAdmin() map[string]*RelationAnalysis {
+	return map[string]*RelationAnalysis{
+		// org.admin is complex (exclusion → forces subject_pool) but does not
+		// reference folder.viewer, so composition is safe.
+		"org.admin": {
+			ObjectType:              "org",
+			Relation:                "admin",
+			Capabilities:            GenerationCapabilities{ListAllowed: true},
+			ListStrategy:            ListStrategyDirect,
+			Features:                RelationFeatures{HasExclusion: true},
+			SimpleExcludedRelations: []string{"blocked"},
+		},
+		"org.blocked": {ObjectType: "org", Relation: "blocked"},
+	}
+}
+
+func TestSubjectFirstTTU_ComposesWhenSafe(t *testing.T) {
+	plan, parent := subjectFirstPlan(composableOrgAdmin())
+
+	blocks := buildSubjectFirstTTUSubjectBlocks(plan, parent)
+	if len(blocks) != 1 {
+		t.Fatalf("expected 1 subject-first block, got %d", len(blocks))
+	}
+	sql := blocks[0].Query.SQL()
+	if !strings.Contains(sql, "CROSS JOIN LATERAL list_org_admin_sub(link.subject_id, p_subject_type) AS sub") {
+		t.Errorf("expected LATERAL compose with list_org_admin_sub, got:\n%s", sql)
+	}
+	if strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("subject-first block must not call check_permission_internal:\n%s", sql)
+	}
+	if strings.Contains(sql, "subject_pool") {
+		t.Errorf("subject-first block must not reference subject_pool:\n%s", sql)
+	}
+}
+
+func TestSubjectFirstTTU_FallsBackWhenCyclic(t *testing.T) {
+	lookup := composableOrgAdmin()
+	// org.admin reaches back into folder.viewer → composition unsafe.
+	lookup["org.admin"].ParentRelations = []ParentRelationInfo{{
+		Relation: "viewer", LinkingRelation: "link", AllowedLinkingTypes: []string{"folder"},
+	}}
+	plan, parent := subjectFirstPlan(lookup)
+
+	if blocks := buildSubjectFirstTTUSubjectBlocks(plan, parent); blocks != nil {
+		t.Errorf("cyclic composition must fall back to subject_pool, got %d blocks", len(blocks))
+	}
+}
+
+func TestSubjectFirstTTU_FallsBackWhenTargetHasWildcard(t *testing.T) {
+	lookup := composableOrgAdmin()
+	lookup["org.admin"].Features.HasWildcard = true
+	plan, parent := subjectFirstPlan(lookup)
+
+	if blocks := buildSubjectFirstTTUSubjectBlocks(plan, parent); blocks != nil {
+		t.Errorf("wildcard target must fall back to subject_pool (subject-side '*' handling)")
+	}
+}
+
+func TestSubjectFirstTTU_FallsBackForClosurePattern(t *testing.T) {
+	plan, parent := subjectFirstPlan(composableOrgAdmin())
+	parent.IsClosurePattern = true
+
+	if blocks := buildSubjectFirstTTUSubjectBlocks(plan, parent); blocks != nil {
+		t.Errorf("closure pattern must fall back to subject_pool")
+	}
+}
+
+func TestSubjectFirstTTU_FallsBackWhenNotListGeneratable(t *testing.T) {
+	lookup := composableOrgAdmin()
+	lookup["org.admin"].Capabilities.ListAllowed = false
+	plan, parent := subjectFirstPlan(lookup)
+
+	if blocks := buildSubjectFirstTTUSubjectBlocks(plan, parent); blocks != nil {
+		t.Errorf("non-generatable target must fall back to subject_pool")
+	}
+}

--- a/lib/sqlgen/list_subjects_subjectfirst_test.go
+++ b/lib/sqlgen/list_subjects_subjectfirst_test.go
@@ -145,3 +145,40 @@ func TestReachesWildcard_Transitive(t *testing.T) {
 		t.Error("no wildcard reachable once org.viewer removed")
 	}
 }
+
+// TestComposableListSubjectsTarget pins the extracted subject-first gate (the
+// single predicate now shared by complex-closure, complex-userset and TTU
+// subject-first composition sites): composable only when the target is
+// list-generatable, cycle/DepthExceeded-safe, AND not wildcard-reachable.
+func TestComposableListSubjectsTarget(t *testing.T) {
+	plan, _ := subjectFirstPlan(composableOrgAdmin())
+	if !composableListSubjectsTarget(plan, "org", "admin") {
+		t.Fatal("safe, non-wildcard, generatable target must be composable")
+	}
+
+	// Wildcard-reachable target: list_org_admin_sub would emit '*', so skip.
+	wc := composableOrgAdmin()
+	wc["org.admin"].Features.HasWildcard = true
+	planWC, _ := subjectFirstPlan(wc)
+	if composableListSubjectsTarget(planWC, "org", "admin") {
+		t.Error("wildcard-reachable target must not be composable")
+	}
+
+	// Cyclic: target references back into the caller relation → unsafe.
+	cyc := composableOrgAdmin()
+	cyc["org.admin"].ParentRelations = []ParentRelationInfo{{
+		Relation: "viewer", LinkingRelation: "link", AllowedLinkingTypes: []string{"folder"},
+	}}
+	planCyc, _ := subjectFirstPlan(cyc)
+	if composableListSubjectsTarget(planCyc, "org", "admin") {
+		t.Error("cyclic target must not be composable")
+	}
+
+	// Not list-generatable → unsafe.
+	ng := composableOrgAdmin()
+	ng["org.admin"].Capabilities.ListAllowed = false
+	planNG, _ := subjectFirstPlan(ng)
+	if composableListSubjectsTarget(planNG, "org", "admin") {
+		t.Error("non-generatable target must not be composable")
+	}
+}

--- a/lib/sqlgen/plpgsql/plpgsql.go
+++ b/lib/sqlgen/plpgsql/plpgsql.go
@@ -192,7 +192,12 @@ type PlpgsqlFunction struct {
 	Body       []Stmt
 	Header     []string // Comment lines at the top of the function (without -- prefix)
 	SearchPath string   // If set, appends SET search_path = '<value>' to the function definition
-	Cost       int      // If non-zero, appends COST <n> so the planner treats this function as costlier than the default (100)
+	// NoSearchPath omits the SET search_path clause entirely. Safe only for
+	// functions whose body references no unqualified melange_tuples (dispatchers
+	// and public wrappers, which use schema-qualified names). Omitting the SET
+	// lets LANGUAGE sql wrappers inline and avoids a per-call GUC save/restore.
+	NoSearchPath bool
+	Cost         int // If non-zero, appends COST <n> so the planner treats this function as costlier than the default (100)
 }
 
 // SQL renders the complete CREATE OR REPLACE FUNCTION statement.
@@ -226,7 +231,9 @@ func (f PlpgsqlFunction) SQL() string {
 	if f.Cost > 0 {
 		fmt.Fprintf(&sb, " COST %d", f.Cost)
 	}
-	writeSearchPath(&sb, f.SearchPath, f.Schema)
+	if !f.NoSearchPath {
+		writeSearchPath(&sb, f.SearchPath, f.Schema)
+	}
 	sb.WriteString(";")
 
 	return sb.String()
@@ -320,6 +327,9 @@ type SqlFunction struct {
 	Body       sqldsl.SQLer // The body expression (e.g., a SelectStmt or function call)
 	Header     []string     // Comment lines at the top of the function (without -- prefix)
 	SearchPath string       // If set, appends SET search_path = '<value>' to the function definition
+	// NoSearchPath omits the SET search_path clause. See PlpgsqlFunction.NoSearchPath.
+	// For LANGUAGE sql wrappers this is what allows the planner to inline them.
+	NoSearchPath bool
 }
 
 // SQL renders the complete CREATE OR REPLACE FUNCTION statement as LANGUAGE sql.
@@ -333,7 +343,9 @@ func (f SqlFunction) SQL() string {
 	sb.WriteString(f.Body.SQL())
 	sb.WriteString(";\n")
 	sb.WriteString("$$ LANGUAGE sql STABLE")
-	writeSearchPath(&sb, f.SearchPath, f.Schema)
+	if !f.NoSearchPath {
+		writeSearchPath(&sb, f.SearchPath, f.Schema)
+	}
 	sb.WriteString(";")
 
 	return sb.String()

--- a/lib/sqlgen/plpgsql/plpgsql.go
+++ b/lib/sqlgen/plpgsql/plpgsql.go
@@ -117,12 +117,14 @@ type SelectInto struct {
 }
 
 func (s SelectInto) StmtSQL() string {
-	q := s.Query.SQL()
+	q := strings.TrimSpace(s.Query.SQL())
 	// Insert INTO clause after SELECT
 	if len(q) >= 6 && q[:6] == "SELECT" {
 		return "SELECT" + " INTO " + s.Variable + q[6:] + ";"
 	}
-	// Fallback: wrap the query
+	// Fallback: wrap the query in a scalar subquery. Adds a SubPlan layer per
+	// execution — extend the primary branch instead if a new query shape hits
+	// this.
 	return fmt.Sprintf("SELECT INTO %s (%s);", s.Variable, q)
 }
 

--- a/lib/sqlgen/search_path_optout_test.go
+++ b/lib/sqlgen/search_path_optout_test.go
@@ -1,0 +1,123 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pthm/melange/lib/sqlgen/plpgsql"
+	"github.com/pthm/melange/lib/sqlgen/sqldsl"
+)
+
+// #8b: dispatchers and public wrappers reference only schema-qualified names,
+// so they carry NoSearchPath and must render WITHOUT a SET search_path clause —
+// which is what lets LANGUAGE sql wrappers inline and drops a per-call GUC
+// cycle. Leaf functions (check_{type}_{rel}, list_*, etc.) reference
+// unqualified melange_tuples and MUST keep search_path so pg_temp can shadow it
+// for contextual tuples.
+func TestSearchPath_NoSearchPathOptOut(t *testing.T) {
+	sp := plpgsql.PlpgsqlFunction{Schema: "authz", Name: "f", Returns: "INTEGER", Body: []plpgsql.Stmt{plpgsql.ReturnInt{Value: 0}}}
+	if !strings.Contains(sp.SQL(), "SET search_path = 'authz'") {
+		t.Errorf("plpgsql without NoSearchPath should emit SET search_path:\n%s", sp.SQL())
+	}
+	sp.NoSearchPath = true
+	if strings.Contains(sp.SQL(), "SET search_path") {
+		t.Errorf("plpgsql with NoSearchPath should omit SET search_path:\n%s", sp.SQL())
+	}
+
+	sq := plpgsql.SqlFunction{Schema: "authz", Name: "f", Returns: "INTEGER", Body: sqldsl.Raw("SELECT 0")}
+	if !strings.Contains(sq.SQL(), "SET search_path = 'authz'") {
+		t.Errorf("sql func without NoSearchPath should emit SET search_path:\n%s", sq.SQL())
+	}
+	sq.NoSearchPath = true
+	if strings.Contains(sq.SQL(), "SET search_path") {
+		t.Errorf("sql func with NoSearchPath should omit SET search_path:\n%s", sq.SQL())
+	}
+}
+
+// End-to-end: dispatchers/wrappers render without search_path; the leaf
+// check_{type}_{rel} keeps it. Pins the exact set of functions opted out.
+func TestSearchPath_DispatchersOptOut_LeavesKeep(t *testing.T) {
+	analyses := []RelationAnalysis{
+		mkAnalysis("document", "viewer", RelationFeatures{HasDirect: true}, true),
+	}
+	analyses[0].DirectSubjectTypes = []string{"user"}
+
+	gen, err := GenerateSQL(analyses, InlineSQLData{}, "authz")
+	if err != nil {
+		t.Fatalf("GenerateSQL: %v", err)
+	}
+
+	// Dispatchers + wrappers: no search_path.
+	for name, sql := range map[string]string{
+		"check dispatcher":   gen.Dispatcher,
+		"nw dispatcher":      gen.DispatcherNoWildcard,
+		"explain dispatcher": gen.ExplainDispatcher,
+		"expand dispatcher":  gen.ExpandDispatcher,
+	} {
+		if strings.Contains(sql, "SET search_path") {
+			t.Errorf("%s must NOT contain SET search_path (references only schema-qualified names):\n%s", name, sql)
+		}
+	}
+
+	// Leaf check function: keeps search_path (references unqualified melange_tuples).
+	if len(gen.Functions) == 0 {
+		t.Fatal("expected at least one leaf check function")
+	}
+	for _, fn := range gen.Functions {
+		if !strings.Contains(fn, "SET search_path = 'authz'") {
+			t.Errorf("leaf check function must keep SET search_path so pg_temp shadows melange_tuples:\n%s", fn)
+		}
+	}
+
+	// Bulk dispatcher inlines a direct melange_tuples EXISTS, so it MUST keep it.
+	if !strings.Contains(gen.BulkDispatcher, "SET search_path = 'authz'") {
+		t.Errorf("bulk dispatcher references unqualified melange_tuples and must keep SET search_path:\n%s", gen.BulkDispatcher)
+	}
+}
+
+// #8a: the per-row list_subjects validation calls the internal dispatchers
+// directly (empty visited), skipping the public LANGUAGE sql wrappers that
+// cannot inline. Pins the DSL call shapes and that the nw routing is preserved.
+func TestListSubjects_CallsInternalDirectly(t *testing.T) {
+	// Regular (wildcard-allowed) per-row check: check_permission_internal, not
+	// the bare check_permission wrapper.
+	reg := CheckPermission{
+		Schema:      "authz",
+		Subject:     SubjectRef{Type: Param("v_filter_type"), ID: Col{Table: "t", Column: "subject_id"}},
+		Relation:    "viewer",
+		Object:      LiteralObject("document", ObjectID),
+		ExpectAllow: true,
+	}.SQL()
+	if !strings.Contains(reg, "check_permission_internal") {
+		t.Errorf("regular list_subjects check must call check_permission_internal:\n%s", reg)
+	}
+	if !strings.Contains(reg, "ARRAY[]::TEXT[]") {
+		t.Errorf("internal call must pass an empty visited array:\n%s", reg)
+	}
+
+	// No-wildcard per-row check: check_permission_nw_internal (nw routing
+	// preserved), not the regular internal and not the bare nw wrapper.
+	nw := sqldsl.NoWildcardPermissionCheckCall("authz", "viewer", "document", Col{Table: "br", Column: "subject_id"}, ObjectID).SQL()
+	if !strings.Contains(nw, "check_permission_nw_internal") {
+		t.Errorf("no-wildcard list_subjects check must call check_permission_nw_internal:\n%s", nw)
+	}
+	if !strings.Contains(nw, "ARRAY[]::TEXT[]") {
+		t.Errorf("nw internal call must pass an empty visited array:\n%s", nw)
+	}
+}
+
+// Depth-limit routing is preserved: the internal dispatchers still enforce the
+// M2002 depth guard that the public wrappers bypassed by starting empty.
+func TestDispatchers_DepthGuardPreserved(t *testing.T) {
+	analyses := []RelationAnalysis{
+		mkAnalysis("document", "viewer", RelationFeatures{HasDirect: true}, true),
+	}
+	analyses[0].DirectSubjectTypes = []string{"user"}
+	checkSQL, err := generateDispatcher(analyses, "authz", false)
+	if err != nil {
+		t.Fatalf("generateDispatcher: %v", err)
+	}
+	if !strings.Contains(checkSQL, "M2002") || !strings.Contains(checkSQL, "array_length") {
+		t.Errorf("internal dispatcher must keep the depth guard:\n%s", checkSQL)
+	}
+}

--- a/lib/sqlgen/source_relation_compose_test.go
+++ b/lib/sqlgen/source_relation_compose_test.go
@@ -1,0 +1,103 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// sourceRelationPlan builds a list_objects ListPlan for object type "doc",
+// relation "can_read", with a lookup that makes the source relation "editor"
+// composable or not depending on the supplied lookup.
+func sourceRelationPlan(lookup map[string]*RelationAnalysis) ListPlan {
+	return ListPlan{
+		DatabaseSchema: "",
+		ObjectType:     "doc",
+		Relation:       "can_read",
+		AnalysisLookup: lookup,
+	}
+}
+
+var sourceParent = ListParentRelationData{
+	SourceRelation:   "editor",
+	IsClosurePattern: true,
+}
+
+func TestSourceRelationCheck_SemiJoinWhenComposable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.editor": {
+			ObjectType:   "doc",
+			Relation:     "editor",
+			Capabilities: GenerationCapabilities{ListAllowed: true},
+			ListStrategy: ListStrategyRecursive, // complex, but acyclic below
+			ParentRelations: []ParentRelationInfo{{
+				Relation: "editor", LinkingRelation: "org", AllowedLinkingTypes: []string{"org"},
+			}},
+		},
+		"org.editor": {ObjectType: "org", Relation: "editor"},
+	}
+
+	sql := sourceRelationCheck(sourceRelationPlan(lookup), sourceParent).SQL()
+
+	if !strings.Contains(sql, "child.object_id IN (SELECT src_obj.object_id FROM list_doc_editor_obj(p_subject_type, p_subject_id, NULL, NULL) src_obj)") {
+		t.Errorf("expected set-oriented semi-join against list_doc_editor_obj, got:\n%s", sql)
+	}
+	// Userset-typed subjects keep a guarded per-candidate check for parity.
+	if !strings.Contains(sql, "position('#' in p_subject_id) > 0") {
+		t.Errorf("expected userset-subject parity guard, got:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', child.object_id") {
+		t.Errorf("expected guarded per-candidate check for userset subjects, got:\n%s", sql)
+	}
+}
+
+func TestSourceRelationCheck_FallsBackWhenCyclic(t *testing.T) {
+	// doc.editor reaches back into doc.can_read → composition unsafe.
+	lookup := map[string]*RelationAnalysis{
+		"doc.editor": {
+			ObjectType:              "doc",
+			Relation:                "editor",
+			Capabilities:            GenerationCapabilities{ListAllowed: true},
+			ListStrategy:            ListStrategyRecursive,
+			ComplexClosureRelations: []string{"can_read"},
+		},
+	}
+
+	sql := sourceRelationCheck(sourceRelationPlan(lookup), sourceParent).SQL()
+
+	if strings.Contains(sql, "list_doc_editor_obj") {
+		t.Errorf("cyclic composition must fall back to per-candidate check, got semi-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal(p_subject_type, p_subject_id, 'editor', 'doc', child.object_id") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestSourceRelationCheck_FallsBackWhenNotListGeneratable(t *testing.T) {
+	lookup := map[string]*RelationAnalysis{
+		"doc.editor": {
+			ObjectType:   "doc",
+			Relation:     "editor",
+			Capabilities: GenerationCapabilities{ListAllowed: false}, // no list function
+		},
+	}
+
+	sql := sourceRelationCheck(sourceRelationPlan(lookup), sourceParent).SQL()
+
+	if strings.Contains(sql, "list_doc_editor_obj") {
+		t.Errorf("non-generatable target must fall back to per-candidate check, got semi-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}
+
+func TestSourceRelationCheck_FallsBackWhenNoLookup(t *testing.T) {
+	sql := sourceRelationCheck(sourceRelationPlan(nil), sourceParent).SQL()
+
+	if strings.Contains(sql, "list_doc_editor_obj") {
+		t.Errorf("nil lookup must fall back to per-candidate check, got semi-join:\n%s", sql)
+	}
+	if !strings.Contains(sql, "check_permission_internal") {
+		t.Errorf("expected per-candidate check fallback, got:\n%s", sql)
+	}
+}

--- a/lib/sqlgen/sqldsl/func_call.go
+++ b/lib/sqlgen/sqldsl/func_call.go
@@ -62,17 +62,23 @@ func InternalPermissionCheckCall(schema, relation, objectType string, objectID, 
 	}
 }
 
-// NoWildcardPermissionCheckCall creates a check_permission_nw function call.
+// NoWildcardPermissionCheckCall creates a check_permission_nw_internal call
+// with an empty visited array. It targets the internal dispatcher directly
+// rather than the public check_permission_nw wrapper so the per-candidate-row
+// validation in list_subjects skips the extra LANGUAGE sql wrapper layer (and
+// its GUC save/restore). Semantics are identical: the nw dispatcher excludes
+// wildcard grants, and visited starts empty at a fresh check.
 func NoWildcardPermissionCheckCall(schema, relation, objectType string, subjectID, objectID Expr) FuncCallEq {
 	return FuncCallEq{
 		Schema:   schema,
-		FuncName: "check_permission_nw",
+		FuncName: "check_permission_nw_internal",
 		Args: []Expr{
 			SubjectType,
 			subjectID,
 			Lit(relation),
 			Lit(objectType),
 			objectID,
+			EmptyArray{},
 		},
 		Value: Int(1),
 	}

--- a/lib/sqlgen/userset_self_fold_test.go
+++ b/lib/sqlgen/userset_self_fold_test.go
@@ -25,7 +25,7 @@ func mkFoldAnalysis(objType, relation string, satisfying []string) RelationAnaly
 // bigClosure returns closure rows for the target relation plus many unrelated
 // rows, so a VALUES-scan self-check would embed all of them.
 func bigClosure(objType, relation string, satisfying []string) InlineSQLData {
-	var rows []ValuesRow
+	rows := make([]ValuesRow, 0, len(satisfying)+200)
 	for _, s := range satisfying {
 		rows = append(rows, closureRow(objType, relation, s))
 	}

--- a/lib/sqlgen/userset_self_fold_test.go
+++ b/lib/sqlgen/userset_self_fold_test.go
@@ -35,58 +35,66 @@ func bigClosure(objType, relation string, satisfying []string) InlineSQLData {
 	return InlineSQLData{ClosureRows: rows}
 }
 
-func TestUsersetSelfCheck_CheckFunctionFold(t *testing.T) {
-	a := mkFoldAnalysis("doc", "viewer", []string{"viewer", "editor"})
-	plan := BuildCheckPlan(a, bigClosure("doc", "viewer", []string{"viewer", "editor"}), "", false)
-	selfCheck, _ := buildUsersetSubjectChecks(plan)
-	sql := selfCheck.SQL()
-
-	if strings.Contains(sql, closureAlias) {
-		t.Fatalf("check self-check still embeds closure VALUES:\n%s", sql)
-	}
-	if !strings.Contains(sql, "IN ('viewer', 'editor')") {
-		t.Fatalf("check self-check missing folded IN-list:\n%s", sql)
-	}
-}
-
-func TestUsersetSelfCheck_ListObjectsFold(t *testing.T) {
-	a := mkFoldAnalysis("doc", "viewer", []string{"viewer"})
-	plan := ListPlan{
-		Analysis:   a,
-		Inline:     bigClosure("doc", "viewer", []string{"viewer"}),
+// listFoldPlan builds a ListPlan for the doc#viewer self-candidate fold tests,
+// with a big unrelated closure that a VALUES-scan would embed.
+func listFoldPlan(satisfying []string) ListPlan {
+	return ListPlan{
+		Analysis:   mkFoldAnalysis("doc", "viewer", satisfying),
+		Inline:     bigClosure("doc", "viewer", satisfying),
 		ObjectType: "doc",
 		Relation:   "viewer",
 	}
-	block := buildListObjectsSelfCandidateBlock(plan)
-	sql := block.Query.SQL()
-
-	if strings.Contains(sql, closureAlias) {
-		t.Fatalf("list_objects self-candidate still embeds closure VALUES:\n%s", sql)
-	}
-	if !strings.Contains(sql, "IN ('viewer')") {
-		t.Fatalf("list_objects self-candidate missing folded IN-list:\n%s", sql)
-	}
 }
 
-func TestUsersetSelfCheck_ComposedObjectsFold(t *testing.T) {
-	a := mkFoldAnalysis("doc", "viewer", []string{"viewer"})
-	plan := ListPlan{
-		Analysis:   a,
-		Inline:     bigClosure("doc", "viewer", []string{"viewer"}),
-		ObjectType: "doc",
-		Relation:   "viewer",
+// Each self-check site folds the whole-model closure VALUES scan to a
+// compile-time IN-list: the rendered SQL must not embed the closure table and
+// must carry the satisfying set as an IN-list.
+func TestUsersetSelfCheck_Fold(t *testing.T) {
+	cases := []struct {
+		name   string
+		wantIN string
+		sql    func(t *testing.T) string
+	}{
+		{
+			name:   "check function",
+			wantIN: "IN ('viewer', 'editor')",
+			sql: func(t *testing.T) string {
+				a := mkFoldAnalysis("doc", "viewer", []string{"viewer", "editor"})
+				plan := BuildCheckPlan(a, bigClosure("doc", "viewer", []string{"viewer", "editor"}), "", false)
+				selfCheck, _ := buildUsersetSubjectChecks(plan)
+				return selfCheck.SQL()
+			},
+		},
+		{
+			name:   "list_objects self-candidate",
+			wantIN: "IN ('viewer')",
+			sql: func(t *testing.T) string {
+				return buildListObjectsSelfCandidateBlock(listFoldPlan([]string{"viewer"})).Query.SQL()
+			},
+		},
+		{
+			name:   "composed self-block",
+			wantIN: "IN ('viewer')",
+			sql: func(t *testing.T) string {
+				block, err := buildComposedObjectsSelfBlock(listFoldPlan([]string{"viewer"}))
+				if err != nil {
+					t.Fatal(err)
+				}
+				return block.Query.SQL()
+			},
+		},
 	}
-	block, err := buildComposedObjectsSelfBlock(plan)
-	if err != nil {
-		t.Fatal(err)
-	}
-	sql := block.Query.SQL()
 
-	if strings.Contains(sql, closureAlias) {
-		t.Fatalf("composed self-block still embeds closure VALUES:\n%s", sql)
-	}
-	if !strings.Contains(sql, "IN ('viewer')") {
-		t.Fatalf("composed self-block missing folded IN-list:\n%s", sql)
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			sql := tc.sql(t)
+			if strings.Contains(sql, closureAlias) {
+				t.Fatalf("%s still embeds closure VALUES:\n%s", tc.name, sql)
+			}
+			if !strings.Contains(sql, tc.wantIN) {
+				t.Fatalf("%s missing folded IN-list %q:\n%s", tc.name, tc.wantIN, sql)
+			}
+		})
 	}
 }
 

--- a/lib/sqlgen/userset_self_fold_test.go
+++ b/lib/sqlgen/userset_self_fold_test.go
@@ -1,0 +1,102 @@
+package sqlgen
+
+import (
+	"strings"
+	"testing"
+)
+
+// The userset self-check ("is the subject a userset on THIS object type whose
+// relation satisfies plan.Relation?") folds from a VALUES-scan over the whole
+// model's closure to a compile-time IN-list, since object_type and relation are
+// codegen constants and the satisfying set is plan.Analysis.SatisfyingRelations.
+// These tests pin the folded shape and prove the closure VALUES no longer
+// appears in the self-check, so its size is independent of unrelated relations.
+
+// closureAlias is the fragment ClosureTable emits for its VALUES table; if the
+// self-check still scanned the closure it would appear in the rendered SQL.
+const closureAlias = "AS c(object_type"
+
+func mkFoldAnalysis(objType, relation string, satisfying []string) RelationAnalysis {
+	a := mkAnalysis(objType, relation, RelationFeatures{HasDirect: true}, true)
+	a.SatisfyingRelations = satisfying
+	return a
+}
+
+// bigClosure returns closure rows for the target relation plus many unrelated
+// rows, so a VALUES-scan self-check would embed all of them.
+func bigClosure(objType, relation string, satisfying []string) InlineSQLData {
+	var rows []ValuesRow
+	for _, s := range satisfying {
+		rows = append(rows, closureRow(objType, relation, s))
+	}
+	for i := 0; i < 200; i++ {
+		rows = append(rows, closureRow("aaa", "rel", "rel"))
+	}
+	return InlineSQLData{ClosureRows: rows}
+}
+
+func TestUsersetSelfCheck_CheckFunctionFold(t *testing.T) {
+	a := mkFoldAnalysis("doc", "viewer", []string{"viewer", "editor"})
+	plan := BuildCheckPlan(a, bigClosure("doc", "viewer", []string{"viewer", "editor"}), "", false)
+	selfCheck, _ := buildUsersetSubjectChecks(plan)
+	sql := selfCheck.SQL()
+
+	if strings.Contains(sql, closureAlias) {
+		t.Fatalf("check self-check still embeds closure VALUES:\n%s", sql)
+	}
+	if !strings.Contains(sql, "IN ('viewer', 'editor')") {
+		t.Fatalf("check self-check missing folded IN-list:\n%s", sql)
+	}
+}
+
+func TestUsersetSelfCheck_ListObjectsFold(t *testing.T) {
+	a := mkFoldAnalysis("doc", "viewer", []string{"viewer"})
+	plan := ListPlan{
+		Analysis:   a,
+		Inline:     bigClosure("doc", "viewer", []string{"viewer"}),
+		ObjectType: "doc",
+		Relation:   "viewer",
+	}
+	block := buildListObjectsSelfCandidateBlock(plan)
+	sql := block.Query.SQL()
+
+	if strings.Contains(sql, closureAlias) {
+		t.Fatalf("list_objects self-candidate still embeds closure VALUES:\n%s", sql)
+	}
+	if !strings.Contains(sql, "IN ('viewer')") {
+		t.Fatalf("list_objects self-candidate missing folded IN-list:\n%s", sql)
+	}
+}
+
+func TestUsersetSelfCheck_ComposedObjectsFold(t *testing.T) {
+	a := mkFoldAnalysis("doc", "viewer", []string{"viewer"})
+	plan := ListPlan{
+		Analysis:   a,
+		Inline:     bigClosure("doc", "viewer", []string{"viewer"}),
+		ObjectType: "doc",
+		Relation:   "viewer",
+	}
+	block, err := buildComposedObjectsSelfBlock(plan)
+	if err != nil {
+		t.Fatal(err)
+	}
+	sql := block.Query.SQL()
+
+	if strings.Contains(sql, closureAlias) {
+		t.Fatalf("composed self-block still embeds closure VALUES:\n%s", sql)
+	}
+	if !strings.Contains(sql, "IN ('viewer')") {
+		t.Fatalf("composed self-block missing folded IN-list:\n%s", sql)
+	}
+}
+
+// Empty SatisfyingRelations must render FALSE (never matches), matching the
+// empty VALUES-scan it replaces.
+func TestUsersetSelfCheck_EmptySatisfyingRendersFalse(t *testing.T) {
+	a := mkFoldAnalysis("doc", "viewer", nil)
+	plan := BuildCheckPlan(a, InlineSQLData{}, "", false)
+	selfCheck, _ := buildUsersetSubjectChecks(plan)
+	if !strings.Contains(selfCheck.SQL(), "FALSE") {
+		t.Fatalf("empty satisfying set must render FALSE:\n%s", selfCheck.SQL())
+	}
+}

--- a/lib/version/version.go
+++ b/lib/version/version.go
@@ -3,6 +3,7 @@ package version
 import (
 	"fmt"
 	"runtime"
+	"runtime/debug"
 )
 
 // These variables are set via ldflags by GoReleaser
@@ -11,6 +12,64 @@ var (
 	Commit  = "none"
 	Date    = "unknown"
 )
+
+// init fills Version/Commit/Date from the embedded build info when they were
+// not stamped via ldflags. This makes "go install github.com/pthm/melange/...@v"
+// builds report their real module version, and — importantly — lets library
+// consumers of pkg/migrator (who never run cmd/melange's init) get a real
+// CodegenVersion so the phase-1 migration fast-path skip is not permanently
+// disabled. ldflags-stamped builds are left untouched (Version != "dev").
+func init() {
+	if Version != "dev" {
+		return
+	}
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return
+	}
+	if v := melangeModuleVersion(info); v != "" {
+		Version = v
+	}
+	for _, setting := range info.Settings {
+		switch setting.Key {
+		case "vcs.revision":
+			if len(setting.Value) >= 7 {
+				Commit = setting.Value[:7]
+			} else {
+				Commit = setting.Value
+			}
+		case "vcs.time":
+			Date = setting.Value
+		}
+	}
+}
+
+// melangeModuleVersion returns Melange's own module version from the build info,
+// or "" if it cannot be resolved. For the melange CLI, Melange is the main
+// module; for library consumers of pkg/migrator it is a dependency, so Deps is
+// consulted. Using info.Main.Version unconditionally would pick up the consuming
+// application's version and make CodegenVersion track the wrong module — a
+// Melange dependency upgrade without an app version bump could then wrongly
+// trigger the phase-1 migration skip and leave stale generated SQL installed.
+func melangeModuleVersion(info *debug.BuildInfo) string {
+	const modulePath = "github.com/pthm/melange"
+
+	version := info.Main.Version
+	if info.Main.Path != modulePath {
+		version = ""
+		for _, dep := range info.Deps {
+			if dep.Path == modulePath {
+				version = dep.Version
+				break
+			}
+		}
+	}
+
+	if version == "(devel)" {
+		return ""
+	}
+	return version
+}
 
 // Info returns formatted version information
 func Info() string {

--- a/lib/version/version_test.go
+++ b/lib/version/version_test.go
@@ -1,0 +1,61 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestMelangeModuleVersion(t *testing.T) {
+	const modulePath = "github.com/pthm/melange"
+
+	tests := []struct {
+		name string
+		info *debug.BuildInfo
+		want string
+	}{
+		{
+			name: "cli main module carries a real version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: "v0.8.4"},
+			},
+			want: "v0.8.4",
+		},
+		{
+			name: "cli built from source (devel) resolves to empty",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: modulePath, Version: "(devel)"},
+			},
+			want: "",
+		},
+		{
+			// The bug codex flagged: when a tagged application imports
+			// pkg/migrator, Main is the app — Melange must come from Deps, not
+			// the app's own version.
+			name: "library consumer reads melange from deps, not the app version",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/acme/app", Version: "v1.2.3"},
+				Deps: []*debug.Module{
+					{Path: "github.com/some/other", Version: "v9.9.9"},
+					{Path: modulePath, Version: "v0.8.4"},
+				},
+			},
+			want: "v0.8.4",
+		},
+		{
+			name: "library consumer with melange absent from deps resolves to empty",
+			info: &debug.BuildInfo{
+				Main: debug.Module{Path: "github.com/acme/app", Version: "v1.2.3"},
+				Deps: []*debug.Module{{Path: "github.com/some/other", Version: "v9.9.9"}},
+			},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := melangeModuleVersion(tt.info); got != tt.want {
+				t.Fatalf("melangeModuleVersion() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/pkg/migrator/api.go
+++ b/pkg/migrator/api.go
@@ -129,20 +129,8 @@ func MigrateWithOptions(ctx context.Context, db Execer, schemaPath string, opts 
 		SchemaContent: string(schemaContent),
 	}
 
-	// Check if we should skip (only if not dry-run and not force)
-	if !opts.Force && opts.DryRun == nil {
-		checksum := ComputeSchemaChecksum(string(schemaContent))
-		lastMigration, err := m.GetLastMigration(ctx)
-		if err != nil {
-			return false, fmt.Errorf("checking last migration: %w", err)
-		}
-		if lastMigration != nil &&
-			lastMigration.SchemaChecksum == checksum &&
-			lastMigration.CodegenVersion == CodegenVersion() {
-			return true, nil // Skipped
-		}
-	}
-
-	err = m.MigrateWithTypesAndOptions(ctx, types, internalOpts)
-	return false, err
+	// Skip detection (both phases) happens inside migrateWithTypesAndOptions;
+	// its skipped result covers the phase 1 fast path and the phase 2 no-op
+	// that dev builds rely on (see shouldSkipMigration).
+	return m.migrateWithTypesAndOptions(ctx, types, internalOpts)
 }

--- a/pkg/migrator/ddl.go
+++ b/pkg/migrator/ddl.go
@@ -50,22 +50,46 @@ ADD COLUMN IF NOT EXISTS melange_version TEXT NOT NULL DEFAULT '';
 `, table)
 }
 
-// widenVersionColumns returns a query that widens the version columns of
-// existing tables from their original VARCHAR types to TEXT. Module
-// pseudo-versions (e.g. "v0.8.4-0.20260701080815-8f95d5d39b90" from
-// go-install builds) are 38+ characters and overflowed the original
-// codegen_version VARCHAR(32), failing every migrate with "value too long".
-// Runs unconditionally like the sibling ADD COLUMN helpers: ALTER TYPE has
-// no IF syntax, varchar→text is catalog-only (no table rewrite), and re-runs
-// on an already-TEXT column are harmless no-op catalog updates on a table
-// with one row per migration.
-func widenVersionColumns(databaseSchema string) string {
+// widenVersionColumnsDDL returns a guarded statement that widens the version
+// columns to TEXT only when they are still bounded VARCHAR. Module
+// pseudo-versions (e.g. "v0.8.4-0.20260701080815-8f95d5d39b90" from go-install
+// builds) are 38+ characters and overflowed the original codegen_version
+// VARCHAR(32), failing every migrate with "value too long".
+//
+// ALTER TYPE has no IF syntax and PostgreSQL rejects even a no-op
+// VARCHAR->TEXT/TEXT->TEXT change when a view or rule depends on the column, so
+// the widen must be conditional: once the columns are TEXT
+// (character_maximum_length IS NULL) the ALTERs are skipped, leaving dependent
+// views intact. The guard runs server-side in a DO block so the same statement
+// is correct on both the direct apply path and the dry-run/file output path.
+func widenVersionColumnsDDL(databaseSchema string) string {
 	table := sqldsl.PrefixIdent("melange_migrations", databaseSchema)
+	schema := sqldsl.PostgresSchemaExpr(databaseSchema)
 
 	return fmt.Sprintf(`
-ALTER TABLE %[1]s ALTER COLUMN codegen_version TYPE TEXT;
-ALTER TABLE %[1]s ALTER COLUMN melange_version TYPE TEXT;
-`, table)
+DO $mig$
+BEGIN
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'melange_migrations'
+          AND column_name = 'codegen_version'
+          AND table_schema = %[2]s
+          AND character_maximum_length IS NOT NULL
+    ) THEN
+        ALTER TABLE %[1]s ALTER COLUMN codegen_version TYPE TEXT;
+    END IF;
+    IF EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'melange_migrations'
+          AND column_name = 'melange_version'
+          AND table_schema = %[2]s
+          AND character_maximum_length IS NOT NULL
+    ) THEN
+        ALTER TABLE %[1]s ALTER COLUMN melange_version TYPE TEXT;
+    END IF;
+END
+$mig$;
+`, table, schema)
 }
 
 // migrationsTableDDL returns every statement that brings the
@@ -79,7 +103,7 @@ func migrationsTableDDL(databaseSchema string) []string {
 		migrationsDDL(databaseSchema),
 		addMelangeVersionColumn(databaseSchema),
 		addFunctionChecksumsColumn(databaseSchema),
-		widenVersionColumns(databaseSchema),
+		widenVersionColumnsDDL(databaseSchema),
 	}
 }
 

--- a/pkg/migrator/ddl.go
+++ b/pkg/migrator/ddl.go
@@ -27,9 +27,9 @@ func migrationsDDL(databaseSchema string) string {
 CREATE TABLE IF NOT EXISTS %[1]s (
     id SERIAL PRIMARY KEY,
     migrated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
-    melange_version VARCHAR(64) NOT NULL DEFAULT '',
+    melange_version TEXT NOT NULL DEFAULT '',
     schema_checksum VARCHAR(64) NOT NULL,
-    codegen_version VARCHAR(32) NOT NULL,
+    codegen_version TEXT NOT NULL,
     function_names TEXT[] NOT NULL
 );
 
@@ -46,8 +46,41 @@ func addMelangeVersionColumn(databaseSchema string) string {
 
 	return fmt.Sprintf(`
 ALTER TABLE %s
-ADD COLUMN IF NOT EXISTS melange_version VARCHAR(64) NOT NULL DEFAULT '';
+ADD COLUMN IF NOT EXISTS melange_version TEXT NOT NULL DEFAULT '';
 `, table)
+}
+
+// widenVersionColumns returns a query that widens the version columns of
+// existing tables from their original VARCHAR types to TEXT. Module
+// pseudo-versions (e.g. "v0.8.4-0.20260701080815-8f95d5d39b90" from
+// go-install builds) are 38+ characters and overflowed the original
+// codegen_version VARCHAR(32), failing every migrate with "value too long".
+// Runs unconditionally like the sibling ADD COLUMN helpers: ALTER TYPE has
+// no IF syntax, varchar→text is catalog-only (no table rewrite), and re-runs
+// on an already-TEXT column are harmless no-op catalog updates on a table
+// with one row per migration.
+func widenVersionColumns(databaseSchema string) string {
+	table := sqldsl.PrefixIdent("melange_migrations", databaseSchema)
+
+	return fmt.Sprintf(`
+ALTER TABLE %[1]s ALTER COLUMN codegen_version TYPE TEXT;
+ALTER TABLE %[1]s ALTER COLUMN melange_version TYPE TEXT;
+`, table)
+}
+
+// migrationsTableDDL returns every statement that brings the
+// melange_migrations table to the current shape, in order: create if absent,
+// then the column migrations for tables created by earlier versions. Both
+// the direct apply path (applyMigrationsDDL) and the dry-run/file output
+// (outputDryRun) must emit all of them — a statement missing from either
+// path resurfaces the legacy-table bugs for that workflow.
+func migrationsTableDDL(databaseSchema string) []string {
+	return []string{
+		migrationsDDL(databaseSchema),
+		addMelangeVersionColumn(databaseSchema),
+		addFunctionChecksumsColumn(databaseSchema),
+		widenVersionColumns(databaseSchema),
+	}
 }
 
 // addFunctionChecksumsColumn return a query to add function_checksums to existing melange_migrations

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -495,9 +495,12 @@ func migrationRecordMatches(lastMigration *MigrationRecord, schemaChecksum strin
 // shouldSkipMigration returns true if the schema and codegen version are unchanged.
 // This is the fast-path (phase 1) skip: no SQL generation needed at all.
 //
-// Dev builds never skip here: "dev" is a constant, so a rebuilt binary with
-// changed codegen would look identical to the last migration. Falling through
-// lets the phase 2 checksum comparison (which includes dispatchers) decide.
+// Unstamped "dev" builds never skip here: "dev" is a constant, so a rebuilt
+// binary with changed codegen would look identical to the last migration.
+// Falling through lets the phase 2 checksum comparison (which includes
+// dispatchers) decide. Released binaries and go-install/library builds report a
+// real version (lib/version resolves it from ldflags or embedded build info),
+// so they still get the fast-path skip.
 func shouldSkipMigration(lastMigration *MigrationRecord, schemaChecksum string) bool {
 	if CodegenVersion() == "dev" {
 		return false

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -41,6 +41,8 @@ var (
 	GenerateListSQL        = sqlgen.GenerateListSQL
 	CollectFunctionNames   = sqlgen.CollectFunctionNames
 	collectNamedFunctions  = sqlgen.CollectNamedFunctions
+
+	collectDispatcherFunctions = sqlgen.CollectDispatcherFunctions
 )
 
 // CodegenVersion returns the melange version used to identify which codegen
@@ -480,14 +482,27 @@ func (m *Migrator) getLastMigration(ctx context.Context, db Execer) (*MigrationR
 	return &rec, nil
 }
 
-// shouldSkipMigration returns true if the schema and codegen version are unchanged.
-// This is the fast-path (phase 1) skip: no SQL generation needed at all.
-func shouldSkipMigration(lastMigration *MigrationRecord, schemaChecksum string) bool {
+// migrationRecordMatches reports whether the last migration was recorded with
+// the same schema checksum and codegen version as the current run.
+func migrationRecordMatches(lastMigration *MigrationRecord, schemaChecksum string) bool {
 	if lastMigration == nil {
 		return false
 	}
 	return lastMigration.SchemaChecksum == schemaChecksum &&
 		lastMigration.CodegenVersion == CodegenVersion()
+}
+
+// shouldSkipMigration returns true if the schema and codegen version are unchanged.
+// This is the fast-path (phase 1) skip: no SQL generation needed at all.
+//
+// Dev builds never skip here: "dev" is a constant, so a rebuilt binary with
+// changed codegen would look identical to the last migration. Falling through
+// lets the phase 2 checksum comparison (which includes dispatchers) decide.
+func shouldSkipMigration(lastMigration *MigrationRecord, schemaChecksum string) bool {
+	if CodegenVersion() == "dev" {
+		return false
+	}
+	return migrationRecordMatches(lastMigration, schemaChecksum)
 }
 
 // shouldSkipApply returns true if the generated SQL is identical to what was
@@ -649,9 +664,17 @@ func (m *Migrator) insertMigrationRecord(ctx context.Context, db Execer, melange
 //
 // See MigrateWithTypes for basic usage without options.
 func (m *Migrator) MigrateWithTypesAndOptions(ctx context.Context, types []TypeDefinition, opts InternalMigrateOptions) error {
+	_, err := m.migrateWithTypesAndOptions(ctx, types, opts)
+	return err
+}
+
+// migrateWithTypesAndOptions implements MigrateWithTypesAndOptions and
+// additionally reports whether the migration was a no-op (both skip phases
+// count; recording a new migration state does not).
+func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeDefinition, opts InternalMigrateOptions) (skipped bool, err error) {
 	// 1. Validate schema before any computation
 	if err := DetectCycles(types); err != nil {
-		return err
+		return false, err
 	}
 
 	// 2. Compute schema checksum if content provided
@@ -663,14 +686,13 @@ func (m *Migrator) MigrateWithTypesAndOptions(ctx context.Context, types []TypeD
 	// 3. Fetch last migration record (needed for both skip phases)
 	var lastMigration *MigrationRecord
 	if !opts.Force && opts.DryRun == nil && schemaChecksum != "" {
-		var err error
 		lastMigration, err = m.getLastMigration(ctx, m.db)
 		if err != nil {
-			return fmt.Errorf("checking last migration: %w", err)
+			return false, fmt.Errorf("checking last migration: %w", err)
 		}
-		// Phase 1 skip: schema + melange version unchanged → skip entirely
+		// Phase 1 skip: schema + codegen version unchanged → skip entirely
 		if shouldSkipMigration(lastMigration, schemaChecksum) {
-			return nil
+			return true, nil
 		}
 	}
 
@@ -683,24 +705,28 @@ func (m *Migrator) MigrateWithTypesAndOptions(ctx context.Context, types []TypeD
 	inline := buildInlineSQLData(closureRows, analyses)
 	generatedSQL, err := GenerateSQL(analyses, inline, m.databaseSchema)
 	if err != nil {
-		return fmt.Errorf("generating check SQL: %w", err)
+		return false, fmt.Errorf("generating check SQL: %w", err)
 	}
 
 	// 6. Generate list functions
 	listSQL, err := GenerateListSQL(analyses, inline, m.databaseSchema)
 	if err != nil {
-		return fmt.Errorf("generating list SQL: %w", err)
+		return false, fmt.Errorf("generating list SQL: %w", err)
 	}
 
-	// 7. Collect expected function names and checksums for tracking
+	// 7. Collect expected function names and checksums for tracking.
+	// Dispatchers are checksummed alongside specialized functions so that a
+	// codegen change altering only dispatcher SQL still defeats the phase 2
+	// skip below.
 	expectedFunctions := CollectFunctionNames(analyses)
 	namedFunctions := collectNamedFunctions(generatedSQL, listSQL, analyses)
+	namedFunctions = append(namedFunctions, collectDispatcherFunctions(generatedSQL, listSQL)...)
 	functionChecksums := ComputeFunctionChecksums(namedFunctions)
 
 	// 8. Handle dry-run mode
 	if opts.DryRun != nil {
 		m.outputDryRun(opts.DryRun, opts.Version, schemaChecksum, generatedSQL, listSQL, expectedFunctions)
-		return nil
+		return false, nil
 	}
 
 	// 9. Phase 2 skip: generated SQL is identical to what's already applied.
@@ -708,7 +734,12 @@ func (m *Migrator) MigrateWithTypesAndOptions(ctx context.Context, types []TypeD
 	// generated functions are byte-for-byte identical. Record the new version
 	// but skip re-applying the functions.
 	if !opts.Force && schemaChecksum != "" && shouldSkipApply(lastMigration, functionChecksums, expectedFunctions) {
-		return m.recordMigrationOnly(ctx, opts.Version, schemaChecksum, expectedFunctions, functionChecksums)
+		// Nothing changed at all (dev-build re-run that bypassed phase 1):
+		// pure no-op, don't insert a migration record per run.
+		if migrationRecordMatches(lastMigration, schemaChecksum) {
+			return true, nil
+		}
+		return false, m.recordMigrationOnly(ctx, opts.Version, schemaChecksum, expectedFunctions, functionChecksums)
 	}
 
 	// 10. Apply everything atomically
@@ -717,69 +748,69 @@ func (m *Migrator) MigrateWithTypesAndOptions(ctx context.Context, types []TypeD
 	}); ok {
 		tx, err := txer.BeginTx(ctx, nil)
 		if err != nil {
-			return fmt.Errorf("starting transaction: %w", err)
+			return false, fmt.Errorf("starting transaction: %w", err)
 		}
 		defer func() { _ = tx.Rollback() }()
 
 		// Apply migrations DDL (creates tracking table)
 		if err := m.applyMigrationsDDL(ctx, tx); err != nil {
-			return err
+			return false, err
 		}
 
 		// Get current functions before applying new ones (for orphan detection)
 		currentFunctions, err := m.getCurrentFunctions(ctx, tx)
 		if err != nil {
-			return fmt.Errorf("getting current functions: %w", err)
+			return false, fmt.Errorf("getting current functions: %w", err)
 		}
 
 		// Apply generated specialized check functions
 		if err := m.applyGeneratedSQL(ctx, tx, generatedSQL); err != nil {
-			return err
+			return false, err
 		}
 
 		// Apply generated specialized list functions
 		if err := m.applyGeneratedListSQL(ctx, tx, listSQL); err != nil {
-			return err
+			return false, err
 		}
 
 		// Drop orphaned functions
 		if err := m.dropOrphanedFunctions(ctx, tx, currentFunctions, expectedFunctions); err != nil {
-			return err
+			return false, err
 		}
 
 		// Record migration
 		if schemaChecksum != "" {
 			if err := m.insertMigrationRecord(ctx, tx, opts.Version, schemaChecksum, expectedFunctions, functionChecksums); err != nil {
-				return err
+				return false, err
 			}
 		}
 
-		return tx.Commit()
+		return false, tx.Commit()
 	}
 
 	// Fall back to non-transactional (for *sql.Conn)
 	if err := m.applyMigrationsDDL(ctx, m.db); err != nil {
-		return err
+		return false, err
 	}
 	currentFunctions, err := m.getCurrentFunctions(ctx, m.db)
 	if err != nil {
-		return fmt.Errorf("getting current functions: %w", err)
+		return false, fmt.Errorf("getting current functions: %w", err)
 	}
 	if err := m.applyGeneratedSQL(ctx, m.db, generatedSQL); err != nil {
-		return err
+		return false, err
 	}
 	if err := m.applyGeneratedListSQL(ctx, m.db, listSQL); err != nil {
-		return err
+		return false, err
 	}
 	if err := m.dropOrphanedFunctions(ctx, m.db, currentFunctions, expectedFunctions); err != nil {
-		return err
+		return false, err
 	}
 	if schemaChecksum != "" {
 		if err := m.insertMigrationRecord(ctx, m.db, opts.Version, schemaChecksum, expectedFunctions, functionChecksums); err != nil {
-			return err
+			return false, err
 		}
 	}
-	return nil
+	return false, nil
 }
 
 // outputDryRun writes the migration SQL to the provided writer.

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -589,16 +589,10 @@ func (m *Migrator) dropOrphanedFunctions(ctx context.Context, db Execer, current
 // applyMigrationsDDL creates the melange_migrations table if it doesn't exist.
 // Also applies any necessary column migrations for existing tables.
 func (m *Migrator) applyMigrationsDDL(ctx context.Context, db Execer) error {
-	if _, err := db.ExecContext(ctx, migrationsDDL(m.databaseSchema)); err != nil {
-		return fmt.Errorf("applying migrations DDL: %w", err)
-	}
-	// Add melange_version column if it doesn't exist (for existing tables)
-	if _, err := db.ExecContext(ctx, addMelangeVersionColumn(m.databaseSchema)); err != nil {
-		return fmt.Errorf("adding melange_version column: %w", err)
-	}
-	// Add function_checksums column if it doesn't exist (for existing tables)
-	if _, err := db.ExecContext(ctx, addFunctionChecksumsColumn(m.databaseSchema)); err != nil {
-		return fmt.Errorf("adding function_checksums column: %w", err)
+	for _, stmt := range migrationsTableDDL(m.databaseSchema) {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("applying migrations DDL: %w", err)
+		}
 	}
 	return nil
 }
@@ -833,11 +827,13 @@ func (m *Migrator) outputDryRun(w io.Writer, melangeVersion, schemaChecksum stri
 		_, _ = fmt.Fprintf(w, "-- ============================================================\n\n")
 	}
 
-	// Migrations DDL
+	// Migrations DDL (including column migrations for legacy tables)
 	_, _ = fmt.Fprintf(w, "-- ============================================================\n")
 	_, _ = fmt.Fprintf(w, "-- DDL: Migration Tracking Table\n")
 	_, _ = fmt.Fprintf(w, "-- ============================================================\n\n")
-	_, _ = fmt.Fprintf(w, "%s\n\n", migrationsDDL(m.databaseSchema))
+	for _, stmt := range migrationsTableDDL(m.databaseSchema) {
+		_, _ = fmt.Fprintf(w, "%s\n\n", stmt)
+	}
 
 	// Check functions
 	_, _ = fmt.Fprintf(w, "-- ============================================================\n")

--- a/pkg/migrator/migrator_test.go
+++ b/pkg/migrator/migrator_test.go
@@ -7,7 +7,18 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/pthm/melange/lib/version"
 )
+
+// withVersion temporarily overrides the build version so tests can exercise
+// release-build skip behavior (the test binary reports "dev").
+func withVersion(t *testing.T, v string) {
+	t.Helper()
+	prev := version.Version
+	version.Version = v
+	t.Cleanup(func() { version.Version = prev })
+}
 
 func TestNewMigrator(t *testing.T) {
 	m := NewMigrator(nil, "schemas/schema.fga")
@@ -96,12 +107,24 @@ func TestShouldSkipMigration(t *testing.T) {
 	})
 
 	t.Run("matching checksum and codegen version skips", func(t *testing.T) {
+		withVersion(t, "v9.9.9")
 		rec := &MigrationRecord{
 			SchemaChecksum: checksum,
 			CodegenVersion: CodegenVersion(),
 		}
 		if !shouldSkipMigration(rec, checksum) {
 			t.Error("should skip when checksum and codegen version match")
+		}
+	})
+
+	t.Run("dev build never skips phase 1", func(t *testing.T) {
+		withVersion(t, "dev")
+		rec := &MigrationRecord{
+			SchemaChecksum: checksum,
+			CodegenVersion: CodegenVersion(),
+		}
+		if shouldSkipMigration(rec, checksum) {
+			t.Error("dev builds must fall through to phase 2: codegen can change without a version bump")
 		}
 	})
 
@@ -166,6 +189,26 @@ func TestShouldSkipApply(t *testing.T) {
 		}
 		if !shouldSkipApply(rec, checksums, functions) {
 			t.Error("should skip when all checksums match and no orphans")
+		}
+	})
+
+	t.Run("changed dispatcher checksum does not skip", func(t *testing.T) {
+		// Dispatchers are checksummed alongside specialized functions
+		// (see MigrateWithTypesAndOptions step 7); a dispatcher-only codegen
+		// change must defeat the phase 2 skip.
+		current := map[string]string{
+			"check_doc_viewer": "hash_a",
+			"check_permission": "dispatcher_hash_new",
+		}
+		rec := &MigrationRecord{
+			FunctionNames: []string{"check_doc_viewer", "check_permission"},
+			FunctionChecksums: map[string]string{
+				"check_doc_viewer": "hash_a",
+				"check_permission": "dispatcher_hash_old",
+			},
+		}
+		if shouldSkipApply(rec, current, []string{"check_doc_viewer", "check_permission"}) {
+			t.Error("should not skip when only a dispatcher checksum changed")
 		}
 	})
 

--- a/test/codegen_test.go
+++ b/test/codegen_test.go
@@ -95,12 +95,16 @@ func TestCodegen_DispatcherRouting(t *testing.T) {
 
 	t.Logf("Internal dispatcher definition:\n%s", internalDispatcherDef)
 
-	// Verify the internal dispatcher contains specialized routing
-	// It should contain CASE statements for routing to specialized functions
+	// Verify the internal dispatcher contains specialized routing: an IF-chain
+	// of guarded RETURNs, one per (object_type, relation) pair.
 	assert.Contains(t, internalDispatcherDef, "check_organization_owner",
 		"internal dispatcher should route to check_organization_owner")
-	// Phase 5: Dispatcher returns 0 for unknown type/relation pairs (no generic fallback)
-	assert.Contains(t, internalDispatcherDef, "ELSE 0",
+	assert.Contains(t, internalDispatcherDef, "IF p_object_type = 'organization' THEN",
+		"internal dispatcher should nest dispatch by object type")
+	assert.Contains(t, internalDispatcherDef, "IF p_relation = 'owner' THEN",
+		"internal dispatcher should route relations within a type block")
+	// Dispatcher returns 0 for unknown type/relation pairs (no generic fallback)
+	assert.Contains(t, internalDispatcherDef, "RETURN 0;",
 		"internal dispatcher should return 0 for unknown type/relation pairs")
 
 	// Also verify the public check_permission delegates to internal

--- a/test/migrator_version_columns_test.go
+++ b/test/migrator_version_columns_test.go
@@ -111,6 +111,36 @@ type document
 			"file-based migrations must include column additions for legacy tables")
 	})
 
+	t.Run("re-migrate succeeds with a view over melange_migrations", func(t *testing.T) {
+		// The widen must be conditional: PostgreSQL rejects ALTER COLUMN TYPE
+		// (even a no-op TEXT->TEXT) when a view depends on the column. On a
+		// fresh install the version columns are already TEXT, so the widen must
+		// be skipped and a dependent view must not break re-migration.
+		db := testutil.EmptyDB(t)
+		_, err := db.ExecContext(ctx, `
+			CREATE TABLE melange_tuples (
+				subject_type TEXT NOT NULL,
+				subject_id TEXT NOT NULL,
+				relation TEXT NOT NULL,
+				object_type TEXT NOT NULL,
+				object_id TEXT NOT NULL
+			)`)
+		require.NoError(t, err)
+
+		_, err = migrator.MigrateWithOptions(ctx, db, schemaPath, migrator.MigrateOptions{Version: version.Version})
+		require.NoError(t, err)
+
+		_, err = db.ExecContext(ctx,
+			`CREATE VIEW mig_audit AS SELECT codegen_version, melange_version FROM melange_migrations`)
+		require.NoError(t, err)
+
+		_, err = migrator.MigrateWithOptions(ctx, db, schemaPath, migrator.MigrateOptions{
+			Version: version.Version,
+			Force:   true,
+		})
+		require.NoError(t, err, "re-migrate must not break on a view depending on melange_migrations")
+	})
+
 	t.Run("upgrade widens legacy varchar columns", func(t *testing.T) {
 		db := testutil.EmptyDB(t)
 		_, err := db.ExecContext(ctx, `

--- a/test/migrator_version_columns_test.go
+++ b/test/migrator_version_columns_test.go
@@ -1,0 +1,153 @@
+package test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pthm/melange/lib/version"
+	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/test/testutil"
+)
+
+// Module pseudo-versions from go-install builds (e.g.
+// "v0.8.4-0.20260701080815-8f95d5d39b90", 38+ chars) overflowed the original
+// codegen_version VARCHAR(32), failing every migrate with "value too long".
+// This covers both the fresh-install DDL (TEXT columns) and the upgrade path
+// (widenVersionColumns on a table created with the original VARCHAR DDL).
+func TestMigrate_PseudoVersionFitsVersionColumns(t *testing.T) {
+	prev := version.Version
+	version.Version = "v0.8.4-0.20260701080815-8f95d5d39b90+dirty"
+	t.Cleanup(func() { version.Version = prev })
+
+	schemaPath := filepath.Join(t.TempDir(), "schema.fga")
+	require.NoError(t, os.WriteFile(schemaPath, []byte(`model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: [user]
+`), 0o644))
+
+	ctx := context.Background()
+
+	t.Run("fresh install", func(t *testing.T) {
+		db := testutil.EmptyDB(t)
+		_, err := db.ExecContext(ctx, `
+			CREATE TABLE melange_tuples (
+				subject_type TEXT NOT NULL,
+				subject_id TEXT NOT NULL,
+				relation TEXT NOT NULL,
+				object_type TEXT NOT NULL,
+				object_id TEXT NOT NULL
+			)`)
+		require.NoError(t, err)
+
+		_, err = migrator.MigrateWithOptions(ctx, db, schemaPath, migrator.MigrateOptions{Version: version.Version})
+		require.NoError(t, err, "migrate with pseudo-version must succeed on a fresh install")
+
+		var got string
+		require.NoError(t, db.QueryRowContext(ctx,
+			`SELECT codegen_version FROM melange_migrations ORDER BY id DESC LIMIT 1`).Scan(&got))
+		require.Equal(t, version.Version, got)
+	})
+
+	t.Run("upgrade widens legacy varchar columns in named schema", func(t *testing.T) {
+		db := testutil.EmptyDB(t)
+		_, err := db.ExecContext(ctx, `CREATE SCHEMA authz`)
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, `
+			CREATE TABLE authz.melange_tuples (
+				subject_type TEXT NOT NULL,
+				subject_id TEXT NOT NULL,
+				relation TEXT NOT NULL,
+				object_type TEXT NOT NULL,
+				object_id TEXT NOT NULL
+			)`)
+		require.NoError(t, err)
+		_, err = db.ExecContext(ctx, `
+			CREATE TABLE authz.melange_migrations (
+				id SERIAL PRIMARY KEY,
+				migrated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				melange_version VARCHAR(64) NOT NULL DEFAULT '',
+				schema_checksum VARCHAR(64) NOT NULL,
+				codegen_version VARCHAR(32) NOT NULL,
+				function_names TEXT[] NOT NULL,
+				function_checksums JSONB NOT NULL DEFAULT '{}'
+			)`)
+		require.NoError(t, err)
+
+		_, err = migrator.MigrateWithOptions(ctx, db, schemaPath, migrator.MigrateOptions{
+			Version:        version.Version,
+			DatabaseSchema: "authz",
+		})
+		require.NoError(t, err, "migrate must widen legacy varchar columns in a named schema")
+
+		var dataType string
+		require.NoError(t, db.QueryRowContext(ctx, `
+			SELECT data_type FROM information_schema.columns
+			WHERE table_schema = 'authz' AND table_name = 'melange_migrations' AND column_name = 'codegen_version'`).Scan(&dataType))
+		require.Equal(t, "text", dataType)
+	})
+
+	t.Run("dry-run output includes column migrations", func(t *testing.T) {
+		db := testutil.EmptyDB(t)
+		var out strings.Builder
+		_, err := migrator.MigrateWithOptions(ctx, db, schemaPath, migrator.MigrateOptions{
+			Version: version.Version,
+			DryRun:  &out,
+		})
+		require.NoError(t, err)
+		sql := out.String()
+		require.Contains(t, sql, "ALTER COLUMN codegen_version TYPE TEXT",
+			"file-based migrations must widen legacy tables too")
+		require.Contains(t, sql, "ADD COLUMN IF NOT EXISTS function_checksums",
+			"file-based migrations must include column additions for legacy tables")
+	})
+
+	t.Run("upgrade widens legacy varchar columns", func(t *testing.T) {
+		db := testutil.EmptyDB(t)
+		_, err := db.ExecContext(ctx, `
+			CREATE TABLE melange_tuples (
+				subject_type TEXT NOT NULL,
+				subject_id TEXT NOT NULL,
+				relation TEXT NOT NULL,
+				object_type TEXT NOT NULL,
+				object_id TEXT NOT NULL
+			)`)
+		require.NoError(t, err)
+
+		// Recreate the original (pre-widening) tracking table shape.
+		_, err = db.ExecContext(ctx, `
+			CREATE TABLE melange_migrations (
+				id SERIAL PRIMARY KEY,
+				migrated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+				melange_version VARCHAR(64) NOT NULL DEFAULT '',
+				schema_checksum VARCHAR(64) NOT NULL,
+				codegen_version VARCHAR(32) NOT NULL,
+				function_names TEXT[] NOT NULL,
+				function_checksums JSONB NOT NULL DEFAULT '{}'
+			)`)
+		require.NoError(t, err)
+
+		_, err = migrator.MigrateWithOptions(ctx, db, schemaPath, migrator.MigrateOptions{Version: version.Version})
+		require.NoError(t, err, "migrate with pseudo-version must widen legacy varchar columns and succeed")
+
+		var dataType string
+		require.NoError(t, db.QueryRowContext(ctx, `
+			SELECT data_type FROM information_schema.columns
+			WHERE table_name = 'melange_migrations' AND column_name = 'codegen_version'`).Scan(&dataType))
+		require.Equal(t, "text", dataType)
+
+		var got string
+		require.NoError(t, db.QueryRowContext(ctx,
+			`SELECT codegen_version FROM melange_migrations ORDER BY id DESC LIMIT 1`).Scan(&got))
+		require.Equal(t, version.Version, got)
+	})
+}

--- a/test/openfgatests/testdata/userset_subject_listing.yaml
+++ b/test/openfgatests/testdata/userset_subject_listing.yaml
@@ -1,0 +1,88 @@
+# Melange-specific tests: userset-typed QUERY subjects in list_objects
+#
+# Regression coverage for issue #10: list_accessible_objects called with a
+# subject that is itself a userset (e.g. group:g2#member) under-reported
+# objects that check_permission allows, when access flowed through a
+# complex-closure relation (a relation wrapped by an exclusion/intersection).
+#
+# The userset query subject is named directly on a candidate-relation tuple
+# (group:g2#member is a viewer of doc:d1), but the complex-closure candidate
+# arm restricted candidates to concrete direct subject types (user), dropping
+# the userset subject. check_permission has full userset coverage, so the two
+# diverged. This case pins them back together.
+#
+# Test names are prefixed with "melange/" by the loader.
+
+tests:
+  - name: userset_subject_list_objects_complex_closure
+    stages:
+      - model: |
+          model
+            schema 1.1
+
+          type user
+
+          type group
+            relations
+              define member: [user]
+
+          type doc
+            relations
+              define viewer: [user, group#member]
+              define blocked: [user, group#member]
+              define can_read: viewer but not blocked
+        tuples:
+          # group:g2#member is granted viewer on d1 (userset subject reaching
+          # access through the complex-closure relation can_read = viewer but
+          # not blocked).
+          - user: group:g2#member
+            relation: viewer
+            object: doc:d1
+          # group:g2#member is granted viewer AND blocked on d3 -> can_read false.
+          - user: group:g2#member
+            relation: viewer
+            object: doc:d3
+          - user: group:g2#member
+            relation: blocked
+            object: doc:d3
+          # alice is a concrete member of g2 (plain-subject path must stay intact).
+          - user: user:alice
+            relation: member
+            object: group:g2
+        checkAssertions:
+          # The userset subject can_read d1 (viewer, not blocked).
+          - name: userset_subject_can_read_d1_allowed
+            tuple:
+              user: group:g2#member
+              relation: can_read
+              object: doc:d1
+            expectation: true
+          # The userset subject is blocked on d3 -> can_read false.
+          - name: userset_subject_can_read_d3_blocked
+            tuple:
+              user: group:g2#member
+              relation: can_read
+              object: doc:d3
+            expectation: false
+          # Plain member alice inherits can_read on d1 via group#member.
+          - name: alice_can_read_d1_allowed
+            tuple:
+              user: user:alice
+              relation: can_read
+              object: doc:d1
+            expectation: true
+        listObjectsAssertions:
+          # The bug: this returned [] before the fix; must return doc:d1.
+          - request:
+              user: group:g2#member
+              type: doc
+              relation: can_read
+            expectation:
+              - doc:d1
+          # Plain subject path unchanged: alice reads d1 via her group membership.
+          - request:
+              user: user:alice
+              type: doc
+              relation: can_read
+            expectation:
+              - doc:d1

--- a/test/openfgatests/testdata/wildcard_exclusion_listsubjects.yaml
+++ b/test/openfgatests/testdata/wildcard_exclusion_listsubjects.yaml
@@ -1,0 +1,95 @@
+# Melange-specific regression test: wildcard grant + exclusion in list_subjects.
+#
+# Regression for issue #11: when a relation allows a wildcard subject AND has an
+# exclusion (e.g. `admin: [user, user:*, group#member] but not blocked`), the
+# generated list_{type}_{relation}_sub function emitted an UNQUALIFIED subject_id
+# in the excluded_subjects CTE. Since the function returns TABLE(subject_id TEXT,
+# ...), that column collided with the OUT parameter and Postgres raised
+# "column reference subject_id is ambiguous" at query time.
+#
+# The listUsersAssertions below are EXPLICIT (not derived) so require.NoError
+# catches the ambiguous-column error: this case FAILS before the fix and PASSES
+# after it.
+#
+# Test names are prefixed with "melange/" by the loader.
+
+tests:
+  # ---------------------------------------------------------------------------
+  # wildcard_exclusion_list_subjects
+  # Pattern: admin: [user, user:*, group#member] but not blocked
+  # ---------------------------------------------------------------------------
+  - name: wildcard_exclusion_list_subjects
+    stages:
+      - model: |
+          model
+            schema 1.1
+
+          type user
+
+          type group
+            relations
+              define member: [user]
+
+          type org
+            relations
+              define blocked: [user]
+              define admin: [user, user:*, group#member] but not blocked
+        tuples:
+          # alice is a direct admin
+          - user: user:alice
+            relation: admin
+            object: org:o1
+          # everyone (wildcard) is an admin
+          - user: user:*
+            relation: admin
+            object: org:o1
+          # the g1 group's members are admins
+          - user: group:g1#member
+            relation: admin
+            object: org:o1
+          # gm1 is a member of g1
+          - user: user:gm1
+            relation: member
+            object: group:g1
+          # bob is blocked (excluded from admin)
+          - user: user:bob
+            relation: blocked
+            object: org:o1
+        checkAssertions:
+          - name: alice_is_admin_direct
+            tuple:
+              user: user:alice
+              relation: admin
+              object: org:o1
+            expectation: true
+          - name: gm1_is_admin_via_group
+            tuple:
+              user: user:gm1
+              relation: admin
+              object: org:o1
+            expectation: true
+          - name: carol_is_admin_via_wildcard
+            tuple:
+              user: user:carol
+              relation: admin
+              object: org:o1
+            expectation: true
+          - name: bob_is_not_admin_blocked
+            tuple:
+              user: user:bob
+              relation: admin
+              object: org:o1
+            expectation: false
+        listUsersAssertions:
+          # Explicit assertion — reproduces issue #11. The wildcard token
+          # (user:*) is returned alongside the direct + group-expanded concrete
+          # subjects; the blocked user (bob) is excluded.
+          - request:
+              object: org:o1
+              relation: admin
+              filters:
+                - user
+            expectation:
+              - user:*
+              - user:alice
+              - user:gm1

--- a/test/openfgatests/testdata/wildcard_ttu_listsubjects.yaml
+++ b/test/openfgatests/testdata/wildcard_ttu_listsubjects.yaml
@@ -1,0 +1,83 @@
+# Melange-specific regression test: wildcard reached via a TTU parent in
+# list_subjects.
+#
+# Regression: a relation can surface the wildcard token '*' either directly
+# (its own Features.HasWildcard) OR transitively through a TTU parent whose
+# target relation is wildcard-granted. The analyzer does NOT propagate
+# HasWildcard across TTU edges, so folder.viewer below had HasWildcard=false
+# even though `viewer from org` resolves to org.viewer=[user:*]. As a result
+# list_folder_viewer_sub (and the composed list_subjects path) filtered '*' out
+# of the parent-closure scan and never expanded the wildcard, so
+# list_accessible_subjects returned only concrete subjects — dropping every
+# subject who has access ONLY via the wildcard, while check_permission still
+# granted them.
+#
+# The listUsersAssertions below are EXPLICIT (not derived) so they hard-fail:
+# this case is RED before the fix (missing user:*) and GREEN after it.
+#
+# Test names are prefixed with "melange/" by the loader.
+
+tests:
+  - name: wildcard_ttu_list_subjects
+    stages:
+      - model: |
+          model
+            schema 1.1
+
+          type user
+
+          type group
+            relations
+              define member: [user]
+
+          type org
+            relations
+              define viewer: [user:*]
+
+          type folder
+            relations
+              define org: [org]
+              define viewer: [user, group#member] or viewer from org
+              define can_view: viewer
+        tuples:
+          # everyone (wildcard) is a viewer of org o1
+          - user: user:*
+            relation: viewer
+            object: org:o1
+          # folder f1 belongs to org o1
+          - user: org:o1
+            relation: org
+            object: folder:f1
+          # alice is a direct member of group g1
+          - user: user:alice
+            relation: member
+            object: group:g1
+          # g1's members are viewers of f1
+          - user: group:g1#member
+            relation: viewer
+            object: folder:f1
+        checkAssertions:
+          - name: alice_can_view_via_group
+            tuple:
+              user: user:alice
+              relation: can_view
+              object: folder:f1
+            expectation: true
+          - name: bob_can_view_via_wildcard
+            tuple:
+              user: user:bob
+              relation: can_view
+              object: folder:f1
+            expectation: true
+        listUsersAssertions:
+          # Explicit assertion. The wildcard token (user:*) must be returned
+          # alongside the group-expanded concrete subject (alice). Before the
+          # fix only user:alice came back — the TTU-reached wildcard was dropped.
+          - request:
+              object: folder:f1
+              relation: can_view
+              filters:
+                - user
+            expectation:
+              - user:*
+              - user:alice


### PR DESCRIPTION
Fixes the performance and correctness problems reported in #67 (30s `list_accessible_objects`, schema-size scaling), plus correctness bugs uncovered along the way.

## Measured impact (user's real workload — 91,663 tuples, PG16)

| Function | Before | After |
| --- | --- | --- |
| `list_accessible_objects` (base) | 3982 ms | ~12 ms (**~330×**) |
| `list_accessible_objects` (+50 rels) | 7769 ms | ~12 ms (**~650×**) |
| `list_accessible_subjects` | 170 ms | ~2 ms (**~85×**, and more correct) |

Schema-size scaling eliminated: dispatch is now O(1) in relation count.

## What changed

**Performance**
- **Nested IF-chain dispatcher** — schema-size-independent routing; replaces the per-relation `CASE` sub-expression that fell out of PL/pgSQL's simple-expression fast path.
- **Set-oriented composition** — replaces per-candidate `check_permission_internal` fan-out in the list functions with `IN (SELECT … list_*_obj/sub(…))` semi-joins, gated by a compile-time cycle/depth safety walk (`listCompositionSafe`).
- **Set-oriented anti-join** for complex exclusions in `list_objects`.
- **Per-relation inline VALUES filtering** for check/list functions; compile-time userset self-check folding.
- **`search_path` dropped** from dispatchers/wrappers (schema-qualified names only) and internal called directly.

**Correctness (pre-existing bugs found & fixed)**
- List userset query-subjects through the complex-closure arm — new `userset_subject_listing.yaml`.
- Qualify ambiguous `subject_id` in the wildcard+exclusion `list_subjects` path — new `wildcard_exclusion_listsubjects.yaml`.
- Surface TTU-reachable wildcards in `list_subjects` — new `wildcard_ttu_listsubjects.yaml`.
- Widen migration version columns to TEXT for go-install pseudo-versions, guarded so dependent views don't break re-migration.

## Validation
- `go build`, `go test ./lib/sqlgen/ ./pkg/migrator/`, full OpenFGA compatibility suite, and integration tests all green.
- Every list/check change verified against per-candidate ground truth on live PG16 (0 divergences on plain subjects across all strategies).
- Full-stack Fable code review: 4 real findings fixed, false positives verified, one pre-existing out-of-scope `list_objects` incompleteness logged as a follow-up.
