### PR TITLE
fix(sqlgen): route self-referential recursive TTU to recursive list strategy

### DIFF
--- a/lib/sqlgen/analysis/capabilities.go
+++ b/lib/sqlgen/analysis/capabilities.go
@@ -1,9 +1,11 @@
 // Package analysis provides relation analysis and strategy selection for SQL code generation.
 package analysis
 
+import "slices"
+
 // GenerationCapabilities represents the unified generation eligibility for a relation.
-// This consolidates the former separate CanGenerate (check) and CanGenerateListValue (list)
-// flags into a single structure with clear semantics.
+// CheckAllowed gates specialized check SQL; ListAllowed gates specialized list SQL.
+// When false, the respective dispatcher falls back to the generic implementation.
 type GenerationCapabilities struct {
 	// CheckAllowed is true if specialized check SQL can be generated.
 	// When false, the check dispatcher falls back to check_permission_generic_internal.
@@ -80,18 +82,37 @@ func (s ListStrategy) String() string {
 	}
 }
 
+// hasSelfReferentialParent reports whether the relation recurses on itself
+// through a TTU parent arm — i.e. an arm "R from L" where L links through the
+// relation's own object type AND R is the relation being defined (e.g.
+// "local_admin: admin from org or local_admin from parent"). Only that shape
+// chains across the parent edge and needs the Recursive strategy's CTE.
+//
+// An arm like "can_read: viewer from parent" (parent: [document, folder]) links
+// through the object type too, but its target relation is viewer, not can_read,
+// so it is a single hop — the Composed strategy handles it and the Recursive
+// CTE would wrongly chain can_read through the parent. Hence the R == a.Relation
+// guard, not a bare linking-type check.
+func hasSelfReferentialParent(a RelationAnalysis) bool {
+	isSelfRecursive := func(p ParentRelationInfo) bool {
+		return p.Relation == a.Relation && slices.Contains(p.AllowedLinkingTypes, a.ObjectType)
+	}
+	return slices.ContainsFunc(a.ParentRelations, isSelfRecursive) ||
+		slices.ContainsFunc(a.ClosureParentRelations, isSelfRecursive)
+}
+
 // DetermineListStrategy computes the appropriate list generation strategy
-// based on the relation's analysis data. The priority order matches the
-// former selectListObjectsTemplate/selectListSubjectsTemplate functions.
+// for a relation based on its analysis data.
 //
 // Priority (highest to lowest):
