### PR TITLE
fix(parser): reject schemas containing conditions instead of dropping them

### DIFF
--- a/docs/content/docs/reference/openfga-compatibility.md
+++ b/docs/content/docs/reference/openfga-compatibility.md
@@ -168,6 +168,18 @@ condition ip_allowed(user_ip: ipaddress) {
 define viewer: [user with ip_allowed]
 ```
 
+Melange rejects these schemas rather than dropping the condition, since a
+dropped condition would silently widen access:
+
+```
+$ melange validate --schema schema.fga
+Error: parsing schema: melange: invalid schema: conditions are not supported
+and would be silently dropped: document#viewer allows [user with ip_allowed].
+```
+
+Remove the condition (and tighten the relation another way) to use the schema
+with Melange.
+
 ## Migration Path to OpenFGA
 
 Melange is designed to be a stepping stone. If you outgrow its capabilities, you can migrate to the full OpenFGA service.

--- a/pkg/parser/conditions_test.go
+++ b/pkg/parser/conditions_test.go
@@ -1,0 +1,100 @@
+package parser
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pthm/melange/melange"
+)
+
+// Conditions are unsupported and dropped by convertModel, so parsing must
+// fail closed rather than report a narrower schema as valid (issue #81).
+func TestParseSchemaString_RejectsConditions(t *testing.T) {
+	tests := []struct {
+		name   string
+		schema string
+		want   string
+	}{
+		{
+			name: "applied to a type restriction",
+			schema: `model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: [user with non_expired_grant]
+
+condition non_expired_grant(current_time: timestamp, grant_time: timestamp) {
+  current_time < grant_time
+}`,
+			want: "document#viewer allows [user with non_expired_grant]",
+		},
+		{
+			name: "applied to a userset restriction",
+			schema: `model
+  schema 1.1
+
+type user
+
+type group
+  relations
+    define member: [user]
+
+type document
+  relations
+    define viewer: [group#member with non_expired_grant]
+
+condition non_expired_grant(current_time: timestamp, grant_time: timestamp) {
+  current_time < grant_time
+}`,
+			want: "document#viewer allows [group#member with non_expired_grant]",
+		},
+		{
+			name: "declared but never applied",
+			schema: `model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: [user]
+
+condition non_expired_grant(current_time: timestamp, grant_time: timestamp) {
+  current_time < grant_time
+}`,
+			want: `condition "non_expired_grant" is declared`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := ParseSchemaString(tt.schema)
+			if err == nil {
+				t.Fatal("expected conditions to be rejected, got nil error")
+			}
+			if !melange.IsInvalidSchemaErr(err) {
+				t.Errorf("expected an ErrInvalidSchema, got %v", err)
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Errorf("error %q does not mention %q", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSchemaString_AllowsConditionFreeSchema(t *testing.T) {
+	_, err := ParseSchemaString(`model
+  schema 1.1
+
+type user
+
+type document
+  relations
+    define viewer: [user, user:*]`)
+	if err != nil {
+		t.Fatalf("condition-free schema should parse: %v", err)
+	}
+}

--- a/pkg/parser/modular.go
+++ b/pkg/parser/modular.go
@@ -80,6 +80,10 @@ func ParseModularSchemaFromStrings(modules map[string]string, schemaVersion stri
 		return nil, fmt.Errorf("compiling modules: %w", err)
 	}
 
+	if err := checkUnsupported(model); err != nil {
+		return nil, err
+	}
+
 	return convertModel(model), nil
 }
 

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -29,9 +29,12 @@ package parser
 
 import (
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
+	"strings"
 
 	openfgav1 "github.com/openfga/api/proto/openfga/v1"
 	"github.com/openfga/language/pkg/go/transformer"
@@ -97,6 +100,10 @@ func ParseModularSchema(manifestPath string) ([]schema.TypeDefinition, error) {
 		return nil, fmt.Errorf("compiling modules: %w", err)
 	}
 
+	if err := checkUnsupported(model); err != nil {
+		return nil, err
+	}
+
 	return convertModel(model), nil
 }
 
@@ -109,7 +116,62 @@ func ParseSchemaString(content string) ([]schema.TypeDefinition, error) {
 		return nil, fmt.Errorf("%w: %v", melange.ErrInvalidSchema, err)
 	}
 
+	if err := checkUnsupported(model); err != nil {
+		return nil, err
+	}
+
 	return convertModel(model), nil
+}
+
+// compatibilityDocsURL documents which OpenFGA features melange supports.
+const compatibilityDocsURL = "https://melange.sh/docs/reference/openfga-compatibility/"
+
+// checkUnsupported rejects models using OpenFGA features melange cannot
+// compile. Conditions are the only one: convertModel drops them, so a schema
+// relying on a condition to narrow access would compile to a broader grant.
+// Failing closed is the only safe option until conditions are supported.
+func checkUnsupported(model *openfgav1.AuthorizationModel) error {
+	var found []string
+
+	for _, td := range model.GetTypeDefinitions() {
+		relMeta := td.GetMetadata().GetRelations()
+		for _, relName := range slices.Sorted(maps.Keys(relMeta)) {
+			for _, t := range relMeta[relName].GetDirectlyRelatedUserTypes() {
+				if cond := t.GetCondition(); cond != "" {
+					found = append(found, fmt.Sprintf("%s#%s allows [%s with %s]",
+						td.GetType(), relName, subjectRefString(t), cond))
+				}
+			}
+		}
+	}
+
+	// A condition can be declared but never applied to a type restriction.
+	// Still unsupported, and reporting it beats a confusing silent pass.
+	if len(found) == 0 {
+		for _, name := range slices.Sorted(maps.Keys(model.GetConditions())) {
+			found = append(found, fmt.Sprintf("condition %q is declared", name))
+		}
+	}
+
+	if len(found) == 0 {
+		return nil
+	}
+
+	return fmt.Errorf("%w: conditions are not supported and would be silently dropped: %s. Remove them or see %s",
+		melange.ErrInvalidSchema, strings.Join(found, "; "), compatibilityDocsURL)
+}
+
+// subjectRefString renders a type restriction the way it appears in the DSL:
+// "user", "user:*", or "group#member".
+func subjectRefString(t *openfgav1.RelationReference) string {
+	switch v := t.GetRelationOrWildcard().(type) {
+	case *openfgav1.RelationReference_Wildcard:
+		return t.GetType() + ":*"
+	case *openfgav1.RelationReference_Relation:
+		return t.GetType() + "#" + v.Relation
+	default:
+		return t.GetType()
+	}
 }
 
 // ConvertProtoModel converts an OpenFGA protobuf AuthorizationModel to schema
@@ -117,7 +179,9 @@ func ParseSchemaString(content string) ([]schema.TypeDefinition, error) {
 // (e.g., from the OpenFGA API) rather than DSL text.
 //
 // This function is used by the OpenFGA test suite adapter to convert test
-// models without re-implementing the parsing logic.
+// models without re-implementing the parsing logic. Unlike the DSL
+// entrypoints it does not reject unsupported features: conditions on a model
+// passed here are still dropped silently.
 func ConvertProtoModel(model *openfgav1.AuthorizationModel) []schema.TypeDefinition {
 	return convertModel(model)
 }


### PR DESCRIPTION
Fixes #81.

## Problem

Conditions are unsupported, and documented as such — but `convertModel` discarded them silently. A schema copied from OpenFGA would pass `melange validate` and compile through `melange migrate` with the condition simply gone.

That is a fail-open: a condition meant to *narrow* access disappears, leaving a broader grant than the schema author wrote.

## Change

`checkUnsupported` runs after the OpenFGA transformer and before conversion, naming the offending `type#relation` and condition:

```
$ melange validate --schema schema.fga
Error: parsing schema: melange: invalid schema: conditions are not supported and would be
silently dropped: document#viewer allows [user with non_expired_grant]. Remove them or see
https://melange.sh/docs/reference/openfga-compatibility/
```

It is wired into all three DSL entrypoints — `ParseSchemaString`, `ParseModularSchema`, `ParseModularSchemaFromStrings` — so every caller fails closed: `validate`, `migrate`, `generate migration`, `generate client`, `doctor`. Each verified to exit non-zero.

Conditions declared but never applied to a type restriction are reported too, rather than passing confusingly.

## Scope

`ConvertProtoModel` stays unchecked. It is the low-level escape hatch the conformance harness uses to feed OpenFGA’s own test models, several of which carry conditions. Its doc comment now states that it does not reject unsupported features.

Not adding conditions support — the reporter did not ask for it and this only changes the failure mode.

## Tests

`pkg/parser/conditions_test.go` covers a type restriction, a userset restriction (`[group#member with cond]`), declared-but-unused, and a condition-free schema still parsing.

Docs page updated with the new error.