### PR TITLE
fix(list_subjects): apply exclusion to TTU-composed arms in recursive path

### DIFF
--- a/internal/sqlgen/list_subjects_blocks_recursive.go
+++ b/internal/sqlgen/list_subjects_blocks_recursive.go
@@ -772,8 +772,13 @@ func buildSubjectFirstTTUSubjectBlocks(plan ListPlan, parent ListParentRelationD
 // is composable and cycle-safe. Wildcards are fine, as in
 // buildSubjectFirstTTUSubjectBlocks: the '*' this list_subjects surfaces flows
 // into base_results and is verified by the wildcard-completion tail rather than
-// kept unconditionally. The closure-pattern subject_pool block does not apply
-// plan.Exclusions, so neither does this replacement.
+// kept unconditionally.
+//
+// The composed list_subjects yields the source relation's positive subjects; the
+// outer relation's exclusion (`but not …`) still has to be subtracted or blocked
+// subjects reached through this arm leak into the result. Apply plan.Exclusions
+// here for exactly the same reason the sibling arms do — skip only when the
+// wildcard-completion tail re-validates every row (regularBranchTailValidated).
 func buildSubjectFirstTTUClosureSubjectBlocks(plan ListPlan, parent ListParentRelationData) []TypedQueryBlock {
 	if !composableListSubjectsTarget(plan, plan.ObjectType, parent.SourceRelation) {
 		return nil
@@ -789,6 +794,12 @@ func buildSubjectFirstTTUClosureSubjectBlocks(plan ListPlan, parent ListParentRe
 			Alias:  "sub",
 		},
 	}
+	if !regularBranchTailValidated(plan) {
+		exclusions := buildExclusionInput(plan.Analysis, plan.DatabaseSchema, ObjectID, SubjectType, Col{Table: "sub", Column: "subject_id"})
+		if preds := exclusions.BuildPredicates(); len(preds) > 0 {
+			stmt.Where = And(preds...)
+		}
+	}
 
 	return []TypedQueryBlock{{
 		Comments: []string{fmt.Sprintf("-- TTU subject-first: subjects via %s -> %s (closure pattern from %s - compose list_subjects)", parent.LinkingRelation, parent.Relation, parent.SourceRelation)},
@@ -801,6 +812,20 @@ func buildSubjectFirstTTUClosureSubjectBlocks(plan ListPlan, parent ListParentRe
 // enumerate the subjects holding parent.Relation on it via the parent's
 // list_subjects function.
 func buildSubjectFirstTTUSubjectBlock(plan ListPlan, parent ListParentRelationData, parentType string) TypedQueryBlock {
+	whereConditions := []Expr{
+		Eq{Left: Col{Table: "link", Column: "object_type"}, Right: Lit(plan.ObjectType)},
+		Eq{Left: Col{Table: "link", Column: "object_id"}, Right: ObjectID},
+		Eq{Left: Col{Table: "link", Column: "relation"}, Right: Lit(parent.LinkingRelation)},
+		Eq{Left: Col{Table: "link", Column: "subject_type"}, Right: Lit(parentType)},
+	}
+	// Subtract the outer relation's exclusion from the composed subjects; without
+	// it, subjects reached via this TTU arm bypass `but not …`. The
+	// wildcard-completion tail, when present, re-validates instead.
+	if !regularBranchTailValidated(plan) {
+		exclusions := buildExclusionInput(plan.Analysis, plan.DatabaseSchema, ObjectID, SubjectType, Col{Table: "sub", Column: "subject_id"})
+		whereConditions = append(whereConditions, exclusions.BuildPredicates()...)
+	}
+
 	stmt := SelectStmt{
 		Distinct:    true,
 		ColumnExprs: []Expr{Col{Table: "sub", Column: "subject_id"}},
@@ -814,12 +839,7 @@ func buildSubjectFirstTTUSubjectBlock(plan ListPlan, parent ListParentRelationDa
 				Alias:  "sub",
 			},
 		}},
-		Where: And(
-			Eq{Left: Col{Table: "link", Column: "object_type"}, Right: Lit(plan.ObjectType)},
-			Eq{Left: Col{Table: "link", Column: "object_id"}, Right: ObjectID},
-			Eq{Left: Col{Table: "link", Column: "relation"}, Right: Lit(parent.LinkingRelation)},
-			Eq{Left: Col{Table: "link", Column: "subject_type"}, Right: Lit(parentType)},
-		),
+		Where: And(whereConditions...),
 	}
 
 	return TypedQueryBlock{
@@ -877,6 +897,16 @@ func buildListSubjectsRecursiveTTUBlockSubjectPool(plan ListPlan, parent ListPar
 		comment = fmt.Sprintf("-- TTU: subjects via %s -> %s (complex parent relation - using subject_pool)", parent.LinkingRelation, parent.Relation)
 	}
 
+	// The per-row check validates the parent/source relation, which does not carry
+	// the outer relation's exclusion (`but not …`). Subtract plan.Exclusions so
+	// subjects reached through this arm can't bypass it; the wildcard-completion
+	// tail, when present, re-validates instead.
+	linkWhere = append(linkWhere, Raw(checkCallSQL))
+	if !regularBranchTailValidated(plan) {
+		exclusions := buildExclusionInput(plan.Analysis, plan.DatabaseSchema, ObjectID, SubjectType, Col{Table: "sp", Column: "subject_id"})
+		linkWhere = append(linkWhere, exclusions.BuildPredicates()...)
+	}
+
 	// Build the query: CROSS JOIN subject_pool with parent links, filter by permission check
 	stmt := SelectStmt{
 		Distinct:    true,
@@ -888,7 +918,7 @@ func buildListSubjectsRecursiveTTUBlockSubjectPool(plan ListPlan, parent ListPar
 			Table:  "melange_tuples",
 			Alias:  "link",
 		}},
-		Where: And(append(linkWhere, Raw(checkCallSQL))...),
+		Where: And(linkWhere...),
 	}
 
 	return TypedQueryBlock{
@@ -982,6 +1012,24 @@ func buildListSubjectsRecursiveUsersetFilterDirectBlock(plan ListPlan) TypedQuer
 	}
 }
 
+// usersetFilterFullCheck returns a check_permission guard validating that an
+// emitted userset subject actually satisfies the full target relation. The
+// userset-filter TTU arms are otherwise flat unions that never re-apply the
+// relation's exclusion, so a userset reached via a TTU/parent/nested hop but
+// excluded by `but not …` would leak (issue #80, userset-filter branch). The
+// direct userset-filter arm already carries this guard; the TTU arms did not.
+// Gated by the caller on plan.HasExclusion so non-exclusion relations keep their
+// pure-union SQL (and avoid the per-row check cost).
+func usersetFilterFullCheck(plan ListPlan, subjectID Expr) Expr {
+	return CheckPermission{
+		Schema:      plan.DatabaseSchema,
+		Subject:     SubjectRef{Type: Param("v_filter_type"), ID: subjectID},
+		Relation:    plan.Relation,
+		Object:      LiteralObject(plan.ObjectType, Param("p_object_id")),
+		ExpectAllow: true,
+	}
+}
+
 // buildListSubjectsRecursiveUsersetFilterTTUBlock builds the TTU path block for userset filter.
 func buildListSubjectsRecursiveUsersetFilterTTUBlock(plan ListPlan, parent ListParentRelationData) TypedQueryBlock {
 	closureRelStmt := SelectStmt{
@@ -1017,6 +1065,11 @@ func buildListSubjectsRecursiveUsersetFilterTTUBlock(plan ListPlan, parent ListP
 
 	if len(parent.AllowedLinkingTypesSlice) > 0 {
 		whereConditions = append(whereConditions, In{Expr: Col{Table: "link", Column: "subject_type"}, Values: parent.AllowedLinkingTypesSlice})
+	}
+
+	if plan.HasExclusion {
+		whereConditions = append(whereConditions, usersetFilterFullCheck(plan,
+			NormalizedUsersetSubject(Col{Table: "pt", Column: "subject_id"}, Param("v_filter_relation"))))
 	}
 
 	subjectExpr := Alias{Expr: NormalizedUsersetSubject(Col{Table: "pt", Column: "subject_id"}, Param("v_filter_relation")), Name: "subject_id"}
@@ -1069,6 +1122,11 @@ func buildListSubjectsRecursiveUsersetFilterTTUIntermediateBlock(plan ListPlan, 
 		whereConditions = append(whereConditions, In{Expr: Col{Table: "link", Column: "subject_type"}, Values: parent.AllowedLinkingTypesSlice})
 	}
 
+	if plan.HasExclusion {
+		whereConditions = append(whereConditions, usersetFilterFullCheck(plan,
+			Concat{Parts: []Expr{Col{Table: "link", Column: "subject_id"}, Lit("#"), Param("v_filter_relation")}}))
+	}
+
 	subjectExpr := Raw("link.subject_id || '#' || v_filter_relation AS subject_id")
 
 	stmt := SelectStmt{
@@ -1106,6 +1164,11 @@ func buildListSubjectsRecursiveUsersetFilterTTUNestedBlock(plan ListPlan, parent
 
 	if len(parent.AllowedLinkingTypesSlice) > 0 {
 		whereConditions = append(whereConditions, In{Expr: Col{Table: "link", Column: "subject_type"}, Values: parent.AllowedLinkingTypesSlice})
+	}
+
+	if plan.HasExclusion {
+		whereConditions = append(whereConditions, usersetFilterFullCheck(plan,
+			Col{Table: "nested", Column: "subject_id"}))
 	}
 
 	stmt := SelectStmt{

--- a/test/openfgatests/list_check_parity.go
+++ b/test/openfgatests/list_check_parity.go
@@ -1,0 +1,235 @@
+package openfgatests
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+	"testing"
+
+	openfgav1 "github.com/openfga/api/proto/openfga/v1"
+	"github.com/stretchr/testify/require"
+)
+
+// runListCheckParityAssertions cross-references every list assertion in the stage
+// against Check, so the two APIs are proven to agree on the same data. For each
+// ListObjects / ListUsers assertion it runs the list op and, over a candidate
+// universe drawn from the stage's tuples, asserts:
+//
+//   - list ⊆ check: every element the list returns is ALLOWED by Check. A denied
+//     element that the list still returns is an over-report — the class of bug in
+//     issue #80 (list_accessible_subjects returning subjects Check denies).
+//   - check ⊆ list: every universe candidate that Check ALLOWS is returned by the
+//     list. A candidate Check allows but the list omits is an under-report.
+//
+// The candidate universe is every "type:id" token that appears in the stage's
+// tuples (either side), which is exactly the set of subjects/objects that can
+// participate — enough to make the comparison exhaustive for these fixtures.
+//
+// Skipped (not failed), because faithfully replaying their semantics on the Check
+// side is out of scope and those paths are covered by other sweeps:
+//   - assertions with an error code (the list is expected to fail),
+//   - assertions with contextual tuples,
+//   - wildcard results ("type:*") — Check-cover semantics differ from element
+//     equality; a wildcard grant covers every subject of the type.
+func runListCheckParityAssertions(t *testing.T, ctx context.Context, client *Client, storeID, modelID string, stage *Stage) {
+	t.Helper()
+
+	tokens := collectTokensByType(stage.Tuples)
+
+	for i, a := range stage.ListObjectsAssertions {
+		t.Run(fmt.Sprintf("list_check_parity_objects_%d", i), func(t *testing.T) {
+			if a.ErrorCode != 0 || len(a.ContextualTuples) != 0 {
+				t.Skip("error-coded or contextual-tuple assertion — no Check parity contract")
+			}
+			resp, err := client.ListObjects(ctx, &openfgav1.ListObjectsRequest{
+				StoreId: storeID, AuthorizationModelId: modelID,
+				Type: a.Request.Type, Relation: a.Request.Relation, User: a.Request.User,
+			})
+			require.NoError(t, err)
+			got := resp.GetObjects()
+			if containsWildcard(got) {
+				t.Skip("wildcard result — Check-cover semantics out of scope")
+			}
+
+			// Universe: every object of the requested type, plus whatever the list
+			// returned and the assertion expected.
+			universe := map[string]bool{}
+			for _, id := range tokens[a.Request.Type] {
+				universe[a.Request.Type+":"+id] = true
+			}
+			for _, o := range got {
+				universe[o] = true
+			}
+			for _, o := range a.Expectation {
+				universe[o] = true
+			}
+
+			gotSet := toSet(got)
+			var over, under []string
+			for obj := range universe {
+				if strings.HasSuffix(obj, ":*") {
+					continue
+				}
+				allowed := checkAllowed(t, ctx, client, storeID, modelID, a.Request.User, a.Request.Relation, obj)
+				if gotSet[obj] && !allowed {
+					over = append(over, obj)
+				}
+				if allowed && !gotSet[obj] {
+					under = append(under, obj)
+				}
+			}
+			sort.Strings(over)
+			sort.Strings(under)
+			require.Empty(t, over,
+				"list_objects OVER-reports vs check: user=%s relation=%s type=%s returned-but-check-denies=%v",
+				a.Request.User, a.Request.Relation, a.Request.Type, over)
+			require.Empty(t, under,
+				"list_objects UNDER-reports vs check: user=%s relation=%s type=%s check-allows-but-missing=%v",
+				a.Request.User, a.Request.Relation, a.Request.Type, under)
+		})
+	}
+
+	for i, a := range stage.ListUsersAssertions {
+		t.Run(fmt.Sprintf("list_check_parity_users_%d", i), func(t *testing.T) {
+			if a.ErrorCode != 0 || len(a.ContextualTuples) != 0 {
+				t.Skip("error-coded or contextual-tuple assertion — no Check parity contract")
+			}
+			objType, objID, ok := strings.Cut(a.Request.Object, ":")
+			if !ok {
+				t.Skipf("unparseable object %q", a.Request.Object)
+			}
+			filters := make([]*openfgav1.UserTypeFilter, 0, len(a.Request.Filters))
+			for _, f := range a.Request.Filters {
+				filters = append(filters, parseUserTypeFilter(f))
+			}
+			resp, err := client.ListUsers(ctx, &openfgav1.ListUsersRequest{
+				StoreId: storeID, AuthorizationModelId: modelID,
+				Object:      &openfgav1.Object{Type: objType, Id: objID},
+				Relation:    a.Request.Relation,
+				UserFilters: filters,
+			})
+			require.NoError(t, err)
+
+			var got []string
+			for _, u := range resp.GetUsers() {
+				if s := userString(u); s != "" {
+					got = append(got, s)
+				}
+			}
+			if containsWildcard(got) {
+				t.Skip("wildcard result — Check-cover semantics out of scope")
+			}
+
+			// Universe: for each requested filter, every candidate subject of that
+			// filter's shape (concrete "type:id" or userset "type:id#relation")
+			// drawn from the tuple tokens, plus the list result and expectation.
+			universe := map[string]bool{}
+			for _, f := range a.Request.Filters {
+				ftype, frel, isUserset := strings.Cut(f, "#")
+				for _, id := range tokens[ftype] {
+					if isUserset {
+						universe[ftype+":"+id+"#"+frel] = true
+					} else {
+						universe[ftype+":"+id] = true
+					}
+				}
+			}
+			for _, u := range got {
+				universe[u] = true
+			}
+			for _, u := range a.Expectation {
+				universe[u] = true
+			}
+
+			gotSet := toSet(got)
+			var over, under []string
+			for subj := range universe {
+				if strings.HasSuffix(subj, ":*") {
+					continue
+				}
+				allowed := checkAllowedSubject(t, ctx, client, storeID, modelID, subj, a.Request.Relation, a.Request.Object)
+				if gotSet[subj] && !allowed {
+					over = append(over, subj)
+				}
+				if allowed && !gotSet[subj] {
+					under = append(under, subj)
+				}
+			}
+			sort.Strings(over)
+			sort.Strings(under)
+			require.Empty(t, over,
+				"list_users OVER-reports vs check: object=%s relation=%s filters=%v returned-but-check-denies=%v",
+				a.Request.Object, a.Request.Relation, a.Request.Filters, over)
+			require.Empty(t, under,
+				"list_users UNDER-reports vs check: object=%s relation=%s filters=%v check-allows-but-missing=%v",
+				a.Request.Object, a.Request.Relation, a.Request.Filters, under)
+		})
+	}
+}
+
+// collectTokensByType returns, per type, the set of ids that appear in any tuple
+// (either the user or object side). Userset subjects ("group:g#member") contribute
+// their base id ("g" under type "group"); wildcards ("user:*") are dropped.
+func collectTokensByType(tuples []*openfgav1.TupleKey) map[string][]string {
+	sets := map[string]map[string]bool{}
+	add := func(tok string) {
+		if tok == "" {
+			return
+		}
+		if h := strings.IndexByte(tok, '#'); h != -1 {
+			tok = tok[:h] // strip "#relation" from a userset subject
+		}
+		typ, id, ok := strings.Cut(tok, ":")
+		if !ok || id == "" || id == "*" {
+			return
+		}
+		if sets[typ] == nil {
+			sets[typ] = map[string]bool{}
+		}
+		sets[typ][id] = true
+	}
+	for _, tp := range tuples {
+		add(tp.GetUser())
+		add(tp.GetObject())
+	}
+	out := map[string][]string{}
+	for typ, ids := range sets {
+		for id := range ids {
+			out[typ] = append(out[typ], id)
+		}
+		sort.Strings(out[typ])
+	}
+	return out
+}
+
+func checkAllowed(t *testing.T, ctx context.Context, client *Client, storeID, modelID, user, relation, object string) bool {
+	return checkAllowedSubject(t, ctx, client, storeID, modelID, user, relation, object)
+}
+
+func checkAllowedSubject(t *testing.T, ctx context.Context, client *Client, storeID, modelID, subject, relation, object string) bool {
+	t.Helper()
+	resp, err := client.Check(ctx, &openfgav1.CheckRequest{
+		StoreId: storeID, AuthorizationModelId: modelID,
+		TupleKey: &openfgav1.CheckRequestTupleKey{User: subject, Relation: relation, Object: object},
+	})
+	require.NoError(t, err, "check %s#%s@%s", subject, relation, object)
+	return resp.GetAllowed()
+}
+
+func toSet(xs []string) map[string]bool {
+	s := make(map[string]bool, len(xs))
+	for _, x := range xs {
+		s[x] = true
+	}
+	return s
+}
+
+func containsWildcard(xs []string) bool {
+	for _, x := range xs {
+		if strings.HasSuffix(x, ":*") {
+			return true
+		}
+	}
+	return false
+}

--- a/test/openfgatests/runner.go
+++ b/test/openfgatests/runner.go
@@ -714,6 +714,13 @@ func RunTest(t *testing.T, parent *Client, tc TestCase) {
 				// Sentinel responses (relation not yet eligible for
 				// Expand) skip — see expand_parity.go.
 				runExpandParityAssertions(t, ctx, client, storeID, modelID, stage.ListObjectsAssertions)
+
+				// Cross-reference every list assertion against Check: the list
+				// result and Check must agree on the same data, both directions
+				// (no over- or under-report). This is the list -> check mirror of
+				// the derived-assertion sweep (check -> list), over a tuple-derived
+				// candidate universe. See list_check_parity.go.
+				runListCheckParityAssertions(t, ctx, client, storeID, modelID, stage)
 			})
 		}
 	})

--- a/test/openfgatests/testdata/exclusion_recursive_ttu_listsubjects.yaml
+++ b/test/openfgatests/testdata/exclusion_recursive_ttu_listsubjects.yaml
@@ -1,0 +1,151 @@
+# Regression tests for issue #80:
+# list_accessible_subjects returned subjects that check_permission denies when a
+# `but not` relation's positive base reached subjects through a recursive TTU
+# combined with a second arm (cross-type TTU or nested userset). The subject-first
+# TTU compose blocks enumerated the source relation's subjects without subtracting
+# the outer exclusion, so blocked subjects leaked into the list.
+#
+# The harness derives list_subjects (ListUsers) assertions from the checkAssertions
+# below (DENY -> must-not-contain), which is what catches the leak; the explicit
+# listUsersAssertions pin the full expected set.
+
+tests:
+  # Issue #80 canonical repro: recursive TTU (viewer from parent) + cross-type TTU
+  # (member from org), all behind `viewer but not blocked`.
+  - name: recursive_ttu_exclusion_listsubjects
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type org
+            relations
+              define member: [user]
+          type folder
+            relations
+              define org: [org]
+              define parent: [folder]
+              define viewer: [user] or viewer from parent or member from org
+              define blocked: [user]
+              define can_see: viewer but not blocked
+        tuples:
+          - {user: user:alice, relation: member, object: org:o1}
+          - {user: org:o1, relation: org, object: folder:f1}
+          - {user: user:alice, relation: blocked, object: folder:f1}
+          - {user: user:bob, relation: viewer, object: folder:f1}
+          - {user: user:bob, relation: blocked, object: folder:f1}
+          - {user: user:carol, relation: member, object: org:o1}
+        checkAssertions:
+          - {name: alice_denied, tuple: {user: user:alice, relation: can_see, object: folder:f1}, expectation: false}
+          - {name: bob_denied, tuple: {user: user:bob, relation: can_see, object: folder:f1}, expectation: false}
+          - {name: carol_allowed, tuple: {user: user:carol, relation: can_see, object: folder:f1}, expectation: true}
+        listUsersAssertions:
+          - name: can_see_of_folder_f1
+            request: {object: folder:f1, relation: can_see, filters: [user]}
+            expectation: [user:carol]
+
+  # Isolated cross-type TTU leak: alice/dave reach viewer via member-from-org and
+  # are blocked; carol reaches it via member-from-org and is not.
+  - name: recursive_ttu_crosstype_exclusion_listsubjects
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type org
+            relations
+              define member: [user]
+          type folder
+            relations
+              define org: [org]
+              define parent: [folder]
+              define viewer: [user] or viewer from parent or member from org
+              define blocked: [user]
+              define can_see: viewer but not blocked
+        tuples:
+          - {user: folder:f0, relation: parent, object: folder:f1}
+          - {user: org:o1, relation: org, object: folder:f1}
+          - {user: user:alice, relation: viewer, object: folder:f0}
+          - {user: user:alice, relation: blocked, object: folder:f1}
+          - {user: user:dave, relation: member, object: org:o1}
+          - {user: user:dave, relation: blocked, object: folder:f1}
+          - {user: user:carol, relation: member, object: org:o1}
+        checkAssertions:
+          - {name: blocked_via_parent_denied, tuple: {user: user:alice, relation: can_see, object: folder:f1}, expectation: false}
+          - {name: blocked_via_org_denied, tuple: {user: user:dave, relation: can_see, object: folder:f1}, expectation: false}
+          - {name: unblocked_allowed, tuple: {user: user:carol, relation: can_see, object: folder:f1}, expectation: true}
+        listUsersAssertions:
+          - name: can_see_of_folder_f1
+            request: {object: folder:f1, relation: can_see, filters: [user]}
+            expectation: [user:carol]
+
+  # Isolated nested-userset leak: bob reaches viewer via a self-referential
+  # grp#member chain and is blocked; carol reaches it via the same chain and is not.
+  - name: recursive_ttu_nested_userset_exclusion_listsubjects
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type grp
+            relations
+              define member: [user, grp#member]
+          type folder
+            relations
+              define parent: [folder]
+              define viewer: [user, grp#member] or viewer from parent
+              define blocked: [user]
+              define can_see: viewer but not blocked
+        tuples:
+          - {user: folder:f0, relation: parent, object: folder:f1}
+          - {user: user:alice, relation: viewer, object: folder:f0}
+          - {user: user:alice, relation: blocked, object: folder:f1}
+          - {user: "grp:g1#member", relation: viewer, object: folder:f1}
+          - {user: "grp:g2#member", relation: member, object: grp:g1}
+          - {user: user:bob, relation: member, object: grp:g2}
+          - {user: user:bob, relation: blocked, object: folder:f1}
+          - {user: user:carol, relation: member, object: grp:g2}
+        checkAssertions:
+          - {name: blocked_via_parent_denied, tuple: {user: user:alice, relation: can_see, object: folder:f1}, expectation: false}
+          - {name: blocked_via_nested_userset_denied, tuple: {user: user:bob, relation: can_see, object: folder:f1}, expectation: false}
+          - {name: unblocked_allowed, tuple: {user: user:carol, relation: can_see, object: folder:f1}, expectation: true}
+        listUsersAssertions:
+          - name: can_see_of_folder_f1
+            request: {object: folder:f1, relation: can_see, filters: [user]}
+            expectation: [user:carol]
+
+  # Same bug class on the USERSET-FILTER branch of the recursive list_subjects
+  # path (querying with a grp#member filter). The TTU/parent/nested arms of that
+  # branch enumerated usersets without re-applying the exclusion, so a userset that
+  # reaches `viewer` via parent-recursion but is `blocked` leaked. grp:g1#member is
+  # viewer of f1 via parent(f0) and blocked -> excluded; grp:g2#member is a direct
+  # viewer and not blocked -> present.
+  - name: recursive_ttu_exclusion_usersetfilter_listsubjects
+    stages:
+      - model: |
+          model
+            schema 1.1
+          type user
+          type grp
+            relations
+              define member: [user, grp#member]
+          type folder
+            relations
+              define parent: [folder]
+              define viewer: [grp#member] or viewer from parent
+              define blocked: [grp#member]
+              define can_see: viewer but not blocked
+        tuples:
+          - {user: folder:f0, relation: parent, object: folder:f1}
+          - {user: "grp:g1#member", relation: viewer, object: folder:f0}
+          - {user: "grp:g1#member", relation: blocked, object: folder:f1}
+          - {user: "grp:g2#member", relation: viewer, object: folder:f1}
+          - {user: user:a, relation: member, object: grp:g1}
+          - {user: user:b, relation: member, object: grp:g2}
+        checkAssertions:
+          - {name: blocked_userset_denied, tuple: {user: "grp:g1#member", relation: can_see, object: folder:f1}, expectation: false}
+          - {name: unblocked_userset_allowed, tuple: {user: "grp:g2#member", relation: can_see, object: folder:f1}, expectation: true}
+        listUsersAssertions:
+          - name: can_see_usersets_of_folder_f1
+            request: {object: folder:f1, relation: can_see, filters: [grp#member]}
+            expectation: ["grp:g2#member"]


### PR DESCRIPTION
Fixes #80.

## Problem

`list_accessible_subjects` returned subjects that `check_permission` denies when a `but not` relation's positive base reached subjects through a recursive TTU combined with a second arm (cross-type TTU or nested userset). The subject-first / compose arms of the recursive `list_subjects` codegen enumerated the source relation's subjects without re-applying the outer relation's exclusion, so blocked subjects leaked into the list.

The reporter isolated the boundary precisely: pure-recursion and flat-userset variants passed (they route through the parent-closure arm, which already subtracts the exclusion); adding a cross-type TTU or a nested userset triggered the leaking compose arm.

## Fix

Two branches of `internal/sqlgen/list_subjects_blocks_recursive.go` were affected:

1. **Concrete-subject branch** (issue #80): apply `plan.Exclusions` to the three subject-first / compose arms that previously emitted `SELECT sub.subject_id FROM list_x_y_sub(...)` (or a source-relation `check_permission`) with no exclusion — `buildSubjectFirstTTUClosureSubjectBlocks`, `buildSubjectFirstTTUSubjectBlock`, `buildListSubjectsRecursiveTTUBlockSubjectPool` — gated on `!regularBranchTailValidated(plan)` (same guard the sibling arms use).

2. **Userset-filter branch** (found by a follow-up correctness scan): the `group#member`-filtered path had the same class of leak in its TTU / intermediate / nested arms, which had no validation while the direct arm did. Added a full-relation `check_permission` guard (`usersetFilterFullCheck`) to those three arms, gated on `plan.HasExclusion`.

## Tests

- New regression cases in `test/openfgatests/testdata/exclusion_recursive_ttu_listsubjects.yaml`: the issue-80 canonical repro, isolated cross-type-TTU, isolated nested-userset, and the userset-filter variant. Each verified to fail without the fix and pass with it.
- New **list↔check parity sweep** (`test/openfgatests/list_check_parity.go`): for every `ListObjects` / `ListUsers` assertion in the suite, the list result is now cross-checked against `check` bidirectionally over a tuple-derived candidate universe (list ⊆ check and check ⊆ list). Runs 1328 parity subtests across the suite (both schemas), all aligned; verified it independently catches the over-report when the fix is removed.

Full OpenFGA integration suite (both `public` and `melange` schemas) and all module unit tests pass.

## Performance

For relations without an exclusion the generated SQL is byte-identical (empty exclusion predicates). For the affected shape, a scaled benchmark (500 org members, half blocked) showed latency impact within noise (~1.4%); memory/allocs roughly halve because the correct result set is smaller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)