-// 1. DepthExceeded - relation exceeds userset depth limit
-// 2. SelfRefUserset - has self-referential userset patterns
-// 3. Composed - has indirect anchor (pure TTU reaching direct grants)
-// 4. Intersection - has intersection patterns (AND groups)
-// 5. Recursive - has TTU patterns or closure TTU patterns
-// 6. Userset - has userset patterns or closure userset patterns
-// 7. Direct - default (handles direct, implied, and exclusion patterns)
+//  1. DepthExceeded - relation exceeds userset depth limit
+//  2. SelfRefUserset - has self-referential userset patterns
+//  3. Composed - has indirect anchor (pure TTU reaching direct grants), but only
+//     when there is no self-referential recursive parent — see below.
+//  4. Intersection - has intersection patterns (AND groups)
+//  5. Recursive - has TTU patterns or closure TTU patterns
+//  6. Userset - has userset patterns or closure userset patterns
+//  7. Direct - default (handles direct, implied, and exclusion patterns)
 func DetermineListStrategy(a RelationAnalysis) ListStrategy {
 	if a.ExceedsDepthLimit {
 		return ListStrategyDepthExceeded
@@ -99,7 +120,14 @@ func DetermineListStrategy(a RelationAnalysis) ListStrategy {
 	if a.HasSelfReferentialUserset {
 		return ListStrategySelfRefUserset
 	}
-	if a.IndirectAnchor != nil {
+	// A relation like "local_admin: admin from org or local_admin from parent"
+	// is pure TTU, so an indirect anchor gets computed for the cross-type arm
+	// (admin from org). But the Composed strategy models a single anchor path
+	// and cannot represent the self-referential "local_admin from parent" walk,
+	// so it under-reports every object reached only through the parent chain.
+	// Route these to Recursive, whose CTE covers both the cross-type anchor base
+	// and the self-referential parent expansion.
+	if a.IndirectAnchor != nil && !hasSelfReferentialParent(a) {
 		return ListStrategyComposed
 	}
 	if a.Features.HasIntersection {

--- a/lib/sqlgen/list_objects_blocks_recursive.go
+++ b/lib/sqlgen/list_objects_blocks_recursive.go
@@ -101,8 +101,11 @@ func buildRecursiveBaseBlocks(plan ListPlan, parentRelations []ListParentRelatio
 		blocks = append(blocks, buildRecursiveUsersetBlocks(plan, pattern, propagatable)...)
 	}
 
-	// Cross-type TTU blocks are non-propagatable (one-hop, not self-referential).
-	blocks = append(blocks, buildCrossTypeTTUBlocks(plan, parentRelations)...)
+	// Cross-type TTU blocks are a one-hop grant of the outer relation. They must
+	// propagate when that relation is itself self-referential (e.g. "local_admin:
+	// admin from org or local_admin from parent"): the object granted via the
+	// cross-type "admin from org" arm has to seed the recursive parent walk.
+	blocks = append(blocks, buildCrossTypeTTUBlocks(plan, parentRelations, propagatable)...)
 
 	return blocks, nil
 }
@@ -301,13 +304,22 @@ func splitBlocksByPropagation(relations []string, propagatable map[string]bool, 
 // check_permission_internal for each one. Recursive parent list functions can
 // form cross-type list cycles, so those keep the check_permission_internal
 // fallback.
-func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelationData) []TypedQueryBlock {
+func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelationData, propagatable map[string]bool) []TypedQueryBlock {
 	var blocks []TypedQueryBlock
 
 	for _, parent := range parentRelations {
 		if !parent.HasCrossTypeLinks {
 			continue
 		}
+
+		// The cross-type arm grants the outer relation (plan.Relation), or the
+		// source relation it was inherited from for a closure pattern. Propagate
+		// the block when that relation seeds a self-referential parent walk.
+		grantedRel := plan.Relation
+		if parent.SourceRelation != "" {
+			grantedRel = parent.SourceRelation
+		}
+		propagate := propagatable[grantedRel]
 
 		crossTypes := dequoteLinkingRelations(parent.CrossTypeLinkingTypes)
 		crossExclusions := buildExclusionInput(
@@ -318,6 +330,11 @@ func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelation
 			SubjectID,
 		)
 
+		appendBlock := func(b TypedQueryBlock) {
+			b.Propagatable = propagate
+			blocks = append(blocks, b)
+		}
+
 		var fallbackTypes []string
 		for _, parentType := range crossTypes {
 			if canUseSubjectFirstTTU(plan, parent, parentType) {
@@ -326,16 +343,15 @@ func buildCrossTypeTTUBlocks(plan ListPlan, parentRelations []ListParentRelation
 				// its list function does not enumerate; keep a per-candidate
 				// check arm for exactly that case. The guard is false for
 				// plain subjects, so the check never runs on the hot path.
-				blocks = append(blocks,
-					buildSubjectFirstCrossTypeTTUBlock(plan, parent, parentType, crossExclusions),
-					buildCheckPermissionCrossTypeTTUBlock(plan, parent, []string{parentType}, crossExclusions, true))
+				appendBlock(buildSubjectFirstCrossTypeTTUBlock(plan, parent, parentType, crossExclusions))
+				appendBlock(buildCheckPermissionCrossTypeTTUBlock(plan, parent, []string{parentType}, crossExclusions, true))
 			} else {
 				fallbackTypes = append(fallbackTypes, parentType)
 			}
 		}
 
 		if len(fallbackTypes) > 0 {
-			blocks = append(blocks, buildCheckPermissionCrossTypeTTUBlock(plan, parent, fallbackTypes, crossExclusions, false))
+			appendBlock(buildCheckPermissionCrossTypeTTUBlock(plan, parent, fallbackTypes, crossExclusions, false))
 		}
 	}
 

--- a/lib/sqlgen/list_objects_blocks_recursive_test.go
+++ b/lib/sqlgen/list_objects_blocks_recursive_test.go
@@ -32,7 +32,7 @@ func TestBuildCrossTypeTTUBlocksUsesSubjectFirstParentList(t *testing.T) {
 		LinkingRelation:       "namespace",
 		CrossTypeLinkingTypes: "'namespace'",
 		HasCrossTypeLinks:     true,
-	}})
+	}}, nil)
 
 	if len(blocks) != 2 {
 		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))
