### PR TITLE
docs(blog): add release notes for v0.9.0, v0.9.1, v0.9.2

### DIFF
--- a/docs/content/blog/v0.9.0.md
+++ b/docs/content/blog/v0.9.0.md
@@ -1,0 +1,56 @@
+---
+title: "Melange v0.9.0"
+date: 2026-08-17
+authors:
+  - name: pthm
+    link: https://github.com/pthm
+    image: https://github.com/pthm.png
+tags:
+  - Release
+---
+
+Melange v0.9.0 restructures the repository into a cleaner module layout and, as part of that, **changes how the CLI is installed**. There are no runtime or generated-SQL changes — your Check and List call sites, and the SQL `melange migrate` emits, are unchanged.
+
+<!--more-->
+
+{{< callout type="warning" >}}
+**Breaking:** the CLI install path changed. Install with `go install github.com/pthm/melange@latest` — the old `go install github.com/pthm/melange/cmd/melange@latest` no longer works. See [Migration](#migration) below.
+{{< /callout >}}
+
+## What changed
+
+- **The CLI now lives in the root module.** `cmd/melange` has been collapsed into the repository root and retired to a deprecated error-shim; its prior versions are retracted. Installing or building the CLI now uses the root module path.
+- **Internal packages are sealed.** The old `lib/` tree moved under `internal/`, so only melange's own code depends on it. The public surface is the `melange` runtime package and the CLI — nothing else is importable.
+- **The test suite is its own module.** `test/` was extracted into a separate module so its heavy test-only dependencies (the OpenFGA oracle, testcontainers) no longer weigh on anyone importing the runtime.
+- **Release plumbing simplified.** The redundant `VERSION` file and the three-stage `cmd/melange` publish step were dropped.
+
+## Migration
+
+Update how you install the CLI:
+
+```bash
+# Old (no longer works)
+go install github.com/pthm/melange/cmd/melange@latest
+
+# New
+go install github.com/pthm/melange@latest
+```
+
+Homebrew, the container image, and the `.deb` / `.rpm` packages are unaffected:
+
+```bash
+brew install pthm/melange/melange
+docker pull ghcr.io/pthm/melange:v0.9.0
+```
+
+The Go runtime import path is unchanged:
+
+```bash
+go get github.com/pthm/melange/melange@v0.9.0
+```
+
+There are no schema, API, or generated-SQL changes in this release — nothing to re-migrate.
+
+## Feedback
+
+[Open an issue](https://github.com/pthm/melange/issues) for bug reports or feature requests.

--- a/docs/content/blog/v0.9.1.md
+++ b/docs/content/blog/v0.9.1.md
@@ -1,0 +1,28 @@
+---
+title: "Melange v0.9.1"
+date: 2026-08-17
+authors:
+  - name: pthm
+    link: https://github.com/pthm
+    image: https://github.com/pthm.png
+tags:
+  - Release
+---
+
+Melange v0.9.1 is a build fix: `go install github.com/pthm/melange@latest` now resolves and builds cleanly. If you install the CLI from source, upgrade past v0.9.0.
+
+<!--more-->
+
+## The fix
+
+v0.9.0 carried a `replace` directive for `google.golang.org/genproto` in the root `go.mod`. `go install` ignores `replace` directives in the module being installed, so installing the CLI from source failed to resolve dependencies. The directive has been moved out of the root module, so `go install` works again.
+
+```bash
+go install github.com/pthm/melange@latest
+```
+
+No runtime, schema, or generated-SQL changes — nothing to re-migrate.
+
+## Feedback
+
+[Open an issue](https://github.com/pthm/melange/issues) for bug reports or feature requests.

--- a/docs/content/blog/v0.9.2.md
+++ b/docs/content/blog/v0.9.2.md
@@ -1,0 +1,86 @@
+---
+title: "Melange v0.9.2"
+date: 2026-08-18
+authors:
+  - name: pthm
+    link: https://github.com/pthm
+    image: https://github.com/pthm.png
+tags:
+  - Release
+---
+
+Melange v0.9.2 fixes a correctness bug where `ListSubjects` could return subjects that `Check` denies — a `but not` exclusion was dropped for subjects reached through certain tuple-to-userset paths. It also adds a suite-wide parity test that pins `ListObjects` / `ListSubjects` to `Check` so this class of bug can't come back unnoticed. The fix is in generated SQL; run `melange migrate` to pick it up.
+
+<!--more-->
+
+{{< callout type="info" >}}
+No breaking changes from v0.9.1, and no API changes. The fix is in generated SQL — run `melange migrate` to regenerate. Relations without a `but not` exclusion compile to byte-identical SQL, so only exclusion relations change.
+{{< /callout >}}
+
+## The bug
+
+Reported as [#80](https://github.com/pthm/melange/issues/80): for a relation like `can_see: viewer but not blocked`, `ListSubjects` returned subjects that `Check` correctly denied. The divergence only appeared when `viewer`'s positive side reached subjects through a **recursive tuple-to-userset** (`viewer from parent`) *combined with* a second path — a **cross-type TTU** (`member from org`) or a **nested userset** (`group#member` over a self-referential group). A blocked subject reachable via one of those paths leaked into the list even though `Check` denied it.
+
+The reporter isolated the boundary precisely: pure recursion and flat usersets were fine; it was the combination that broke.
+
+## Root cause
+
+`ListSubjects` builds its result as a union of "arms", one per way a subject can be reached (direct grant, computed relation, parent recursion, cross-type TTU, userset expansion). Most arms already subtract the relation's exclusion. But the arms that reach subjects by **composing another relation's subject list** — the subject-first TTU arms — enumerated that source relation's subjects *without* re-applying the outer `but not`. Two branches of the recursive `list_subjects` generator had this gap:
+
+- the **concrete-subject** branch (the originally reported case), and
+- the **userset-filter** branch (`group#member`-style queries), found by a follow-up scan across the codebase.
+
+Both now apply the exclusion — the concrete-subject arms subtract it directly, and the userset-filter arms validate each candidate against the full relation — so every arm agrees with `Check`.
+
+## Catching the whole class
+
+The single reported bug pointed at a general risk: any list arm that composes another relation could drop a filter. To close that off, v0.9.2 adds a **list-vs-check parity sweep** to the test suite. For every `ListObjects` and `ListUsers` assertion across the whole conformance corpus, it also runs the list operation and compares the result against `Check`, in both directions, over the full set of subjects and objects in the fixture:
+
+- **no over-reporting** — every subject/object the list returns is allowed by `Check` (the exact bug shape above), and
+- **no under-reporting** — every candidate `Check` allows is returned by the list.
+
+`Check` is the oracle here — it is already pinned against real OpenFGA — so any drift between the list functions and `Check` now fails the suite. This runs on every existing case with no per-test bookkeeping: 1300+ parity checks across both database schemas, all aligned.
+
+## Performance
+
+The added exclusion is a filter the correct answer always needed. Relations without an exclusion generate byte-identical SQL. On a scaled benchmark of the fixed shape (hundreds of members, half of them blocked), the extra `NOT EXISTS` cost was within measurement noise — and the correct result set is smaller, so it moves fewer rows.
+
+## Migration
+
+No breaking changes from v0.9.1. Regenerate the functions:
+
+```bash
+melange migrate
+```
+
+If you emit migration files, regenerate to pick up the corrected SQL:
+
+```bash
+melange generate migration \
+  --schema melange/schema.fga \
+  --output db/migrations \
+  --git-ref main
+```
+
+## Try it out
+
+```bash
+# Install / upgrade CLI
+brew install pthm/melange/melange
+
+# Or pull the container image
+docker pull ghcr.io/pthm/melange:v0.9.2
+
+# Regenerate and apply the corrected functions
+melange migrate
+
+# Go runtime
+go get github.com/pthm/melange/melange@v0.9.2
+
+# TypeScript runtime
+npm install @pthm/melange
+```
+
+## Feedback
+
+Thanks to [@RDust4](https://github.com/RDust4) for the detailed report and reproduction on [#80](https://github.com/pthm/melange/issues/80). [Open an issue](https://github.com/pthm/melange/issues) for bug reports or feature requests.


### PR DESCRIPTION
Backfills the blog with release posts for the 0.9.x releases, which had no write-up (the GitHub Releases now have notes; this mirrors them in the docs site).

- **v0.9.0** — module restructure; the CLI install path changed to `go install github.com/pthm/melange@latest` (breaking).
- **v0.9.1** — `go install` build fix (genproto `replace` moved out of the root `go.mod`).
- **v0.9.2** — `ListSubjects` exclusion correctness fix (#80): a `but not` was dropped for subjects reached via cross-type TTU / nested userset compose arms; plus a new list-vs-check parity sweep across the whole suite.

Docs-only. Uses the `docs:` type, which release-please treats as non-releasing, so merging this will **not** cut a new version. Posts follow the existing `docs/content/blog/*.md` format (frontmatter, `<!--more-->`, callouts).