@@ -87,7 +87,7 @@ func TestBuildCrossTypeTTUBlocksFallsBackForRecursiveParentList(t *testing.T) {
 		LinkingRelation:       "parent",
 		CrossTypeLinkingTypes: "'folder'",
 		HasCrossTypeLinks:     true,
-	}})
+	}}, nil)
 
 	if len(blocks) != 1 {
 		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
@@ -137,7 +137,7 @@ func TestBuildCrossTypeTTUBlocksVerifiesClosureSourceRelationWhenConstrained(t *
 		HasCrossTypeLinks:     true,
 		IsClosurePattern:      true,
 		SourceRelation:        "reader",
-	}})
+	}}, nil)
 
 	if len(blocks) != 2 {
 		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))
@@ -182,7 +182,7 @@ func TestBuildCrossTypeTTUBlocksSkipsClosureSourceCheckWhenUnconstrained(t *test
 		HasCrossTypeLinks:     true,
 		IsClosurePattern:      true,
 		SourceRelation:        "reader",
-	}})
+	}}, nil)
 
 	if len(blocks) != 2 {
 		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))
@@ -237,7 +237,7 @@ func TestBuildCrossTypeTTUBlocksFallbackVerifiesClosureSourceRelation(t *testing
 		HasCrossTypeLinks:     true,
 		IsClosurePattern:      true,
 		SourceRelation:        "reader",
-	}})
+	}}, nil)
 
 	if len(blocks) != 1 {
 		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 1", len(blocks))
@@ -284,7 +284,7 @@ func TestBuildCrossTypeTTUBlocksComposesAcyclicRecursiveParent(t *testing.T) {
 		LinkingRelation:       "workspace",
 		CrossTypeLinkingTypes: "'workspace'",
 		HasCrossTypeLinks:     true,
-	}})
+	}}, nil)
 
 	if len(blocks) != 2 {
 		t.Fatalf("buildCrossTypeTTUBlocks() returned %d blocks, want 2 (subject-first + userset-subject parity)", len(blocks))

--- a/lib/sqlgen/list_subjects_render_recursive.go
+++ b/lib/sqlgen/list_subjects_render_recursive.go
@@ -179,7 +179,15 @@ func buildParentClosureCTESQL(plan ListPlan) string {
 	}
 
 	// Recursive case: walk parent chains
-	// Join on the parent's subject (which becomes the new object to search from)
+	// Join on the parent's subject (which becomes the new object to search from).
+	//
+	// Only recurse OUT FROM nodes of the object's own type: the self-referential
+	// linking relation (e.g. folder.parent -> folder) drives the recursion, while
+	// cross-type linking relations (e.g. folder.org -> org) are one-hop terminals
+	// whose targets feed the grant lookup but must not recurse. Without the
+	// p.subject_type guard the walk would follow a cross-type target's OWN
+	// same-named linking relation (org:o1 -> parent -> org:o0), pulling in grants
+	// from unrelated ancestors and over-reporting subjects.
 	recursiveQuery := SelectStmt{
 		ColumnExprs: []Expr{
 			Col{Table: "link", Column: "subject_type"},
@@ -198,6 +206,7 @@ func buildParentClosureCTESQL(plan ListPlan) string {
 			),
 		}},
 		Where: And(
+			Eq{Left: Col{Table: "p", Column: "subject_type"}, Right: Lit(plan.ObjectType)},
 			In{Expr: Col{Table: "link", Column: "relation"}, Values: linkingRelations},
 			Lt{Left: Col{Table: "p", Column: "depth"}, Right: Int(25)},
 		),

--- a/test/openfgatests/testdata/recursive_ttu_crosstype_collision.yaml
+++ b/test/openfgatests/testdata/recursive_ttu_crosstype_collision.yaml
@@ -1,0 +1,86 @@
+# Melange regression probe for codex review finding P2 on the #12 fix:
+# when a mixed cross-type + self-recursive relation
+# (folder.local_admin = admin from org or local_admin from parent) is routed to
+# the Recursive list strategy, does list_subjects wrongly walk the CROSS-TYPE
+# target's OWN same-named linking relation?
+#
+# Here `org` also has a `parent` relation. folder.local_admin recurses over
+# folder's `parent` (folder -> folder). It must NOT traverse org:o1 -> parent ->
+# org:o0: admin-from-org is a single hop to the folder's DIRECT org, so bob
+# (admin of the grandparent org o0) must NOT be a local_admin of f1.
+#
+# Explicit assertions hard-fail. If the fix over-reports, listUsers for f1 will
+# wrongly include user:bob.
+
+tests:
+  - name: recursive_ttu_crosstype_collision
+    stages:
+      - model: |
+          model
+            schema 1.1
+
+          type user
+
+          type org
+            relations
+              define parent: [org]
+              define admin: [user]
+
+          type folder
+            relations
+              define org: [org]
+              define parent: [folder]
+              define local_admin: admin from org or local_admin from parent
+        tuples:
+          # alice is admin of org o1 (the folder's direct org)
+          - user: user:alice
+            relation: admin
+            object: org:o1
+          # bob is admin of org o0, the PARENT org of o1 (must be irrelevant)
+          - user: user:bob
+            relation: admin
+            object: org:o0
+          # o1's parent is o0 (org-side parent chain, unrelated to folder.local_admin)
+          - user: org:o0
+            relation: parent
+            object: org:o1
+          # folder f1 belongs to org o1
+          - user: org:o1
+            relation: org
+            object: folder:f1
+        checkAssertions:
+          - name: alice_is_local_admin_f1
+            tuple:
+              user: user:alice
+              relation: local_admin
+              object: folder:f1
+            expectation: true
+          - name: bob_not_local_admin_f1_via_org_parent
+            tuple:
+              user: user:bob
+              relation: local_admin
+              object: folder:f1
+            expectation: false
+        listObjectsAssertions:
+          - request:
+              user: user:alice
+              relation: local_admin
+              type: folder
+            expectation:
+              - folder:f1
+          # bob must list NO folders as local_admin
+          - request:
+              user: user:bob
+              relation: local_admin
+              type: folder
+            expectation: []
+        listUsersAssertions:
+          # Only alice (direct org admin). bob (grandparent-org admin) must NOT
+          # appear — that would be the over-report codex flagged.
+          - request:
+              object: folder:f1
+              relation: local_admin
+              filters:
+                - user
+            expectation:
+              - user:alice

--- a/test/openfgatests/testdata/recursive_ttu_listobjects.yaml
+++ b/test/openfgatests/testdata/recursive_ttu_listobjects.yaml
@@ -1,0 +1,102 @@
+# Melange-specific regression test: list_objects completeness for a relation
+# that combines a cross-type TTU with a self-referential recursive TTU (#12).
+#
+# folder.local_admin = admin from org or local_admin from parent
+#
+# A plain subject (alice) reaches local_admin on a deep folder purely through
+# the recursive `local_admin from parent` arm: she is admin of org o1, folder
+# f1 is in o1 (so alice is local_admin of f1 via `admin from org`), and folder
+# f2's parent is f1 (so alice is local_admin of f2 via `local_admin from
+# parent`). check_permission grants alice local_admin on BOTH f1 and f2, but
+# list_folder_local_admin_obj under-reports f2 — the recursive arm's candidate
+# generation does not carry the org-sourced grant across the parent edge.
+#
+# The listObjectsAssertions below are EXPLICIT (not derived) so they hard-fail:
+# RED before the fix (f2 missing), GREEN after.
+#
+# Test names are prefixed with "melange/" by the loader.
+
+tests:
+  - name: recursive_ttu_list_objects
+    stages:
+      - model: |
+          model
+            schema 1.1
+
+          type user
+
+          type org
+            relations
+              define admin: [user]
+
+          type folder
+            relations
+              define org: [org]
+              define parent: [folder]
+              define local_admin: admin from org or local_admin from parent
+        tuples:
+          # alice is admin of org o1
+          - user: user:alice
+            relation: admin
+            object: org:o1
+          # folder f1 belongs to org o1  -> alice is local_admin of f1
+          - user: org:o1
+            relation: org
+            object: folder:f1
+          # folder f2's parent is f1  -> alice is local_admin of f2 (recursive)
+          - user: folder:f1
+            relation: parent
+            object: folder:f2
+          # folder f3's parent is f2  -> alice is local_admin of f3 (2 hops)
+          - user: folder:f2
+            relation: parent
+            object: folder:f3
+        checkAssertions:
+          - name: alice_local_admin_f1
+            tuple:
+              user: user:alice
+              relation: local_admin
+              object: folder:f1
+            expectation: true
+          - name: alice_local_admin_f2_recursive
+            tuple:
+              user: user:alice
+              relation: local_admin
+              object: folder:f2
+            expectation: true
+          - name: alice_local_admin_f3_recursive
+            tuple:
+              user: user:alice
+              relation: local_admin
+              object: folder:f3
+            expectation: true
+        listObjectsAssertions:
+          # Explicit assertion. alice must list all three folders. Before the fix
+          # only f1 came back — f2/f3 (reached via `local_admin from parent`)
+          # were dropped even though check_permission grants them. f3 proves the
+          # walk is genuinely multi-hop, not a single parent step.
+          - request:
+              user: user:alice
+              relation: local_admin
+              type: folder
+            expectation:
+              - folder:f1
+              - folder:f2
+              - folder:f3
+        listUsersAssertions:
+          # Symmetric list_subjects direction: alice must surface as a
+          # local_admin of the recursively-reached f2, not just f1.
+          - request:
+              object: folder:f1
+              relation: local_admin
+              filters:
+                - user
+            expectation:
+              - user:alice
+          - request:
+              object: folder:f2
+              relation: local_admin
+              filters:
+                - user
+            expectation:
+              - user:alice


### PR DESCRIPTION
Stacked on #68 (base branch: `issue-67-performance`). Fixes a pre-existing `list_objects`/`list_subjects` completeness bug found while reconciling the #68 code-review findings — plus a latent over-report the fix exposed (caught by code review).

## The bug (under-report)

For a relation combining a cross-type TTU with a self-referential recursive TTU:

```fga
type folder
  relations
    define org: [org]
    define parent: [folder]
    define local_admin: admin from org or local_admin from parent
```

`check_permission` grants `local_admin` on a folder reached through the `parent` chain, but the list functions dropped it. Given `alice` admin of `org:o1`, `folder:f1` in `o1`, and `f2`→`f3` chained via `parent`, `list_objects` returned only `f1` (should be `f1, f2, f3`).

**Root cause:** `DetermineListStrategy` short-circuits to `ListStrategyComposed` whenever an `IndirectAnchor` exists — *before* the recursive check. The relation is pure TTU, so an anchor is computed for the cross-type `admin from org` arm and it routes to Composed, which models a single anchor path and cannot represent the self-referential `local_admin from parent` walk.

## The latent over-report (fixed here too)

Routing to the Recursive strategy exposed a bug in the recursive `list_subjects` `parent_closure` CTE: it followed **all** linking relations (`org`, `parent`) from **any** node. When the cross-type target (`org`) has its own `parent` relation, the walk went `org:o1 → parent → org:o0` and returned admins of the unrelated grandparent org. (Reported by the code reviewer as a P2; initially I judged it a false positive from static analysis, then the empirical test proved it real.)

## Fix

1. Gate the Composed branch with `!hasSelfReferentialParent(a)` so a relation with a genuinely self-referential recursive arm falls through to `ListStrategyRecursive` — whose CTE covers both the cross-type anchor base *and* the parent expansion. The predicate requires the parent arm's **target relation to be the defined relation itself** (`R == a.Relation`): `can_read: viewer from parent` links the object type too but targets `viewer` ≠ `can_read`, so it stays on Composed. (A bare linking-type check regressed `same_relation_name_different_type`.)
2. Propagate the recursive `list_objects` cross-type anchor block when the outer relation it grants seeds the self-referential walk.
3. Constrain the `list_subjects` `parent_closure` recursive step to only recurse out from the object's own type, so cross-type targets are one-hop terminals (fixes the over-report).

## Validation

- `recursive_ttu_listobjects.yaml` — 3-level chain (`f1→f2→f3`), explicit assertions in **both** list directions (RED→GREEN).
- `recursive_ttu_crosstype_collision.yaml` — cross-type target with its own `parent` relation; asserts the grandparent-org admin does **not** leak (RED→GREEN).
- Full OpenFGA compatibility suite ✓, integration suite ✓, `golangci-lint` 0 issues, code-simplifier clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
