### PR TITLE
feat: deployed model storage, environment profiles, and drift-safe migrate

### DIFF
--- a/docs/content/docs/concepts/how-it-works.md
+++ b/docs/content/docs/concepts/how-it-works.md
@@ -50,7 +50,7 @@ When you run `melange migrate` (or `melange generate migration`), the compiler:
 4. **Generates** specialized SQL functions for each relation
 5. **Installs** the functions into PostgreSQL (`migrate`) or writes them as versioned SQL files (`generate migration`)
 
-See [Running Migrations](../migrations/) for guidance on choosing between the two approaches.
+See [Running Migrations](../../guides/migrations/) for guidance on choosing between the two approaches.
 
 ### Runtime
 

--- a/docs/content/docs/guides/expanding-permissions.md
+++ b/docs/content/docs/guides/expanding-permissions.md
@@ -235,9 +235,9 @@ Opt-in via `ExpandCache` — see [Caching](./caching/#expandcache).
 
 ## See Also
 
-- [Explaining Decisions](./explaining-decisions/): the companion `Explain` API for "why (or why not)?"
-- [Listing Subjects](./listing-subjects/): request-path listing without the tree structure
-- [Caching](./caching/): opt-in caching for Expand trees via `ExpandCache`
+- [Explaining Decisions](../explaining-decisions/): the companion `Explain` API for "why (or why not)?"
+- [Listing Subjects](../listing-subjects/): request-path listing without the tree structure
+- [Caching](../caching/): opt-in caching for Expand trees via `ExpandCache`
 - [Go API reference](../reference/go-api/#expand): `Checker.Expand` / `ExpandRecursive` signatures
 - [SQL API reference](../reference/sql-api/#expand_permission): `expand_permission` SQL function
 - [CLI reference](../reference/cli/#expand): `melange expand` command

--- a/docs/content/docs/guides/explaining-decisions.md
+++ b/docs/content/docs/guides/explaining-decisions.md
@@ -207,10 +207,10 @@ A sentinel response means the requested pair has no generated function. Check wh
 
 ## See Also
 
-- [Expanding Permissions](./expanding-permissions/): the companion `Expand` API for "who has access?"
-- [Checking Permissions](./checking-permissions/): the request-path `Check` API
-- [Caching](./caching/): opt-in caching for Explain traces via `ExplainCache`
-- [Troubleshooting](./troubleshooting/): when checks return the wrong answer
+- [Expanding Permissions](../expanding-permissions/): the companion `Expand` API for "who has access?"
+- [Checking Permissions](../checking-permissions/): the request-path `Check` API
+- [Caching](../caching/): opt-in caching for Explain traces via `ExplainCache`
+- [Troubleshooting](../troubleshooting/): when checks return the wrong answer
 - [Go API reference](../reference/go-api/#explain): `Checker.Explain` signature
 - [SQL API reference](../reference/sql-api/#explain_permission): `explain_permission` SQL function
 - [CLI reference](../reference/cli/#explain): `melange explain` command

--- a/docs/content/docs/guides/testing-authorization.md
+++ b/docs/content/docs/guides/testing-authorization.md
@@ -14,8 +14,7 @@ func TestPermissions(t *testing.T) {
     ctx := context.Background()
 
     // Apply melange migration
-    m := migrator.NewMigrator(db, "schemas/schema.fga")
-    _, err := m.Migrate(ctx)
+    err := migrator.Migrate(ctx, db, "schemas/schema.fga")
     require.NoError(t, err)
 
     // Insert test data into domain tables

--- a/docs/content/docs/reference/_index.md
+++ b/docs/content/docs/reference/_index.md
@@ -8,6 +8,7 @@ Technical reference documentation for Melange. Find detailed information on CLI 
 {{< cards >}}
 {{< card link="cli" title="CLI Reference" subtitle="Commands for migrations, code generation, and validation" icon="terminal" >}}
 {{< card link="configuration" title="Configuration" subtitle="Config files, environment variables, and precedence" icon="cog" >}}
+{{< card link="deployed-model" title="Deployed Model" subtitle="What a migration records, and the commands that read it back" icon="database" >}}
 {{< card link="go-api" title="Go API" subtitle="Runtime types, Checker, bulk checks, caching, and decision overrides" icon="code" >}}
 {{< card link="typescript-api" title="TypeScript API" subtitle="TypeScript runtime client (in development)" icon="code" >}}
 {{< card link="sql-api" title="SQL API" subtitle="Direct SQL functions for permission checks without a client library" icon="database" >}}

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -241,6 +241,25 @@ Deployed:     checksum d0c1746f7e26… · melange v0.9.0 · 2026-07-01T20:46:10Z
 Sync:         in sync — local schema matches deployed
 ```
 
+When the local schema has drifted, the change summary follows the Sync line:
+
+```
+Schema file:  present
+Tuples view:  present
+Deployed:     checksum d0c1746f7e26… · melange v0.9.0 · 2026-07-01T20:46:10Z
+Sync:         drift — local schema differs from deployed (`melange diff` to see changes, `melange migrate` to apply)
+              1 breaking, 2 additive
+              + type audit_log added
+              + relation document.can_export added
+              - relation document.legacy_viewer removed
+```
+
+At most five changes are listed; run `melange diff` for the full list. The
+summary is omitted when the deployed model was never recorded, when either side
+fails to parse (a `Note:` explains why), or when the two models are semantically
+equivalent — reformatting or a comment edit moves the checksum without changing
+behavior, and that is reported as drift with no changes to show.
+
 The **Deployed** line reports the model recorded by the most recent migration
 (checksum, melange version, and time). The **Sync** state compares the local
 schema file's checksum against the deployed one:
@@ -271,6 +290,27 @@ presence and adds a `Note:` line.
     "schema_checksum": "d0c1746f7e26ea40027a24b1c0e0c5f34e279e7c27f6fa17e4611ce2f1ec0962",
     "schema_format": "single",
     "model_recorded": true
+  }
+}
+```
+
+When the sync state is `drift` and both models are available, a `drift` object
+carries the same detail as the text output — the counts plus every change, not
+just the first five. Changes are sorted by type, then relation, so the order is
+stable across runs:
+
+```json
+{
+  "sync": "drift",
+  "deployed": { "schema_checksum": "d0c1746f7e26…", "model_recorded": true },
+  "drift": {
+    "additive": 2,
+    "breaking": 1,
+    "changes": [
+      { "class": "additive", "type": "audit_log", "summary": "type audit_log added" },
+      { "class": "additive", "type": "document", "relation": "can_export", "summary": "relation document.can_export added" },
+      { "class": "breaking", "type": "document", "relation": "legacy_viewer", "summary": "relation document.legacy_viewer removed" }
+    ]
   }
 }
 ```

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -300,7 +300,7 @@ every version:
 Treat it as a prompt to look, not a verdict: it reports what git could see, and
 git cannot see every place a model may have come from.
 
-Databases migrated before v0.9 (or by `MigrateWithTypes`) have no recorded model
+Databases migrated before model storage existed (or by `MigrateWithTypes`) have no recorded model
 DSL; status notes this and `melange schema pull` cannot recover them. Reading the
 migration record is non-fatal — if it fails, status still reports schema/tuples
 presence and adds a `Note:` line.
@@ -392,7 +392,7 @@ bundle for reference/recovery. That combined form does **not** re-parse as a
 single `.fga`, and splitting it back into module files is not supported.
 {{< /callout >}}
 
-Requires a database migrated by melange v0.9 or later. Older databases did not
+Requires a database migrated by a version that records the model. Older databases did not
 record the model; pull reports whether the database was never migrated or was
 migrated before model storage existed.
 
@@ -432,8 +432,8 @@ source instead and are mutually exclusive with a database source.
 ```
 Comparing deployed → melange/schema.fga
 
-  BREAKING  document.legacy removed
   additive  type audit_log added
+  BREAKING  relation document.legacy removed
   additive  document.viewer grants [org]
 
 1 breaking, 2 additive
@@ -486,7 +486,7 @@ melange doctor \
 | Flag                 | Default              | Description                                  |
 | -------------------- | -------------------- | -------------------------------------------- |
 | `--db`               | (from config)        | PostgreSQL connection string                 |
-| `--db-schema`        | `""`                 | Database schema                              |
+| `--db-schema`        | (config, else `public`) | PostgreSQL schema for melange objects     |
 | `--schema`           | `schemas/schema.fga` | Path to schema.fga file                      |
 | `--verbose`          | `false`              | Show detailed output with additional context |
 | `--skip-performance` | `false`              | Skip performance checks (view analysis)      |
@@ -621,7 +621,7 @@ melange explain user:alice viewer document:1 --db postgres://localhost/mydb
 | Flag           | Default       | Description                                                                                          |
 | -------------- | ------------- | ---------------------------------------------------------------------------------------------------- |
 | `--db`         | (from config) | PostgreSQL connection string                                                                          |
-| `--db-schema`  | `"public"`    | Database schema                                                                                       |
+| `--db-schema`  | (config, else `public`) | PostgreSQL schema for melange objects                                                       |
 | `--format`     | `tree`        | `tree` (unicode pretty-print) or `json` (raw `Trace` JSONB)                                          |
 | `--max-nodes`  | `0`           | Cap on trace nodes. `0` defers to the session GUC `melange.max_explain_nodes`, then to 100           |
 | `--color`      | `auto`        | `auto` (TTY + `NO_COLOR` unset), `always`, or `never`. See [Colour Output](#colour-output) below.    |
@@ -661,10 +661,10 @@ melange expand document:1 viewer --db postgres://localhost/mydb
 | Flag             | Default       | Description                                                                                                      |
 | ---------------- | ------------- | ---------------------------------------------------------------------------------------------------------------- |
 | `--db`           | (from config) | PostgreSQL connection string                                                                                     |
-| `--db-schema`   | `"public"`    | Database schema                                                                                                  |
+| `--db-schema`   | (config, else `public`) | PostgreSQL schema for melange objects                                                                  |
 | `--format`       | `tree`        | `tree` (unicode pretty-print) or `json` (raw `UsersetTree` JSONB)                                                |
-| `--flatten`      | `false`       | Call `ExpandRecursive` and print the flat, deduplicated user list (chases `Leaf.Computed` and TTU pointers)      |
-| `--recursive`    | `false`       | Alias for `--flatten`                                                                                            |
+| `--flatten`      | `false`       | Print the flat, deduplicated user list instead of the tree. `Leaf.Users` only — computed and TTU pointers are not chased |
+| `--recursive`    | `false`       | Print the flat list *and* chase `Leaf.Computed` / TTU pointers with follow-up Expand calls (implies `--flatten`) |
 | `--subject-type` | (unset)       | Melange extension. Narrow `Leaf.Users` to a single subject type                                                  |
 | `--max-leaf`     | `0`           | Melange extension. Cap each `Leaf.Users` list. `0` defers to session GUC `melange.max_expand_leaf`, then unbounded |
 | `--color`        | `auto`        | `auto` (TTY + `NO_COLOR` unset), `always`, or `never`. See [Colour Output](#colour-output) below.                |
@@ -808,7 +808,7 @@ melange generate migration \
 | Flag                  | Default              | Description                                                    |
 | --------------------- | -------------------- | -------------------------------------------------------------- |
 | `--schema`            | `schemas/schema.fga` | Path to current `.fga` schema file (required)                  |
-| `--db-schema`         | `""`                 | PostgreSQL schema for melange objects                          |
+| `--db-schema`         | (config, else `public`) | PostgreSQL schema for melange objects                       |
 | `--output`            | (stdout)             | Output directory for migration files                           |
 | `--name`              | `melange`            | Migration name suffix used in filenames                        |
 | `--format`            | `split`              | Output format: `split` (`.up.sql`/`.down.sql`) or `single`    |
@@ -917,6 +917,10 @@ melange init
 | `--output` | `internal/authz` (Go) / `src/authz` (TS) | Client output directory |
 | `--package` | `authz` | Client package name (Go only) |
 | `--id-type` | `string` | Client ID type: `string`, `int64`, `uuid.UUID` |
+| `--migration-strategy` | (prompted) | How migrations are applied: `builtin` (`melange migrate`) or `versioned` (generated SQL files) |
+| `--migration-output` | `migrations/` | Output directory for versioned migration files |
+| `--migration-format` | `split` | Versioned migration format: `split` (`.up.sql`/`.down.sql`) or `single` |
+| `--migration-name` | `melange` | Versioned migration name suffix used in filenames |
 
 **Project detection:**
 
@@ -1260,10 +1264,15 @@ if err != nil {
     log.Fatal(err)
 }
 
-// Create migrator and apply
-m := migrator.NewMigrator(db, "schemas/schema.fga")
-err = m.MigrateWithTypes(ctx, types)
+// Apply, recording the deployed model in melange_migrations
+err = migrator.Migrate(ctx, db, "schemas/schema.fga")
 ```
+
+`migrator.Migrate` and `migrator.MigrateFromString` record the schema they
+applied, so the database stays self-describing and `status`, `schema pull`, and
+`diff` keep working against it. `Migrator.MigrateWithTypes` (used with
+pre-parsed types) deliberately skips that bookkeeping — reach for it only when
+you don't want a migration record, such as in test fixtures.
 
 **With options (dry-run, force, skip-if-unchanged):**
 
@@ -1290,6 +1299,17 @@ opts := migrator.MigrateOptions{}
 skipped, err := migrator.MigrateWithOptions(ctx, db, "schemas/schema.fga", opts)
 if skipped {
     log.Println("Schema unchanged, migration skipped")
+}
+
+// Compare-and-swap: apply only if the database is still at this checksum
+deployed := "3f9a...c21b"
+opts := migrator.MigrateOptions{
+    IfDeployedChecksum: &deployed,
+}
+skipped, err := migrator.MigrateWithOptions(ctx, db, "schemas/schema.fga", opts)
+var changed *migrator.DeployedModelChangedError
+if errors.As(err, &changed) {
+    log.Printf("database drifted: expected %s, found %s", changed.Expected, changed.Actual)
 }
 ```
 

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -65,7 +65,7 @@ The cache respects the `XDG_CACHE_HOME` environment variable if set.
 
 Commands are organized into logical groups:
 
-**Schema Commands:** `validate`, `migrate`, `status`, `schema pull`, `doctor`, `explain`, `expand`
+**Schema Commands:** `validate`, `migrate`, `status`, `schema pull`, `diff`, `history`, `doctor`, `explain`, `expand`
 **Client Commands:** `generate client`, `generate migration`
 **Utility Commands:** `init`, `config show`, `env list`, `version`, `license`
 
@@ -112,13 +112,14 @@ melange migrate \
 
 **Flags:**
 
-| Flag          | Default              | Description                                   |
-| ------------- | -------------------- | --------------------------------------------- |
-| `--db`        | (from config)        | PostgreSQL connection string                  |
-| `--db-schema` | `""`                 | PostgreSQL schema for melange objects          |
-| `--schema`    | `schemas/schema.fga` | Path to schema.fga file                       |
-| `--dry-run`   | `false`              | Output SQL to stdout without applying changes |
-| `--force`     | `false`              | Force migration even if schema is unchanged   |
+| Flag                     | Default              | Description                                                    |
+| ------------------------ | -------------------- | ------------------------------------------------------------- |
+| `--db`                   | (from config)        | PostgreSQL connection string                                  |
+| `--db-schema`            | (config, else `public`) | PostgreSQL schema for melange objects                      |
+| `--schema`               | `schemas/schema.fga` | Path to schema.fga file                                       |
+| `--dry-run`              | `false`              | Output SQL to stdout without applying changes                 |
+| `--force`                | `false`              | Force migration even if schema is unchanged                   |
+| `--if-deployed-checksum` | (unset)              | Apply only if the deployed schema checksum matches (see below) |
 
 This command:
 
@@ -139,6 +140,40 @@ Use --force to re-apply.
 ```
 
 Use `--force` to re-apply the migration anyway (useful after updating Melange itself).
+
+**Drift-safe apply (`--if-deployed-checksum`):**
+
+`--if-deployed-checksum` turns migrate into a compare-and-swap: it applies only if
+the database is currently at the schema checksum you pass, otherwise it aborts
+having changed nothing and exits non-zero. This closes the window where someone
+else migrates the database between the time you plan a change and the time your
+deploy applies — which last-writer-wins would silently clobber.
+
+The intended CI pattern reads the current checksum from `status`, then gates the
+apply on it:
+
+```bash
+CURRENT=$(melange status --env production --format json | jq -r .deployed.schema_checksum)
+# review / plan the change …
+melange migrate --env production --if-deployed-checksum "$CURRENT"
+```
+
+On a mismatch:
+
+```
+Error: migration aborted: deployed model changed: expected checksum abc… but database has def…; nothing was applied
+```
+
+An empty value (`--if-deployed-checksum ""`) matches a database with no migration
+recorded (a fresh database). The guard is enforced in `--dry-run` too, so a
+drift-gated preview aborts rather than printing SQL against a drifted database.
+
+{{< callout type="info" >}}
+The guard is verified up front and again inside the apply transaction, so a
+change committed while your migration runs aborts it. It is not a hard lock
+against two migrations that verify at the exact same instant, but concurrent
+migrations against one database are unsupported regardless.
+{{< /callout >}}
 
 **Dry-run mode:**
 
@@ -290,6 +325,81 @@ single `.fga`, and splitting it back into module files is not supported.
 Requires a database migrated by melange v0.9 or later. Older databases did not
 record the model; pull reports whether the database was never migrated or was
 migrated before model storage existed.
+
+### diff
+
+Show what changed between a deployed (or previous) model and your local schema,
+with each change classified **additive** (safe — widens access or adds structure)
+or **breaking** (narrows access or removes structure).
+
+```bash
+# What would migrating apply to production?
+melange diff --env production
+
+# Compare against the schema on main, or a previous file
+melange diff --git-ref main
+melange diff --previous-schema old.fga
+```
+
+**Flags:**
+
+| Flag                | Default              | Description                                                          |
+| ------------------- | -------------------- | ------------------------------------------------------------------- |
+| `--db`              | (from config)        | Database to compare against (the default source)                    |
+| `--db-schema`       | (config, else `public`) | PostgreSQL schema for melange objects                            |
+| `--schema`          | `schemas/schema.fga` | Local `.fga` — the new side of the diff                             |
+| `--git-ref`         | (unset)              | Compare against your schema at a git commit/branch/tag              |
+| `--previous-schema` | (unset)              | Compare against a previous `.fga` file (modular not supported)      |
+| `--format`          | `tree`               | Output format: `tree` (default) or `json`                           |
+| `--exit-code`       | `false`              | Exit 1 if any change is breaking (CI gate)                          |
+
+The comparison source is the deployed model by default (`--db`/`--env`, or the
+configured database); `--git-ref` and `--previous-schema` select a file/git
+source instead and are mutually exclusive with a database source.
+
+**Output:**
+
+```
+Comparing deployed → melange/schema.fga
+
+  BREAKING  document.legacy removed
+  additive  type audit_log added
+  additive  document.viewer grants [org]
+
+1 breaking, 2 additive
+```
+
+Classification reflects melange's compiled model and is deliberately conservative:
+it accounts for implied-by closure, intersection subsumption, and exclusion
+polarity, and it never under-reports a breaking change — so `--exit-code` is safe
+as a CI gate. `--format=json` emits the structured `SchemaDiff` for tooling.
+
+### history
+
+List recent entries from the `melange_migrations` table — when each migration
+ran, the melange version, the schema checksum, and how many functions it
+installed. An audit trail of how a database's model has evolved.
+
+```bash
+melange history --db postgres://localhost/mydb
+```
+
+**Flags:**
+
+| Flag          | Default              | Description                              |
+| ------------- | -------------------- | ---------------------------------------- |
+| `--db`        | (from config)        | PostgreSQL connection string             |
+| `--db-schema` | (config, else `public`) | PostgreSQL schema for melange objects |
+| `--format`    | `text`               | Output format: `text` (default) or `json` |
+| `--limit`     | `20`                 | Maximum number of entries to show        |
+
+**Output:**
+
+```
+Migration history (most recent first):
+  2026-07-02T20:46:10Z · melange v0.9.1 · checksum 550b0008a779… · single · 23 functions
+  2026-07-01T18:12:03Z · melange v0.9.0 · checksum 0ba53b1429e9… · single · 17 functions
+```
 
 ### doctor
 
@@ -896,6 +1006,11 @@ This displays the Melange license and attribution for all embedded third-party d
 | 3    | Schema parse error                                                   |
 | 4    | Database connection error                                            |
 
+The CI gates exit non-zero on an intentional gate failure, not just tool errors:
+`melange diff --exit-code` exits 1 when a change is breaking, and `melange migrate
+--if-deployed-checksum` exits 1 when the deployed model has drifted. In both cases
+the accompanying message explains the condition.
+
 ## Common Workflows
 
 ### Development Setup
@@ -963,6 +1078,22 @@ For pipelines where you want to ensure migrations are always applied (e.g., afte
 
 ```bash
 melange migrate --force
+```
+
+**Gated deploy against a live environment.** Fail the build on a breaking change,
+then apply only if the environment hasn't drifted since you inspected it:
+
+```bash
+# Fail review if the change narrows access
+melange diff --env production --exit-code
+
+# Capture the state you reviewed
+CURRENT=$(melange status --env production --format json | jq -r .deployed.schema_checksum)
+
+# … approval gate …
+
+# Apply only if production is still at that checksum
+melange migrate --env production --if-deployed-checksum "$CURRENT"
 ```
 
 ### Schema Updates

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -18,9 +18,15 @@ These flags are available on all commands:
 | Flag                | Description                                                                                         |
 | ------------------- | --------------------------------------------------------------------------------------------------- |
 | `--config`          | Path to config file (default: auto-discover `melange.yaml`). See [Configuration](../configuration/). |
+| `--env`             | Select a named environment profile. See [Configuration → Environments](../configuration/#environments). |
 | `-v`, `--verbose`   | Increase verbosity (can be repeated: `-vv`, `-vvv`)                                                 |
 | `-q`, `--quiet`     | Suppress non-error output                                                                           |
 | `--no-update-check` | Disable automatic update checking                                                                   |
+
+Any command that connects to a database accepts `--env <name>` to target one of
+the [environment profiles](../configuration/#environments) defined in your
+config (e.g. `melange status --env production`). An explicit `--db` still wins
+over the environment's connection.
 
 ### Update Notifications
 
@@ -59,9 +65,9 @@ The cache respects the `XDG_CACHE_HOME` environment variable if set.
 
 Commands are organized into logical groups:
 
-**Schema Commands:** `validate`, `migrate`, `status`, `doctor`
+**Schema Commands:** `validate`, `migrate`, `status`, `schema pull`, `doctor`, `explain`, `expand`
 **Client Commands:** `generate client`, `generate migration`
-**Utility Commands:** `init`, `config`, `version`, `license`
+**Utility Commands:** `init`, `config show`, `env list`, `version`, `license`
 
 ---
 
@@ -119,7 +125,9 @@ This command:
 1. Checks if the schema has changed since the last migration
 2. Installs generated SQL functions (`check_permission`, `list_accessible_objects`, etc.)
 3. Cleans up orphaned functions from removed relations
-4. Records the migration in `melange_migrations` table
+4. Records the migration in `melange_migrations` table — including the schema
+   DSL and parsed model, so the database is self-describing. This is what
+   `melange status` and `melange schema pull` read back.
 
 **Skip-if-unchanged behavior:**
 
@@ -171,7 +179,8 @@ See [Tuples View](../../concepts/tuples-view/) for setup instructions.
 
 ### status
 
-Check the current migration status.
+Show whether the schema file and `melange_tuples` view are present, what model
+the database has deployed, and whether the local schema file is in sync with it.
 
 ```bash
 melange status \
@@ -181,23 +190,106 @@ melange status \
 
 **Flags:**
 
-| Flag          | Default              | Description                  |
-| ------------- | -------------------- | ---------------------------- |
-| `--db`        | (from config)        | PostgreSQL connection string |
-| `--db-schema` | `""`                 | Database schema              |
-| `--schema`    | `schemas/schema.fga` | Path to schema.fga file      |
+| Flag          | Default              | Description                                                     |
+| ------------- | -------------------- | -------------------------------------------------------------- |
+| `--db`        | (from config)        | PostgreSQL connection string                                   |
+| `--db-schema` | (config, else `public`) | PostgreSQL schema for melange objects                       |
+| `--schema`    | `schemas/schema.fga` | Path to schema.fga file                                        |
+| `--format`    | `text`               | Output format: `text` or `json`                                |
 
 **Output:**
 
 ```
 Schema file:  present
 Tuples view:  present
+Deployed:     checksum d0c1746f7e26… · melange v0.9.0 · 2026-07-01T20:46:10Z
+Sync:         in sync — local schema matches deployed
 ```
 
-This helps you verify that:
+The **Deployed** line reports the model recorded by the most recent migration
+(checksum, melange version, and time). The **Sync** state compares the local
+schema file's checksum against the deployed one:
 
-- Your schema file exists
-- The tuples view exists in the database
+| Sync state     | Meaning                                                          |
+| -------------- | --------------------------------------------------------------- |
+| `in_sync`      | The local schema matches what's deployed                        |
+| `drift`        | The local schema differs — run `melange migrate` to apply       |
+| `unknown`      | No local schema file to compare against                         |
+| `not_recorded` | The database has no migration record                            |
+
+Databases migrated before v0.9 (or by `MigrateWithTypes`) have no recorded model
+DSL; status notes this and `melange schema pull` cannot recover them. Reading the
+migration record is non-fatal — if it fails, status still reports schema/tuples
+presence and adds a `Note:` line.
+
+**JSON output** (`--format json`) emits the machine-readable report, including a
+`notes` array for any non-fatal warnings:
+
+```json
+{
+  "schema_file": "present",
+  "tuples_view": "present",
+  "sync": "in_sync",
+  "deployed": {
+    "melange_version": "v0.9.0",
+    "migrated_at": "2026-07-01T20:46:10Z",
+    "schema_checksum": "d0c1746f7e26ea40027a24b1c0e0c5f34e279e7c27f6fa17e4611ce2f1ec0962",
+    "schema_format": "single",
+    "model_recorded": true
+  }
+}
+```
+
+### schema pull
+
+Reconstruct the OpenFGA schema recorded by the most recent migration. Use it to
+recover a schema whose source file was lost, or to see exactly what model a
+database is running.
+
+```bash
+# Print the deployed schema
+melange schema pull --db postgres://localhost/mydb
+
+# Recover it to a file, targeting a named environment
+melange schema pull --env production -o recovered.fga
+```
+
+**Flags:**
+
+| Flag             | Default              | Description                                            |
+| ---------------- | -------------------- | ------------------------------------------------------ |
+| `--db`           | (from config)        | PostgreSQL connection string                           |
+| `--db-schema`    | (config, else `public`) | PostgreSQL schema for melange objects               |
+| `-o`, `--output` | (stdout)             | Write to this file instead of stdout                   |
+| `--no-header`    | `false`              | Omit the provenance header comment                     |
+
+**Output:**
+
+```
+# Pulled from a melange-migrated database by `melange schema pull`
+# Deployed: 2026-07-01T20:46:10Z by melange v0.9.0
+# Schema checksum: d0c1746f7e26ea40027a24b1c0e0c5f34e279e7c27f6fa17e4611ce2f1ec0962
+
+model
+  schema 1.1
+
+type user
+...
+```
+
+The provenance header is written as `#` comments (valid DSL), so the output still
+parses; the database URL is never included. Pass `--no-header` for the bare
+schema, which for a single-file schema is byte-identical to what you migrated.
+
+{{< callout type="info" >}}
+A **modular** (`fga.mod`) schema is emitted as the stored manifest + module
+bundle for reference/recovery. That combined form does **not** re-parse as a
+single `.fga`, and splitting it back into module files is not supported.
+{{< /callout >}}
+
+Requires a database migrated by melange v0.9 or later. Older databases did not
+record the model; pull reports whether the database was never migrated or was
+migrated before model storage existed.
 
 ### doctor
 
@@ -705,7 +797,8 @@ melange init -y --template minimal
 
 ### config show
 
-Display the effective configuration after merging defaults, config file, and environment variables.
+Display the effective configuration after merging defaults, config file,
+environment variables, and any selected environment profile.
 
 ```bash
 melange config show
@@ -713,30 +806,59 @@ melange config show
 
 **Flags:**
 
-| Flag       | Default | Description                          |
-| ---------- | ------- | ------------------------------------ |
-| `--source` | `false` | Show the config file path being used |
+| Flag              | Default | Description                                                 |
+| ----------------- | ------- | ----------------------------------------------------------- |
+| `--source`        | `false` | Show the config file path and active environment            |
+| `--reveal-secrets`| `false` | Print passwords in cleartext instead of masking them        |
 
-**Example with source:**
+Passwords — in both `database.url` and the discrete `password` field, across the
+base config and every environment profile — are **masked by default**, including
+values resolved from `${VAR}` references. Pass `--reveal-secrets` to print them.
+
+**Example — inspect the resolved production profile:**
 
 ```bash
-melange config show --source
+melange config show --env production --source
 ```
 
 **Output:**
 
 ```
 Config file: /path/to/project/melange.yaml
+Environment: production
 
 schema: schemas/schema.fga
 database:
-  url: postgres://localhost/mydb
-  host: ""
-  port: 5432
+  url: postgres://prod-user:****@prod-db:5432/app
   ...
 ```
 
-This is useful for debugging configuration issues and understanding which values are in effect.
+This is useful for debugging configuration issues and understanding which values
+are in effect for a given environment.
+
+### env list
+
+List the [environment profiles](../configuration/#environments) defined in your
+config and their connection targets. The active environment is marked with `*`.
+
+```bash
+melange env list
+```
+
+**Output:**
+
+```
+Environments:
+* local            postgres://localhost:5432/mydb_dev
+  production       ${PROD_DATABASE_URL}
+  staging          staging.db.internal:5432/app
+
+Default: local
+Active:  local (marked with *)
+```
+
+Targets are shown as configured — `${VAR}` references are left literal (not
+expanded) and any URL password is redacted, so the listing is safe to share.
 
 ### version
 

--- a/docs/content/docs/reference/cli.md
+++ b/docs/content/docs/reference/cli.md
@@ -264,12 +264,41 @@ The **Deployed** line reports the model recorded by the most recent migration
 (checksum, melange version, and time). The **Sync** state compares the local
 schema file's checksum against the deployed one:
 
-| Sync state     | Meaning                                                          |
-| -------------- | --------------------------------------------------------------- |
-| `in_sync`      | The local schema matches what's deployed                        |
-| `drift`        | The local schema differs — run `melange migrate` to apply       |
-| `unknown`      | No local schema file to compare against                         |
-| `not_recorded` | The database has no migration record                            |
+| Sync state       | Meaning                                                                   |
+| ---------------- | ------------------------------------------------------------------------- |
+| `in_sync`        | The local schema matches what's deployed                                     |
+| `drift`          | The local schema differs — run `melange migrate` to apply                    |
+| `database_ahead` | Drift where the deployed model is in no recent commit of your schema file    |
+| `unknown`        | No local schema file to compare against                                      |
+| `not_recorded`   | The database has no migration record                                         |
+
+`database_ahead` is the warning case: the deployed model is not the local file
+and is not any version of it in your schema's git history, so someone migrated
+that database from a different checkout — applying your local schema would
+overwrite their model rather than move the database forward. Check with
+`melange schema pull` before migrating, and use
+`melange migrate --if-deployed-checksum` to make the apply conditional.
+
+The probe is advisory and errs toward plain `drift`. It follows the schema across
+renames and reads each revision as a checkout would (so end-of-line conversion
+doesn't cause spurious mismatches), and it stays silent whenever it cannot search
+every version:
+
+- outside a git repository, or without git installed
+- in a shallow (`--depth`) or partial clone — CI checkouts are shallow by
+  default, so this is the common case in automation
+- when the schema is uncommitted or has local modifications: migrating from a
+  dirty working tree is routine, so the deployed model may be a version git
+  never saw
+- for modular (`fga.mod`) schemas, whose checksum covers the manifest plus every
+  module
+- for a schema with more than 50 commits of history, past which the search is no
+  longer exhaustive
+- when the two models are semantically equivalent — a checksum that moved on
+  formatting or comments alone is drift, never an allegation
+
+Treat it as a prompt to look, not a verdict: it reports what git could see, and
+git cannot see every place a model may have come from.
 
 Databases migrated before v0.9 (or by `MigrateWithTypes`) have no recorded model
 DSL; status notes this and `melange schema pull` cannot recover them. Reading the
@@ -294,7 +323,8 @@ presence and adds a `Note:` line.
 }
 ```
 
-When the sync state is `drift` and both models are available, a `drift` object
+When the sync state is `drift` or `database_ahead` and both models are
+available, a `drift` object
 carries the same detail as the text output — the counts plus every change, not
 just the first five. Changes are sorted by type, then relation, so the order is
 stable across runs:

--- a/docs/content/docs/reference/configuration.md
+++ b/docs/content/docs/reference/configuration.md
@@ -10,6 +10,10 @@ Melange supports configuration via YAML files, environment variables, and comman
 3. **Configuration file** (`melange.yaml` or `melange.yml`)
 4. **Built-in defaults**
 
+A selected [environment profile](#environments) overlays the base configuration
+before this precedence is applied, so an explicit flag still wins over the
+environment's value.
+
 ## Configuration File
 
 Melange automatically discovers a configuration file by checking each directory for the following names (in order):
@@ -41,7 +45,8 @@ Create a `melange.yaml` in your project root, or use `melange init` to generate 
 # Path to OpenFGA schema file (used by all commands)
 schema: schemas/schema.fga
 
-# Database connection (used by migrate, status, doctor)
+# Database connection (used by migrate, status, doctor, schema pull, explain, expand)
+# See "Environments" below for per-environment overrides selected with --env.
 database:
   # Option 1: Full connection URL
   url: postgres://user:password@localhost:5432/mydb?sslmode=prefer
@@ -238,6 +243,10 @@ Or via CLI flag:
 melange migrate --db postgres://localhost/mydb --db-schema authz
 ```
 
+When `--db-schema` is not passed, every database command resolves it from
+`database.schema` in the config (or the selected environment), falling back to
+`public`.
+
 ### Tuples view setup
 
 Create your `melange_tuples` view in the target schema. The view itself lives in the custom schema but can reference tables in any schema:
@@ -269,6 +278,108 @@ checker := melange.NewChecker(db, melange.WithDatabaseSchema("authz"))
 const checker = new Checker({ db, databaseSchema: 'authz' });
 ```
 
+## Environments
+
+Named **environment profiles** let a single `--env` flag point a command at a
+specific database — `local`, `staging`, `production` — instead of hand-swapping
+`--db` connection strings. Each profile overlays the base configuration.
+
+```yaml
+schema: melange/schema.fga
+
+# Base connection — used when no environment is selected, and the fallback
+# for any field an environment leaves unset.
+database:
+  url: postgres://localhost:5432/mydb_dev
+
+default_environment: local        # optional; used when --env / MELANGE_ENV absent
+
+environments:
+  local:
+    database:
+      url: postgres://localhost:5432/mydb_dev
+  staging:
+    database:
+      host: staging.db.internal
+      name: app
+      user: melange
+      password: ${STAGING_DB_PASSWORD}   # expanded from the OS environment
+      schema: public
+  production:
+    database:
+      url: ${PROD_DATABASE_URL}
+```
+
+Then target an environment on any database command:
+
+```bash
+melange status --env production
+melange migrate --env staging
+melange schema pull --env production -o recovered.fga
+```
+
+### Selecting an environment
+
+The active environment is resolved with this precedence (highest first):
+
+1. `--env <name>` flag
+2. `MELANGE_ENV` environment variable
+3. `default_environment` config key
+4. none → the base `database` block (behaviour identical to configs without an `environments:` map)
+
+An explicitly selected environment (`--env` or `MELANGE_ENV`) that isn't defined
+is a hard error, so a typo can't silently run against the wrong database. A
+`default_environment` that names a missing environment is treated leniently: a
+warning is printed and the base config is used, so a stale default never blocks
+diagnostic commands.
+
+### Overlay semantics
+
+An environment's `database` block overlays the base one — fields it sets win,
+fields it omits fall through. To keep behaviour predictable, when an environment
+supplies a discrete connection (`host`/`name`) on top of a base that uses a
+`url`, the base URL is dropped rather than decomposed. In that case the
+environment must provide a complete connection (including `user`); melange does
+not split a base URL into its parts.
+
+### Secrets with `${VAR}`
+
+Environment values may reference OS environment variables with `${VAR}` syntax,
+so production credentials stay out of the committed config file:
+
+```yaml
+environments:
+  production:
+    database:
+      url: ${PROD_DATABASE_URL}
+```
+
+Only the braced `${VAR}` form is expanded; a literal `$` (e.g. in a password) is
+left untouched. An unset variable referenced by a database field is reported
+**when a command actually connects** — not at startup — so diagnostic commands
+like `melange env list`, `melange config show`, and `melange validate` still run
+even if a secret is missing from the current shell.
+
+### Inspecting environments
+
+`melange env list` prints the defined profiles and their targets (with the
+active one marked `*`); `${VAR}` references are shown literally and passwords
+redacted:
+
+```bash
+$ melange env list
+Environments:
+* local            postgres://localhost:5432/mydb_dev
+  production       ${PROD_DATABASE_URL}
+  staging          staging.db.internal:5432/app
+
+Default: local
+```
+
+`melange config show --env production` prints the fully-resolved configuration
+for a profile, with passwords masked by default (pass `--reveal-secrets` to see
+them). See the [CLI reference](../cli/#config-show).
+
 ## Environment Variables
 
 All configuration options can be set via environment variables with the `MELANGE_` prefix. Use underscores to separate nested keys:
@@ -297,6 +408,7 @@ All configuration options can be set via environment variables with the `MELANGE
 | `MELANGE_MIGRATE_FORCE` | `migrate.force` |
 | `MELANGE_DOCTOR_VERBOSE` | `doctor.verbose` |
 | `MELANGE_DOCTOR_SKIP_PERFORMANCE` | `doctor.skip_performance` |
+| `MELANGE_ENV` | selects an [environment profile](#environments) (like `--env`) |
 | `CI` | _(special)_ |
 
 Setting `CI` to any value disables the automatic update check. Most CI providers set this automatically.
@@ -326,23 +438,29 @@ generate:
 
 ## Viewing Effective Configuration
 
-Use `melange config show` to see the effective configuration after merging all sources:
+Use `melange config show` to see the effective configuration after merging all
+sources (and any selected environment). Passwords are masked by default; pass
+`--reveal-secrets` to print them.
 
 ```bash
 # Show effective configuration
 melange config show
 
-# Show with config file path
+# Show with config file path and active environment
 melange config show --source
+
+# Show the resolved production profile
+melange config show --env production
 ```
 
 **Output:**
 ```
 Config file: /path/to/project/melange.yaml
+Environment: production
 
 schema: schemas/schema.fga
 database:
-  url: postgres://localhost/mydb
+  url: postgres://prod-user:****@prod-db:5432/app
   host: ""
   port: 5432
   ...
@@ -350,10 +468,11 @@ database:
 
 ## Security Considerations
 
-- **Prefer environment variables for secrets** in production environments
+- **Prefer environment variables for secrets** in production environments — reference them from an [environment profile](#environments) with `${VAR}` (e.g. `url: ${PROD_DATABASE_URL}`) so the config file stays credential-free
 - Avoid committing `melange.yaml` files containing `database.password` to version control
 - Consider using connection URLs with credentials stored in secure secret management systems
 - For local development, discrete fields in a `.gitignore`d config file are acceptable
+- `melange config show` masks passwords by default; `--reveal-secrets` is opt-in
 
 ## Example Configurations
 
@@ -395,29 +514,31 @@ generate:
 
 ### Multi-Environment
 
-Use different config files per environment:
-
-```bash
-# Development
-melange --config melange.dev.yaml migrate
-
-# Production
-melange --config melange.prod.yaml migrate
-```
-
-Or use environment variable overrides with a shared base config:
+Define [environment profiles](#environments) in one config and select them with
+`--env`:
 
 ```yaml
-# melange.yaml (shared)
+# melange.yaml
 schema: schemas/schema.fga
 
-generate:
-  client:
-    runtime: go
-    output: internal/authz
+database:
+  url: postgres://localhost:5432/myapp_dev   # base / default
+
+default_environment: local
+
+environments:
+  local:
+    database:
+      url: postgres://localhost:5432/myapp_dev
+  production:
+    database:
+      url: ${PROD_DATABASE_URL}   # from CI secrets, never committed
 ```
 
 ```bash
-# Override database per environment
-MELANGE_DATABASE_URL="postgres://prod-host/myapp" melange migrate
+melange status --env production
+melange migrate --env production
 ```
+
+Alternatively, use separate config files (`melange --config melange.prod.yaml
+migrate`) or override the connection with `MELANGE_DATABASE_URL` per invocation.

--- a/docs/content/docs/reference/deployed-model.md
+++ b/docs/content/docs/reference/deployed-model.md
@@ -29,7 +29,7 @@ model. Tools prefer `model_json` (already parsed) and fall back to parsing
 ## What reads it
 
 The deployed model is the single source of truth behind a family of commands
-(see the [CLI reference](cli) for each):
+(see the [CLI reference](../cli/) for each):
 
 | Command                          | Uses the deployed model to…                                        |
 | -------------------------------- | ------------------------------------------------------------------ |
@@ -52,12 +52,12 @@ The deployed model is the single source of truth behind a family of commands
 
 ## Compatibility
 
-Model storage was introduced in melange v0.9. Databases migrated by an earlier
-version have no recorded model; the commands above detect this and report it
-plainly (for example, `schema pull` distinguishes "never migrated" from
-"migrated before model storage existed"). Re-running `melange migrate` after
-upgrading backfills the model without re-applying the generated functions, so a
-plain rerun makes these commands work — no `--force` needed.
+Databases migrated before model storage existed have no recorded model. The
+commands above detect that and report it plainly — `schema pull`, for example,
+distinguishes "never migrated" from "migrated before the model was recorded".
+Re-running `melange migrate` after upgrading backfills the model without
+re-applying the generated functions, so a plain rerun makes these commands work,
+with no `--force` needed.
 
 A **modular** (`fga.mod`) schema is stored as its manifest plus module bundle for
 reference and recovery. That combined form does not re-parse as a single `.fga`,

--- a/docs/content/docs/reference/deployed-model.md
+++ b/docs/content/docs/reference/deployed-model.md
@@ -1,0 +1,65 @@
+---
+title: Deployed Model
+weight: 3
+---
+
+Every `melange migrate` records the authorization model it applied into the
+`melange_migrations` table, so the database is **self-describing**: it knows which
+schema is deployed without a separate state file to keep in sync. This is the
+foundation for drift detection, safe deploys, and recovering a schema you have
+lost.
+
+## What is stored
+
+Each migration record carries, alongside the function inventory used for orphan
+cleanup:
+
+| Column            | Contents                                                              |
+| ----------------- | -------------------------------------------------------------------- |
+| `schema_dsl`      | The exact OpenFGA DSL that was applied (a `.fga` file, or an `fga.mod` bundle) |
+| `model_json`      | The parsed model — the same structures melange compiles to SQL       |
+| `schema_format`   | `single` (a `.fga` file) or `modular` (an `fga.mod` manifest)        |
+| `schema_checksum` | A SHA-256 of the schema, used for fast change detection              |
+| `melange_version` | The melange version that applied the migration                       |
+
+`schema_dsl` and `model_json` are two independent representations of the same
+model. Tools prefer `model_json` (already parsed) and fall back to parsing
+`schema_dsl` when it is absent, so a record stays usable even if one is missing.
+
+## What reads it
+
+The deployed model is the single source of truth behind a family of commands
+(see the [CLI reference](cli) for each):
+
+| Command                          | Uses the deployed model to…                                        |
+| -------------------------------- | ------------------------------------------------------------------ |
+| `status`                         | Report whether the local schema is in sync with the database       |
+| `schema pull`                    | Reconstruct and print the deployed `.fga` for recovery or review   |
+| `diff`                           | Classify local changes additive/breaking against what is deployed  |
+| `history`                        | List the migration audit trail (versions, checksums, timestamps)   |
+| `doctor`                         | Check the model is recorded and warn on a pending breaking change  |
+| `migrate --if-deployed-checksum` | Apply only if the database is still at the expected checksum        |
+
+## Why store the model
+
+- **No drift.** The database describes itself, so there is no external state file
+  that can disagree with reality.
+- **Safe deploys.** `diff --exit-code` fails CI on a breaking change, and
+  `migrate --if-deployed-checksum` refuses to apply against a database that has
+  drifted since you planned the change.
+- **Recovery.** `schema pull` reconstructs the deployed schema straight from the
+  database when the source `.fga` has been lost.
+
+## Compatibility
+
+Model storage was introduced in melange v0.9. Databases migrated by an earlier
+version have no recorded model; the commands above detect this and report it
+plainly (for example, `schema pull` distinguishes "never migrated" from
+"migrated before model storage existed"). Re-running `melange migrate` after
+upgrading backfills the model without re-applying the generated functions, so a
+plain rerun makes these commands work — no `--force` needed.
+
+A **modular** (`fga.mod`) schema is stored as its manifest plus module bundle for
+reference and recovery. That combined form does not re-parse as a single `.fga`,
+so `schema pull` labels it as a non-parseable bundle rather than emitting a
+schema you can feed straight back into `melange migrate`.

--- a/internal/cli/command/cli_test.go
+++ b/internal/cli/command/cli_test.go
@@ -1,0 +1,286 @@
+package command
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
+)
+
+// These tests drive the assembled cobra commands in-process, covering the wiring
+// between flags, configuration loading, and environment resolution. They stay
+// on paths that never reach a database: the CLI's own validation, the
+// diagnostic commands, and the errors raised before connecting.
+
+// runCLI executes the root command in a scratch directory containing config, and
+// returns everything written to stdout. The CLI writes to os.Stdout directly
+// (cobra's output stream only carries usage and errors), so stdout is captured
+// around the call.
+func runCLI(t *testing.T, config string, args ...string) (string, error) {
+	t.Helper()
+	return runCLIWithFiles(t, config, nil, args...)
+}
+
+// runCLIWithFiles is runCLI with extra files seeded into the scratch directory,
+// for commands that read the local schema before doing anything else.
+func runCLIWithFiles(t *testing.T, config string, files map[string]string, args ...string) (string, error) {
+	t.Helper()
+
+	dir := t.TempDir()
+	if config != "" {
+		writeFile(t, dir+"/melange.yaml", config)
+	}
+	for name, content := range files {
+		if sub := filepath.Dir(name); sub != "." {
+			if err := os.MkdirAll(filepath.Join(dir, sub), 0o750); err != nil {
+				t.Fatalf("creating %s: %v", sub, err)
+			}
+		}
+		writeFile(t, filepath.Join(dir, name), content)
+	}
+	t.Chdir(dir)
+
+	// Flag values are bound to package globals, so a value set by one run would
+	// otherwise leak into the next. Reset the whole command tree, then the
+	// globals PersistentPreRunE populates, so each run starts from a clean slate
+	// regardless of test order.
+	resetFlags(rootCmd)
+	cfgFile, envFlag, quiet = "", "", false
+	activeEnv, configPath, envResolveErr = "", "", nil
+	cfg, baseCfg = nil, nil
+	noUpdateCheck = true
+	configShowSource, configShowReveal = false, false
+	t.Cleanup(func() { noUpdateCheck = false })
+
+	stdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe: %v", err)
+	}
+	os.Stdout = w
+
+	rootCmd.SetArgs(args)
+	rootCmd.SetOut(&bytes.Buffer{})
+	rootCmd.SetErr(&bytes.Buffer{})
+	runErr := rootCmd.Execute()
+
+	_ = w.Close()
+	os.Stdout = stdout
+	var buf bytes.Buffer
+	_, _ = buf.ReadFrom(r)
+	return buf.String(), runErr
+}
+
+// resetFlags restores every flag in the command tree to its declared default.
+func resetFlags(cmd *cobra.Command) {
+	reset := func(f *pflag.Flag) {
+		_ = f.Value.Set(f.DefValue)
+		f.Changed = false
+	}
+	cmd.Flags().VisitAll(reset)
+	cmd.PersistentFlags().VisitAll(reset)
+	for _, sub := range cmd.Commands() {
+		resetFlags(sub)
+	}
+}
+
+const configWithEnvironments = `
+schema: melange/schema.fga
+database:
+  url: postgres://admin:basesecret@localhost:5432/app
+default_environment: local
+environments:
+  local:
+    database:
+      url: postgres://localhost:5432/app
+  production:
+    database:
+      url: postgres://app:prodsecret@prod:5432/app
+`
+
+func TestCLI_ConfigShow_MasksSecrets(t *testing.T) {
+	out, err := runCLI(t, configWithEnvironments, "config", "show")
+	if err != nil {
+		t.Fatalf("config show: %v", err)
+	}
+
+	for _, secret := range []string{"basesecret", "prodsecret"} {
+		if strings.Contains(out, secret) {
+			t.Errorf("secret %q printed in cleartext:\n%s", secret, out)
+		}
+	}
+	if !strings.Contains(out, "****") {
+		t.Errorf("expected masked passwords in:\n%s", out)
+	}
+}
+
+func TestCLI_ConfigShow_RevealSecretsOptsIn(t *testing.T) {
+	out, err := runCLI(t, configWithEnvironments, "config", "show", "--reveal-secrets")
+	if err != nil {
+		t.Fatalf("config show --reveal-secrets: %v", err)
+	}
+
+	if !strings.Contains(out, "prodsecret") {
+		t.Errorf("--reveal-secrets should print secrets, got:\n%s", out)
+	}
+}
+
+func TestCLI_ConfigShow_Source(t *testing.T) {
+	out, err := runCLI(t, configWithEnvironments, "config", "show", "--source", "--env", "production")
+	if err != nil {
+		t.Fatalf("config show --source: %v", err)
+	}
+
+	if !strings.Contains(out, "Config file: ") || !strings.Contains(out, "melange.yaml") {
+		t.Errorf("--source should report the config file, got:\n%s", out)
+	}
+	if !strings.Contains(out, "Environment: production") {
+		t.Errorf("--source should report the active environment, got:\n%s", out)
+	}
+}
+
+func TestCLI_EnvList(t *testing.T) {
+	out, err := runCLI(t, configWithEnvironments, "env", "list")
+	if err != nil {
+		t.Fatalf("env list: %v", err)
+	}
+
+	for _, want := range []string{"Environments:", "local", "production", "Default: local"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "prodsecret") {
+		t.Errorf("env list must not print credentials:\n%s", out)
+	}
+}
+
+// The default_environment is applied without a flag, and marked as active.
+func TestCLI_EnvList_MarksDefaultEnvironmentActive(t *testing.T) {
+	out, err := runCLI(t, configWithEnvironments, "env", "list")
+	if err != nil {
+		t.Fatalf("env list: %v", err)
+	}
+
+	if !strings.Contains(out, "* local") {
+		t.Errorf("the environment selected by default_environment should be marked active:\n%s", out)
+	}
+}
+
+// A typo in --env must stop the command rather than run it against the base
+// (often local) database.
+func TestCLI_UndefinedEnvironmentIsRejected(t *testing.T) {
+	_, err := runCLI(t, configWithEnvironments, "config", "show", "--env", "prod")
+	if err == nil {
+		t.Fatal("expected an error for an undefined environment")
+	}
+	if !strings.Contains(err.Error(), "prod") {
+		t.Errorf("error should name the environment, got: %v", err)
+	}
+}
+
+func TestCLI_ValidationErrorsBeforeConnecting(t *testing.T) {
+	cases := []struct {
+		name    string
+		args    []string
+		wantErr string
+	}{
+		{"diff format", []string{"diff", "--format", "yaml"}, "invalid --format"},
+		{"diff sources", []string{"diff", "--git-ref", "main", "--previous-schema", "old.fga"}, "mutually exclusive"},
+		{"diff db with git ref", []string{"diff", "--db", "postgres://localhost/app", "--git-ref", "main"}, "cannot be combined"},
+		{"history format", []string{"history", "--format", "yaml"}, "invalid --format"},
+		{"history limit", []string{"history", "--limit", "0"}, "--limit"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := runCLI(t, configWithEnvironments, tc.args...)
+			if err == nil {
+				t.Fatalf("expected an error containing %q", tc.wantErr)
+			}
+			if !strings.Contains(err.Error(), tc.wantErr) {
+				t.Errorf("error = %v, want it to mention %q", err, tc.wantErr)
+			}
+		})
+	}
+}
+
+// Without a database URL anywhere, commands that need one fail with a
+// configuration error rather than attempting a connection.
+func TestCLI_MissingDatabaseURL(t *testing.T) {
+	_, err := runCLI(t, "schema: melange/schema.fga\n", "history")
+	if err == nil {
+		t.Fatal("expected an error when no database is configured")
+	}
+}
+
+// unreachableDB refuses immediately, so these cases stay fast and deterministic.
+const unreachableDB = "postgres://127.0.0.1:1/nope?sslmode=disable&connect_timeout=1"
+
+// A database that cannot be reached must surface as a clear error from every
+// command that needs one — not a panic, and not a silently empty result that
+// would read as "nothing is deployed".
+func TestCLI_UnreachableDatabaseReportsAnError(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"status", []string{"status", "--db", unreachableDB}},
+		{"status json", []string{"status", "--db", unreachableDB, "--format", "json"}},
+		{"history", []string{"history", "--db", unreachableDB}},
+		{"schema pull", []string{"schema", "pull", "--db", unreachableDB}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			out, err := runCLI(t, "schema: melange/schema.fga\n", tc.args...)
+			if err == nil {
+				t.Fatalf("expected an error; output was:\n%s", out)
+			}
+			if !strings.Contains(err.Error(), "connect") {
+				t.Errorf("error should describe the connection failure, got: %v", err)
+			}
+		})
+	}
+}
+
+// diff parses the local schema before it connects, so it needs one on disk to
+// reach the database at all.
+func TestCLI_DiffUnreachableDatabase(t *testing.T) {
+	_, err := runCLIWithFiles(t, "schema: melange/schema.fga\n",
+		map[string]string{"melange/schema.fga": "model\n  schema 1.1\ntype user\n"},
+		"diff", "--db", unreachableDB)
+	if err == nil {
+		t.Fatal("expected a connection error")
+	}
+	if !strings.Contains(err.Error(), "connect") {
+		t.Errorf("error should describe the connection failure, got: %v", err)
+	}
+}
+
+// A missing local schema is reported as such, rather than as a database problem.
+func TestCLI_DiffMissingLocalSchema(t *testing.T) {
+	_, err := runCLI(t, "schema: melange/schema.fga\n", "diff", "--db", unreachableDB)
+	if err == nil {
+		t.Fatal("expected an error for a missing schema file")
+	}
+	if !strings.Contains(err.Error(), "melange/schema.fga") {
+		t.Errorf("error should name the missing schema, got: %v", err)
+	}
+}
+
+// status keeps its reachability signal even when the schema file is missing:
+// the file and view checks still report, so the command stays useful.
+func TestCLI_StatusFormatValidatedBeforeConnecting(t *testing.T) {
+	_, err := runCLI(t, "schema: melange/schema.fga\n", "status", "--db", unreachableDB, "--format", "yaml")
+	if err == nil {
+		t.Fatal("expected an invalid-format error")
+	}
+	if !strings.Contains(err.Error(), "invalid --format") {
+		t.Errorf("format should be validated before connecting, got: %v", err)
+	}
+}

--- a/internal/cli/command/config.go
+++ b/internal/cli/command/config.go
@@ -7,7 +7,10 @@ import (
 	"sigs.k8s.io/yaml"
 )
 
-var configShowSource bool
+var (
+	configShowSource bool
+	configShowReveal bool
+)
 
 var configCmd = &cobra.Command{
 	Use:   "config",
@@ -17,23 +20,39 @@ var configCmd = &cobra.Command{
 var configShowCmd = &cobra.Command{
 	Use:   "show",
 	Short: "Show effective configuration",
-	Long:  `Show the effective configuration after merging defaults, config file, and environment variables.`,
+	Long: `Show the effective configuration after merging defaults, config file,
+environment variables, and any selected environment profile.
+
+Passwords (including those resolved from ${VAR} references) are masked by
+default; pass --reveal-secrets to print them in cleartext.`,
 	Example: `  # Show effective configuration
   melange config show
 
   # Show configuration with source file path
-  melange config show --source`,
+  melange config show --source
+
+  # Show the resolved production profile, secrets unmasked
+  melange config show --env production --reveal-secrets`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if configShowSource {
 			if configPath != "" {
-				fmt.Printf("Config file: %s\n\n", configPath)
+				fmt.Printf("Config file: %s\n", configPath)
 			} else {
 				fmt.Println("Config file: (none, using defaults)")
-				fmt.Println()
 			}
+			if activeEnv != "" {
+				fmt.Printf("Environment: %s\n", activeEnv)
+			} else {
+				fmt.Println("Environment: (base, none selected)")
+			}
+			fmt.Println()
 		}
 
-		out, err := yaml.Marshal(cfg)
+		toShow := cfg
+		if !configShowReveal {
+			toShow = cfg.Redacted()
+		}
+		out, err := yaml.Marshal(toShow)
 		if err != nil {
 			return err
 		}
@@ -44,5 +63,6 @@ var configShowCmd = &cobra.Command{
 
 func init() {
 	configShowCmd.Flags().BoolVar(&configShowSource, "source", false, "show config file source")
+	configShowCmd.Flags().BoolVar(&configShowReveal, "reveal-secrets", false, "print passwords in cleartext instead of masking them")
 	configCmd.AddCommand(configShowCmd)
 }

--- a/internal/cli/command/deployed_model.go
+++ b/internal/cli/command/deployed_model.go
@@ -44,7 +44,7 @@ func readDeployedModel(dsn, databaseSchema string) (*migrator.DeployedModel, err
 	case rerr != nil:
 		return nil, cli.GeneralError("reading migration record", rerr)
 	case rec != nil:
-		return nil, cli.GeneralError("this database was migrated before melange v0.9, so the model was not recorded — re-run `melange migrate` with a current version to record it", nil)
+		return nil, cli.GeneralError("this database was migrated before melange recorded deployed models, so the model is not available — re-run `melange migrate` with a current version to record it", nil)
 	default:
 		return nil, cli.GeneralError("no melange migration found in this database", nil)
 	}

--- a/internal/cli/command/deployed_model.go
+++ b/internal/cli/command/deployed_model.go
@@ -3,11 +3,14 @@ package command
 import (
 	"context"
 	"database/sql"
+	"fmt"
 
 	_ "github.com/lib/pq"
 
 	"github.com/pthm/melange/internal/cli"
 	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/pkg/parser"
+	"github.com/pthm/melange/pkg/schema"
 )
 
 // readDeployedModel opens dsn and returns the model recorded by the most recent
@@ -45,4 +48,25 @@ func readDeployedModel(dsn, databaseSchema string) (*migrator.DeployedModel, err
 	default:
 		return nil, cli.GeneralError("no melange migration found in this database", nil)
 	}
+}
+
+// deployedTypesFromRecord returns the parsed model stored in a migration row,
+// preferring model_json and falling back to parsing the recorded DSL when the
+// JSON is absent or empty — the same order `doctor` uses, so both agree on what
+// a database has deployed.
+//
+// Returns nil types and nil error when the row predates model storage (no DSL
+// recorded), which callers report as "not recorded" rather than as an error.
+func deployedTypesFromRecord(rec *migrator.MigrationRecord) ([]schema.TypeDefinition, error) {
+	if rec == nil || rec.SchemaDSL == "" {
+		return nil, nil
+	}
+	if types, err := schema.UnmarshalModel(rec.ModelJSON); err == nil && len(types) > 0 {
+		return types, nil
+	}
+	types, err := parser.ParseSchemaString(rec.SchemaDSL)
+	if err != nil {
+		return nil, fmt.Errorf("parsing recorded schema DSL: %w", err)
+	}
+	return types, nil
 }

--- a/internal/cli/command/deployed_model.go
+++ b/internal/cli/command/deployed_model.go
@@ -1,0 +1,48 @@
+package command
+
+import (
+	"context"
+	"database/sql"
+
+	_ "github.com/lib/pq"
+
+	"github.com/pthm/melange/internal/cli"
+	"github.com/pthm/melange/pkg/migrator"
+)
+
+// readDeployedModel opens dsn and returns the model recorded by the most recent
+// migration. Shared by `schema pull` and `diff` so their handling — including
+// the "never migrated" vs "migrated before the model was recorded" distinction
+// and connection errors — stays consistent.
+func readDeployedModel(dsn, databaseSchema string) (*migrator.DeployedModel, error) {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return nil, cli.DBConnectError("connecting to database", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+	m.SetDatabaseSchema(databaseSchema)
+
+	model, err := m.GetDeployedModel(ctx)
+	if err != nil {
+		return nil, cli.GeneralError("reading deployed model", err)
+	}
+	if model != nil {
+		return model, nil
+	}
+
+	// No model recorded: distinguish an un-migrated database from one migrated
+	// before model storage. A failed re-fetch is surfaced rather than reported
+	// as "never migrated".
+	rec, rerr := m.GetLastMigration(ctx)
+	switch {
+	case rerr != nil:
+		return nil, cli.GeneralError("reading migration record", rerr)
+	case rec != nil:
+		return nil, cli.GeneralError("this database was migrated before melange v0.9, so the model was not recorded — re-run `melange migrate` with a current version to record it", nil)
+	default:
+		return nil, cli.GeneralError("no melange migration found in this database", nil)
+	}
+}

--- a/internal/cli/command/diff.go
+++ b/internal/cli/command/diff.go
@@ -1,0 +1,172 @@
+package command
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pthm/melange/internal/cli"
+	"github.com/pthm/melange/pkg/parser"
+	"github.com/pthm/melange/pkg/schema"
+)
+
+var (
+	diffSchema         string
+	diffDB             string
+	diffDBSchema       string
+	diffGitRef         string
+	diffPreviousSchema string
+	diffFormat         string
+	diffExitCode       bool
+)
+
+var diffCmd = &cobra.Command{
+	Use:   "diff",
+	Short: "Show what changed between a deployed/previous model and your local schema",
+	Long: `Diff compares your local schema (the "new" side) against a previous model
+(the "old" side) and classifies each change as additive (safe — widens access
+or adds structure) or breaking (narrows access or removes structure).
+
+The comparison source is one of:
+  - (default) the model deployed in a database (--db / --env, or config)
+  - --git-ref <ref>: your schema as of a git commit, branch, or tag
+  - --previous-schema <path>: a previous .fga file
+
+Use --exit-code in CI to fail the build when a change is breaking.`,
+	Example: `  # What would migrating apply to production?
+  melange diff --env production
+
+  # Compare against the schema on main
+  melange diff --git-ref main
+
+  # Compare two files
+  melange diff --previous-schema old.fga
+
+  # CI gate: non-zero exit on breaking changes
+  melange diff --env production --exit-code`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		schemaPath := resolveString(diffSchema, cfg.Schema)
+		databaseSchema := resolveString(diffDBSchema, cfg.Database.Schema, "public")
+
+		if schemaPath == "" {
+			return cli.ConfigError("no schema path — set --schema or `schema` in config", nil)
+		}
+		if diffFormat != "tree" && diffFormat != "json" {
+			return cli.ConfigError(fmt.Sprintf("invalid --format %q (want tree or json)", diffFormat), nil)
+		}
+		if boolCount(diffGitRef != "", diffPreviousSchema != "") > 1 {
+			return cli.ConfigError("--git-ref and --previous-schema are mutually exclusive", nil)
+		}
+		// An explicitly requested database source (--db, or an explicit --env /
+		// MELANGE_ENV) can't be combined with a file/git source. A passive
+		// default_environment does not count — git/file still wins there.
+		explicitDBSource := diffDB != "" || resolveString(envFlag, os.Getenv("MELANGE_ENV")) != ""
+		if explicitDBSource && (diffGitRef != "" || diffPreviousSchema != "") {
+			return cli.ConfigError("a database source (--db/--env) cannot be combined with --git-ref or --previous-schema", nil)
+		}
+
+		newTypes, err := parser.ParseSchema(schemaPath)
+		if err != nil {
+			return cli.SchemaParseError("parsing local schema", err)
+		}
+
+		oldTypes, source, err := diffPreviousModel(schemaPath, databaseSchema)
+		if err != nil {
+			return err
+		}
+
+		d := schema.Diff(oldTypes, newTypes)
+		renderDiff(d, source, schemaPath)
+
+		if diffExitCode && d.HasBreaking() {
+			// git-diff-style signal for CI gates; errors already exited above.
+			os.Exit(1)
+		}
+		return nil
+	},
+}
+
+func init() {
+	f := diffCmd.Flags()
+	f.StringVar(&diffSchema, "schema", "", "path to the local .fga or fga.mod file (the new side)")
+	f.StringVar(&diffDB, "db", "", "database URL to compare against (the default source)")
+	f.StringVar(&diffDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
+	f.StringVar(&diffGitRef, "git-ref", "", "compare against the schema at this git ref")
+	f.StringVar(&diffPreviousSchema, "previous-schema", "", "compare against a previous .fga file (modular not supported)")
+	f.StringVar(&diffFormat, "format", "tree", "output format: tree (default) or json")
+	f.BoolVar(&diffExitCode, "exit-code", false, "exit 1 if any change is breaking")
+}
+
+// diffPreviousModel resolves the "old" side of the diff and a label for it.
+func diffPreviousModel(schemaPath, databaseSchema string) ([]schema.TypeDefinition, string, error) {
+	switch {
+	case diffGitRef != "":
+		relPath, err := gitRelativePath(schemaPath)
+		if err != nil {
+			return nil, "", err
+		}
+		types, err := parsePreviousSchema(diffGitRef, relPath, true)
+		return types, "git:" + diffGitRef, err
+	case diffPreviousSchema != "":
+		if parser.IsModularSchema(diffPreviousSchema) {
+			return nil, "", cli.ConfigError("--previous-schema does not support modular schemas (fga.mod); use --db or --git-ref instead", nil)
+		}
+		types, err := parsePreviousSchema(diffPreviousSchema, "", false)
+		return types, "file:" + diffPreviousSchema, err
+	default:
+		dsn, err := resolveDSN(diffDB)
+		if err != nil {
+			return nil, "", err
+		}
+		types, err := deployedModelTypes(dsn, databaseSchema)
+		return types, "deployed", err
+	}
+}
+
+// deployedModelTypes reads the parsed model recorded in a database. If only the
+// DSL was recorded (model_json absent), it parses the DSL so the deployed side
+// is never silently empty — which would misreport every local type as additive.
+func deployedModelTypes(dsn, databaseSchema string) ([]schema.TypeDefinition, error) {
+	model, err := readDeployedModel(dsn, databaseSchema)
+	if err != nil {
+		return nil, err
+	}
+	if len(model.Types) == 0 && model.DSL != "" {
+		types, perr := parser.ParseSchemaString(model.DSL)
+		if perr != nil {
+			return nil, cli.SchemaParseError("parsing deployed schema", perr)
+		}
+		return types, nil
+	}
+	return model.Types, nil
+}
+
+func renderDiff(d schema.SchemaDiff, source, schemaPath string) {
+	if diffFormat == "json" {
+		out, err := json.MarshalIndent(d, "", "  ")
+		if err != nil {
+			// SchemaDiff is plain data; marshaling cannot fail.
+			out = []byte("{}")
+		}
+		fmt.Println(string(out))
+		return
+	}
+
+	fmt.Printf("Comparing %s → %s\n\n", source, schemaPath)
+	if d.Empty() {
+		fmt.Println("No changes — schemas are equivalent.")
+		return
+	}
+	for _, c := range d.Changes {
+		label := "additive"
+		if c.Class == schema.ClassBreaking {
+			label = "BREAKING"
+		}
+		fmt.Printf("  %-9s %s\n", label, c.Summary)
+	}
+	additive, breaking := d.Counts()
+	fmt.Printf("\n%d breaking, %d additive\n", breaking, additive)
+}

--- a/internal/cli/command/diff.go
+++ b/internal/cli/command/diff.go
@@ -3,6 +3,7 @@ package command
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 
 	"github.com/spf13/cobra"
@@ -51,21 +52,9 @@ Use --exit-code in CI to fail the build when a change is breaking.`,
 		schemaPath := resolveString(diffSchema, cfg.Schema)
 		databaseSchema := resolveString(diffDBSchema, cfg.Database.Schema, "public")
 
-		if schemaPath == "" {
-			return cli.ConfigError("no schema path — set --schema or `schema` in config", nil)
-		}
-		if diffFormat != "tree" && diffFormat != "json" {
-			return cli.ConfigError(fmt.Sprintf("invalid --format %q (want tree or json)", diffFormat), nil)
-		}
-		if boolCount(diffGitRef != "", diffPreviousSchema != "") > 1 {
-			return cli.ConfigError("--git-ref and --previous-schema are mutually exclusive", nil)
-		}
-		// An explicitly requested database source (--db, or an explicit --env /
-		// MELANGE_ENV) can't be combined with a file/git source. A passive
-		// default_environment does not count — git/file still wins there.
 		explicitDBSource := diffDB != "" || resolveString(envFlag, os.Getenv("MELANGE_ENV")) != ""
-		if explicitDBSource && (diffGitRef != "" || diffPreviousSchema != "") {
-			return cli.ConfigError("a database source (--db/--env) cannot be combined with --git-ref or --previous-schema", nil)
+		if err := validateDiffFlags(schemaPath, diffFormat, diffGitRef, diffPreviousSchema, explicitDBSource); err != nil {
+			return err
 		}
 
 		newTypes, err := parser.ParseSchema(schemaPath)
@@ -79,7 +68,7 @@ Use --exit-code in CI to fail the build when a change is breaking.`,
 		}
 
 		d := schema.Diff(oldTypes, newTypes)
-		renderDiff(d, source, schemaPath)
+		renderDiff(os.Stdout, d, source, schemaPath)
 
 		if diffExitCode && d.HasBreaking() {
 			// git-diff-style signal for CI gates; errors already exited above.
@@ -98,6 +87,29 @@ func init() {
 	f.StringVar(&diffPreviousSchema, "previous-schema", "", "compare against a previous .fga file (modular not supported)")
 	f.StringVar(&diffFormat, "format", "tree", "output format: tree (default) or json")
 	f.BoolVar(&diffExitCode, "exit-code", false, "exit 1 if any change is breaking")
+}
+
+// validateDiffFlags rejects flag combinations that have no single answer, before
+// any database connection is attempted.
+//
+// explicitDBSource means the user actively chose a database (--db, or --env /
+// MELANGE_ENV): only then does a database source conflict with --git-ref or
+// --previous-schema. A passive default_environment does not conflict, so
+// `melange diff --git-ref main` still works in a repo that has one configured.
+func validateDiffFlags(schemaPath, format, gitRef, previousSchema string, explicitDBSource bool) error {
+	if schemaPath == "" {
+		return cli.ConfigError("no schema path — set --schema or `schema` in config", nil)
+	}
+	if format != "tree" && format != "json" {
+		return cli.ConfigError(fmt.Sprintf("invalid --format %q (want tree or json)", format), nil)
+	}
+	if boolCount(gitRef != "", previousSchema != "") > 1 {
+		return cli.ConfigError("--git-ref and --previous-schema are mutually exclusive", nil)
+	}
+	if explicitDBSource && (gitRef != "" || previousSchema != "") {
+		return cli.ConfigError("a database source (--db/--env) cannot be combined with --git-ref or --previous-schema", nil)
+	}
+	return nil
 }
 
 // diffPreviousModel resolves the "old" side of the diff and a label for it.
@@ -144,20 +156,20 @@ func deployedModelTypes(dsn, databaseSchema string) ([]schema.TypeDefinition, er
 	return model.Types, nil
 }
 
-func renderDiff(d schema.SchemaDiff, source, schemaPath string) {
+func renderDiff(w io.Writer, d schema.SchemaDiff, source, schemaPath string) {
 	if diffFormat == "json" {
 		out, err := json.MarshalIndent(d, "", "  ")
 		if err != nil {
 			// SchemaDiff is plain data; marshaling cannot fail.
 			out = []byte("{}")
 		}
-		fmt.Println(string(out))
+		_, _ = fmt.Fprintln(w, string(out))
 		return
 	}
 
-	fmt.Printf("Comparing %s → %s\n\n", source, schemaPath)
+	_, _ = fmt.Fprintf(w, "Comparing %s → %s\n\n", source, schemaPath)
 	if d.Empty() {
-		fmt.Println("No changes — schemas are equivalent.")
+		_, _ = fmt.Fprintln(w, "No changes — schemas are equivalent.")
 		return
 	}
 	for _, c := range d.Changes {
@@ -165,8 +177,8 @@ func renderDiff(d schema.SchemaDiff, source, schemaPath string) {
 		if c.Class == schema.ClassBreaking {
 			label = "BREAKING"
 		}
-		fmt.Printf("  %-9s %s\n", label, c.Summary)
+		_, _ = fmt.Fprintf(w, "  %-9s %s\n", label, c.Summary)
 	}
 	additive, breaking := d.Counts()
-	fmt.Printf("\n%d breaking, %d additive\n", breaking, additive)
+	_, _ = fmt.Fprintf(w, "\n%d breaking, %d additive\n", breaking, additive)
 }

--- a/internal/cli/command/diff_test.go
+++ b/internal/cli/command/diff_test.go
@@ -1,0 +1,76 @@
+package command
+
+import (
+	"strings"
+	"testing"
+)
+
+// setDiffFlags points the package-level diff flags at one source and restores
+// them afterwards, so each test exercises resolution in isolation.
+func setDiffFlags(t *testing.T, gitRef, previousSchema string) {
+	t.Helper()
+	origRef, origPrev := diffGitRef, diffPreviousSchema
+	t.Cleanup(func() { diffGitRef, diffPreviousSchema = origRef, origPrev })
+	diffGitRef, diffPreviousSchema = gitRef, previousSchema
+}
+
+func TestDiffPreviousModel_GitRefReadsSchemaAtThatCommit(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1, schemaV2)
+	setDiffFlags(t, "HEAD~1", "")
+
+	types, source, err := diffPreviousModel("schema.fga", "public")
+	if err != nil {
+		t.Fatalf("diffPreviousModel: %v", err)
+	}
+	if source != "git:HEAD~1" {
+		t.Errorf("source = %q, want git:HEAD~1", source)
+	}
+	// HEAD~1 is the one-type version; the working tree has two.
+	if len(types) != 1 || types[0].Name != "user" {
+		t.Errorf("types = %+v, want only the type present at HEAD~1", types)
+	}
+}
+
+func TestDiffPreviousModel_PreviousSchemaReadsTheFile(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV2)
+	writeFile(t, "old.fga", schemaV1)
+	setDiffFlags(t, "", "old.fga")
+
+	types, source, err := diffPreviousModel("schema.fga", "public")
+	if err != nil {
+		t.Fatalf("diffPreviousModel: %v", err)
+	}
+	if source != "file:old.fga" {
+		t.Errorf("source = %q, want file:old.fga", source)
+	}
+	if len(types) != 1 {
+		t.Errorf("types = %d, want 1 from old.fga", len(types))
+	}
+}
+
+// A modular previous schema cannot be read as one file, and saying so beats
+// diffing against a half-parsed model.
+func TestDiffPreviousModel_PreviousSchemaRejectsModular(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1)
+	writeFile(t, "fga.mod", "schema: 1.2\ncontents:\n  - core.fga\n")
+	setDiffFlags(t, "", "fga.mod")
+
+	_, _, err := diffPreviousModel("schema.fga", "public")
+	if err == nil {
+		t.Fatal("expected an error for a modular --previous-schema")
+	}
+	if !strings.Contains(err.Error(), "modular") {
+		t.Errorf("error = %q, want it to name the modular limitation", err)
+	}
+}
+
+// An unknown ref must surface as an error rather than an empty previous model,
+// which would misreport every existing type as newly added.
+func TestDiffPreviousModel_UnknownGitRefErrors(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1)
+	setDiffFlags(t, "no-such-ref", "")
+
+	if _, _, err := diffPreviousModel("schema.fga", "public"); err == nil {
+		t.Error("expected an error for an unknown git ref")
+	}
+}

--- a/internal/cli/command/diff_test.go
+++ b/internal/cli/command/diff_test.go
@@ -74,3 +74,48 @@ func TestDiffPreviousModel_UnknownGitRefErrors(t *testing.T) {
 		t.Error("expected an error for an unknown git ref")
 	}
 }
+
+func TestValidateDiffFlags(t *testing.T) {
+	cases := []struct {
+		name                   string
+		schemaPath, format     string
+		gitRef, previousSchema string
+		explicitDB             bool
+		wantErr                string
+	}{
+		{name: "database source by default", schemaPath: "schema.fga", format: "tree"},
+		{name: "git ref source", schemaPath: "schema.fga", format: "tree", gitRef: "main"},
+		{name: "json format", schemaPath: "schema.fga", format: "json"},
+		// A configured default_environment must not block a git comparison.
+		{name: "passive environment with git ref", schemaPath: "schema.fga", format: "tree", gitRef: "main", explicitDB: false},
+
+		{name: "no schema", format: "tree", wantErr: "no schema path"},
+		{name: "bad format", schemaPath: "schema.fga", format: "yaml", wantErr: "invalid --format"},
+		{
+			name: "two file sources", schemaPath: "schema.fga", format: "tree",
+			gitRef: "main", previousSchema: "old.fga", wantErr: "mutually exclusive",
+		},
+		{
+			name: "explicit database plus git ref", schemaPath: "schema.fga", format: "tree",
+			gitRef: "main", explicitDB: true, wantErr: "cannot be combined",
+		},
+		{
+			name: "explicit database plus previous schema", schemaPath: "schema.fga", format: "tree",
+			previousSchema: "old.fga", explicitDB: true, wantErr: "cannot be combined",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := validateDiffFlags(tc.schemaPath, tc.format, tc.gitRef, tc.previousSchema, tc.explicitDB)
+			switch {
+			case tc.wantErr == "" && err != nil:
+				t.Fatalf("unexpected error: %v", err)
+			case tc.wantErr != "" && err == nil:
+				t.Fatalf("expected an error containing %q", tc.wantErr)
+			case tc.wantErr != "" && !strings.Contains(err.Error(), tc.wantErr):
+				t.Errorf("error = %v, want it to mention %q", err, tc.wantErr)
+			}
+		})
+	}
+}

--- a/internal/cli/command/doctor.go
+++ b/internal/cli/command/doctor.go
@@ -34,7 +34,7 @@ var doctorCmd = &cobra.Command{
   # Run with verbose output
   melange doctor --db postgres://localhost/mydb --verbose`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		databaseSchema := resolveString(doctorDBSchema, cfg.Database.Schema)
+		databaseSchema := resolveString(doctorDBSchema, cfg.Database.Schema, "public")
 		schemaPath := resolveString(doctorSchema, cfg.Schema)
 		verboseFlag := resolveBool(doctorVerbose, cfg.Doctor.Verbose)
 		skipPerf := resolveBool(doctorSkipPerformance, cfg.Doctor.SkipPerformance)
@@ -51,7 +51,7 @@ var doctorCmd = &cobra.Command{
 func init() {
 	f := doctorCmd.Flags()
 	f.StringVar(&doctorDB, "db", "", "database URL")
-	f.StringVar(&doctorDBSchema, "db-schema", "public", "database schema")
+	f.StringVar(&doctorDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
 	f.StringVar(&doctorSchema, "schema", "", "path to schema.fga or fga.mod file")
 	f.BoolVar(&doctorVerbose, "verbose", false, "show detailed output")
 	f.BoolVar(&doctorSkipPerformance, "skip-performance", false, "skip performance checks")

--- a/internal/cli/command/env.go
+++ b/internal/cli/command/env.go
@@ -1,0 +1,80 @@
+package command
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/spf13/cobra"
+
+	"github.com/pthm/melange/internal/cli"
+)
+
+var envCmd = &cobra.Command{
+	Use:   "env",
+	Short: "Environment profile utilities",
+	Long: `Inspect the named environment profiles defined in configuration.
+
+Environments are connection profiles selected with the global --env flag
+(or the MELANGE_ENV variable, or the default_environment config key). Each
+overlays the base database configuration, so a command like
+
+  melange status --env production
+
+targets that environment's database.`,
+}
+
+var envListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List defined environment profiles",
+	Long:  `List the environment profiles defined in configuration and their connection targets.`,
+	Example: `  # List environments
+  melange env list`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runEnvList()
+	},
+}
+
+func init() {
+	envCmd.AddCommand(envListCmd)
+}
+
+func runEnvList() error {
+	// baseCfg holds the configuration before any --env overlay, so each profile
+	// is summarized against the same base.
+	names := make([]string, 0, len(baseCfg.Environments))
+	for name := range baseCfg.Environments {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	if len(names) == 0 {
+		fmt.Println("No environments defined.")
+		fmt.Println("\nAdd them under 'environments:' in your config, e.g.:")
+		fmt.Println("  environments:")
+		fmt.Println("    production:")
+		fmt.Println("      database:")
+		fmt.Println("        url: ${PROD_DATABASE_URL}")
+		return nil
+	}
+
+	fmt.Println("Environments:")
+	for _, name := range names {
+		summary, err := baseCfg.EnvironmentSummary(name)
+		if err != nil {
+			return cli.ConfigError("summarizing environment", err)
+		}
+		marker := "  "
+		if name == activeEnv {
+			marker = "* "
+		}
+		fmt.Printf("%s%-16s %s\n", marker, name, summary)
+	}
+
+	if baseCfg.DefaultEnvironment != "" {
+		fmt.Printf("\nDefault: %s\n", baseCfg.DefaultEnvironment)
+	}
+	if activeEnv != "" {
+		fmt.Printf("Active:  %s (marked with *)\n", activeEnv)
+	}
+	return nil
+}

--- a/internal/cli/command/env.go
+++ b/internal/cli/command/env.go
@@ -2,6 +2,8 @@ package command
 
 import (
 	"fmt"
+	"io"
+	"os"
 	"sort"
 
 	"github.com/spf13/cobra"
@@ -39,42 +41,47 @@ func init() {
 }
 
 func runEnvList() error {
-	// baseCfg holds the configuration before any --env overlay, so each profile
-	// is summarized against the same base.
-	names := make([]string, 0, len(baseCfg.Environments))
-	for name := range baseCfg.Environments {
+	return printEnvironments(os.Stdout, baseCfg, activeEnv)
+}
+
+// printEnvironments writes one line per configured profile, marking the active
+// one. cfg is the configuration before any --env overlay, so every profile is
+// summarized against the same base.
+func printEnvironments(w io.Writer, cfg *cli.Config, active string) error {
+	names := make([]string, 0, len(cfg.Environments))
+	for name := range cfg.Environments {
 		names = append(names, name)
 	}
 	sort.Strings(names)
 
 	if len(names) == 0 {
-		fmt.Println("No environments defined.")
-		fmt.Println("\nAdd them under 'environments:' in your config, e.g.:")
-		fmt.Println("  environments:")
-		fmt.Println("    production:")
-		fmt.Println("      database:")
-		fmt.Println("        url: ${PROD_DATABASE_URL}")
+		_, _ = fmt.Fprintln(w, "No environments defined.")
+		_, _ = fmt.Fprintln(w, "\nAdd them under 'environments:' in your config, e.g.:")
+		_, _ = fmt.Fprintln(w, "  environments:")
+		_, _ = fmt.Fprintln(w, "    production:")
+		_, _ = fmt.Fprintln(w, "      database:")
+		_, _ = fmt.Fprintln(w, "        url: ${PROD_DATABASE_URL}")
 		return nil
 	}
 
-	fmt.Println("Environments:")
+	_, _ = fmt.Fprintln(w, "Environments:")
 	for _, name := range names {
-		summary, err := baseCfg.EnvironmentSummary(name)
+		summary, err := cfg.EnvironmentSummary(name)
 		if err != nil {
 			return cli.ConfigError("summarizing environment", err)
 		}
 		marker := "  "
-		if name == activeEnv {
+		if name == active {
 			marker = "* "
 		}
-		fmt.Printf("%s%-16s %s\n", marker, name, summary)
+		_, _ = fmt.Fprintf(w, "%s%-16s %s\n", marker, name, summary)
 	}
 
-	if baseCfg.DefaultEnvironment != "" {
-		fmt.Printf("\nDefault: %s\n", baseCfg.DefaultEnvironment)
+	if cfg.DefaultEnvironment != "" {
+		_, _ = fmt.Fprintf(w, "\nDefault: %s\n", cfg.DefaultEnvironment)
 	}
-	if activeEnv != "" {
-		fmt.Printf("Active:  %s (marked with *)\n", activeEnv)
+	if active != "" {
+		_, _ = fmt.Fprintf(w, "Active:  %s (marked with *)\n", active)
 	}
 	return nil
 }

--- a/internal/cli/command/expand.go
+++ b/internal/cli/command/expand.go
@@ -67,7 +67,7 @@ Leaf.Users array; capped leaves carry users_truncated: true.`,
   melange expand document:1 viewer --format=json`,
 	Args: cobra.ExactArgs(2),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		databaseSchema := resolveString(expandDBSchema, cfg.Database.Schema)
+		databaseSchema := resolveString(expandDBSchema, cfg.Database.Schema, "public")
 
 		dsn, err := resolveDSN(expandDB)
 		if err != nil {
@@ -88,7 +88,7 @@ Leaf.Users array; capped leaves carry users_truncated: true.`,
 func init() {
 	f := expandCmd.Flags()
 	f.StringVar(&expandDB, "db", "", "database URL")
-	f.StringVar(&expandDBSchema, "db-schema", "public", "database schema")
+	f.StringVar(&expandDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
 	f.StringVar(&expandFormat, "format", "tree", "output format: tree (default) or json")
 	f.StringVar(&expandSubjectType, "subject-type", "", "Melange extension: narrow Leaf.Users to this subject type (empty = no filter)")
 	f.IntVar(&expandMaxLeaf, "max-leaf", 0, "Melange extension: cap entries per Leaf.Users (0 = unbounded, OpenFGA-equivalent)")

--- a/internal/cli/command/explain.go
+++ b/internal/cli/command/explain.go
@@ -52,7 +52,7 @@ when the cap is hit the rendered output ends in "... truncated".`,
   melange explain user:alice viewer document:1 --format=json`,
 	Args: cobra.ExactArgs(3),
 	RunE: func(cmd *cobra.Command, args []string) error {
-		databaseSchema := resolveString(explainDBSchema, cfg.Database.Schema)
+		databaseSchema := resolveString(explainDBSchema, cfg.Database.Schema, "public")
 
 		dsn, err := resolveDSN(explainDB)
 		if err != nil {
@@ -76,7 +76,7 @@ when the cap is hit the rendered output ends in "... truncated".`,
 func init() {
 	f := explainCmd.Flags()
 	f.StringVar(&explainDB, "db", "", "database URL")
-	f.StringVar(&explainDBSchema, "db-schema", "public", "database schema")
+	f.StringVar(&explainDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
 	f.StringVar(&explainFormat, "format", "tree", "output format: tree (default) or json")
 	f.IntVar(&explainMaxNodes, "max-nodes", 0, "cap total nodes in the trace (0 = session GUC melange.max_explain_nodes or built-in 100)")
 	f.StringVar(&explainColor, "color", "auto", "color output: auto|always|never (auto = stdout-is-TTY and NO_COLOR unset)")

--- a/internal/cli/command/generate_migration.go
+++ b/internal/cli/command/generate_migration.go
@@ -62,7 +62,7 @@ Three comparison modes determine orphaned functions to drop:
   melange generate migration --schema schema.fga --output migrations/ --previous-schema old.fga`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Resolve values: flags > config > defaults
-		databaseSchema := resolveString(genMigrationDBSchema, cfg.Database.Schema)
+		databaseSchema := resolveString(genMigrationDBSchema, cfg.Database.Schema, "public")
 		schemaPath := resolveString(genMigrationSchema, cfg.Schema)
 		output := resolveString(genMigrationOutput, cfg.Generate.Migration.Output)
 		name := resolveString(genMigrationName, cfg.Generate.Migration.Name, "melange")
@@ -187,7 +187,7 @@ func init() {
 	f.BoolVar(&genMigrationUp, "up", false, "output only the UP migration")
 	f.BoolVar(&genMigrationDown, "down", false, "output only the DOWN migration")
 	f.StringVar(&genMigrationDB, "db", "", "database URL for comparison (reads previous state)")
-	f.StringVar(&genMigrationDBSchema, "db-schema", "public", "database schema")
+	f.StringVar(&genMigrationDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
 	f.StringVar(&genMigrationGitRef, "git-ref", "", "git ref for comparison (reads previous schema)")
 	f.StringVar(&genMigrationPreviousSchema, "previous-schema", "", "path to previous .fga file for comparison (modular schemas not supported)")
 }

--- a/internal/cli/command/generate_migration.go
+++ b/internal/cli/command/generate_migration.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -415,4 +416,23 @@ func gitShowFile(ref, path string) (string, error) {
 		return "", err
 	}
 	return string(out), nil
+}
+
+// gitRelativePath converts a schema path to one relative to the git repo root,
+// as required by "git show ref:path". A relative path is resolved against the
+// current working directory first, so it works from any subdirectory.
+func gitRelativePath(path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", cli.GeneralError("resolving schema path", err)
+	}
+	out, err := exec.Command("git", "rev-parse", "--show-toplevel").Output() //nolint:gosec // no user input
+	if err != nil {
+		return "", cli.GeneralError("locating git repository root", err)
+	}
+	rel, err := filepath.Rel(strings.TrimSpace(string(out)), abs)
+	if err != nil {
+		return "", cli.GeneralError("resolving schema path relative to repo root", err)
+	}
+	return rel, nil
 }

--- a/internal/cli/command/generate_migration.go
+++ b/internal/cli/command/generate_migration.go
@@ -328,17 +328,12 @@ func previousStateFromDB(dsn, databaseSchema string) (*previousState, error) {
 	}
 
 	// Reconstruct the previous model for the semantic-diff header (best-effort).
-	// Prefer the parsed model; fall back to parsing the stored DSL when the JSON
-	// model is absent, mirroring `melange diff`/`doctor`. A modular DSL won't
-	// parse as a single schema, leaving prevTypes nil (no header). Absent
-	// entirely on databases migrated before model storage existed.
-	var prevTypes []schema.TypeDefinition
-	if rec.SchemaDSL != "" {
-		if t, uerr := schema.UnmarshalModel(rec.ModelJSON); uerr == nil && len(t) > 0 {
-			prevTypes = t
-		} else if parsed, perr := parser.ParseSchemaString(rec.SchemaDSL); perr == nil {
-			prevTypes = parsed
-		}
+	// A model that can't be recovered — never recorded, or a modular DSL, which
+	// won't parse as a single schema — leaves prevTypes nil, and the migration is
+	// generated without a header rather than failing.
+	prevTypes, terr := deployedTypesFromRecord(rec)
+	if terr != nil {
+		prevTypes = nil
 	}
 
 	return &previousState{

--- a/internal/cli/command/generate_migration.go
+++ b/internal/cli/command/generate_migration.go
@@ -137,6 +137,10 @@ Three comparison modes determine orphaned functions to drop:
 			NamedFunctions: namedFunctions,
 		}
 
+		// previousTypes drives the semantic-diff header, when a previous model can
+		// be reconstructed from the chosen comparison source.
+		var previousTypes []schema.TypeDefinition
+
 		if genMigrationDB != "" {
 			prevState, err := previousStateFromDB(genMigrationDB, databaseSchema)
 			if err != nil {
@@ -146,6 +150,7 @@ Three comparison modes determine orphaned functions to drop:
 				opts.PreviousFunctionNames = prevState.FunctionNames
 				opts.PreviousChecksums = prevState.FunctionChecksums
 				opts.PreviousSource = "database"
+				previousTypes = prevState.Types
 			}
 		} else if genMigrationGitRef != "" {
 			prevState, err := previousStateFromSchema(genMigrationGitRef, schemaPath, databaseSchema, true)
@@ -155,6 +160,7 @@ Three comparison modes determine orphaned functions to drop:
 			opts.PreviousFunctionNames = prevState.FunctionNames
 			opts.PreviousChecksums = prevState.FunctionChecksums
 			opts.PreviousSource = fmt.Sprintf("git:%s", genMigrationGitRef)
+			previousTypes = prevState.Types
 		} else if genMigrationPreviousSchema != "" {
 			if parser.IsModularSchema(genMigrationPreviousSchema) {
 				return cli.ConfigError("--previous-schema does not support modular schemas (fga.mod); use --db or --git-ref instead", nil)
@@ -166,10 +172,16 @@ Three comparison modes determine orphaned functions to drop:
 			opts.PreviousFunctionNames = prevState.FunctionNames
 			opts.PreviousChecksums = prevState.FunctionChecksums
 			opts.PreviousSource = fmt.Sprintf("file:%s", genMigrationPreviousSchema)
+			previousTypes = prevState.Types
 		}
 
 		// Generate migration SQL
 		result := compiler.GenerateMigrationSQL(generatedSQL, listSQL, expectedFunctions, opts)
+
+		// Document what the migration changes, when a previous model is known.
+		if previousTypes != nil {
+			result.Up = semanticDiffHeader(schema.Diff(previousTypes, types)) + result.Up
+		}
 
 		// Write output
 		if output == "" {
@@ -256,12 +268,34 @@ func writeFiles(result compiler.MigrationSQL, output, name, format string) error
 	return nil
 }
 
+// semanticDiffHeader renders a SQL comment block summarizing how the migration
+// changes the model relative to the previous one. Returns "" when there are no
+// changes, so an unchanged (version-only) migration gets no header.
+func semanticDiffHeader(diff schema.SchemaDiff) string {
+	if diff.Empty() {
+		return ""
+	}
+	additive, breaking := diff.Counts()
+	var b strings.Builder
+	fmt.Fprintf(&b, "-- Schema changes vs previous model: %d breaking, %d additive\n", breaking, additive)
+	for _, c := range diff.Changes {
+		fmt.Fprintf(&b, "--   [%s] %s\n", c.Class, c.Summary)
+	}
+	b.WriteString("--\n")
+	return b.String()
+}
+
 // previousState holds the function inventory from a prior migration.
 // It normalises the output of all three comparison modes (--db, --git-ref,
 // --previous-schema) so the caller can handle them uniformly.
 type previousState struct {
 	FunctionNames     []string
 	FunctionChecksums map[string]string
+
+	// Types is the previous parsed model, when it can be reconstructed. It drives
+	// the semantic-diff header. Nil when unavailable (e.g. a database migrated
+	// before model storage existed), in which case no header is emitted.
+	Types []schema.TypeDefinition
 }
 
 // previousStateFromDB reads function names and checksums from the most recent
@@ -293,9 +327,24 @@ func previousStateFromDB(dsn, databaseSchema string) (*previousState, error) {
 		fmt.Fprintln(os.Stderr)
 	}
 
+	// Reconstruct the previous model for the semantic-diff header (best-effort).
+	// Prefer the parsed model; fall back to parsing the stored DSL when the JSON
+	// model is absent, mirroring `melange diff`/`doctor`. A modular DSL won't
+	// parse as a single schema, leaving prevTypes nil (no header). Absent
+	// entirely on databases migrated before model storage existed.
+	var prevTypes []schema.TypeDefinition
+	if rec.SchemaDSL != "" {
+		if t, uerr := schema.UnmarshalModel(rec.ModelJSON); uerr == nil && len(t) > 0 {
+			prevTypes = t
+		} else if parsed, perr := parser.ParseSchemaString(rec.SchemaDSL); perr == nil {
+			prevTypes = parsed
+		}
+	}
+
 	return &previousState{
 		FunctionNames:     rec.FunctionNames,
 		FunctionChecksums: rec.FunctionChecksums,
+		Types:             prevTypes,
 	}, nil
 }
 
@@ -334,6 +383,7 @@ func previousStateFromSchema(pathOrRef, schemaPath, databaseSchema string, isGit
 	return &previousState{
 		FunctionNames:     names,
 		FunctionChecksums: checksums,
+		Types:             types,
 	}, nil
 }
 

--- a/internal/cli/command/generate_migration_test.go
+++ b/internal/cli/command/generate_migration_test.go
@@ -1,0 +1,38 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pthm/melange/pkg/schema"
+)
+
+func TestSemanticDiffHeader(t *testing.T) {
+	// No changes → no header, so a version-only migration stays clean.
+	if h := semanticDiffHeader(schema.SchemaDiff{}); h != "" {
+		t.Errorf("empty diff should yield no header, got %q", h)
+	}
+
+	diff := schema.SchemaDiff{Changes: []schema.Change{
+		{Class: schema.ClassBreaking, Type: "document", Relation: "viewer", Summary: "relation document.viewer removed"},
+		{Class: schema.ClassAdditive, Type: "audit_log", Summary: "type audit_log added"},
+	}}
+	h := semanticDiffHeader(diff)
+
+	for _, want := range []string{
+		"1 breaking, 1 additive",
+		"[breaking] relation document.viewer removed",
+		"[additive] type audit_log added",
+	} {
+		if !strings.Contains(h, want) {
+			t.Errorf("header missing %q\n%s", want, h)
+		}
+	}
+
+	// Every line must be a SQL comment so the header is inert in the migration.
+	for _, line := range strings.Split(strings.TrimRight(h, "\n"), "\n") {
+		if !strings.HasPrefix(line, "--") {
+			t.Errorf("header line is not a SQL comment: %q", line)
+		}
+	}
+}

--- a/internal/cli/command/history.go
+++ b/internal/cli/command/history.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -64,11 +66,8 @@ type historyEntry struct {
 }
 
 func runHistory(dsn, databaseSchema, format string, limit int) error {
-	if format != "text" && format != "json" {
-		return cli.ConfigError(fmt.Sprintf("invalid --format %q (want text or json)", format), nil)
-	}
-	if limit < 1 {
-		return cli.ConfigError("--limit must be at least 1", nil)
+	if err := validateHistoryFlags(format, limit); err != nil {
+		return err
 	}
 
 	db, err := sql.Open("postgres", dsn)
@@ -86,6 +85,38 @@ func runHistory(dsn, databaseSchema, format string, limit int) error {
 		return cli.GeneralError("reading migration history", err)
 	}
 
+	entries := historyEntries(records)
+
+	if format == "json" {
+		out, merr := json.MarshalIndent(entries, "", "  ")
+		if merr != nil {
+			return cli.GeneralError("encoding history", merr)
+		}
+		fmt.Println(string(out))
+		return nil
+	}
+
+	printHistory(os.Stdout, entries)
+	return nil
+}
+
+// validateHistoryFlags rejects unusable option values before connecting. The
+// limit is also checked in the migrator, but failing here keeps the error a
+// configuration error rather than a database one.
+func validateHistoryFlags(format string, limit int) error {
+	if format != "text" && format != "json" {
+		return cli.ConfigError(fmt.Sprintf("invalid --format %q (want text or json)", format), nil)
+	}
+	if limit < 1 {
+		return cli.ConfigError("--limit must be at least 1", nil)
+	}
+	return nil
+}
+
+// historyEntries maps migration records to the stable text/JSON shape, filling
+// the fields a legacy record may lack with empty values rather than omitting
+// them, so the JSON schema does not change shape per row.
+func historyEntries(records []migrator.MigrationRecord) []historyEntry {
 	entries := make([]historyEntry, 0, len(records))
 	for _, r := range records {
 		e := historyEntry{
@@ -100,21 +131,17 @@ func runHistory(dsn, databaseSchema, format string, limit int) error {
 		}
 		entries = append(entries, e)
 	}
+	return entries
+}
 
-	if format == "json" {
-		out, merr := json.MarshalIndent(entries, "", "  ")
-		if merr != nil {
-			return cli.GeneralError("encoding history", merr)
-		}
-		fmt.Println(string(out))
-		return nil
-	}
-
+// printHistory writes the audit trail as one line per migration, most recent
+// first. Unknown values from legacy records are labeled rather than left blank.
+func printHistory(w io.Writer, entries []historyEntry) {
 	if len(entries) == 0 {
-		fmt.Println("No migrations recorded in this database.")
-		return nil
+		_, _ = fmt.Fprintln(w, "No migrations recorded in this database.")
+		return
 	}
-	fmt.Println("Migration history (most recent first):")
+	_, _ = fmt.Fprintln(w, "Migration history (most recent first):")
 	for _, e := range entries {
 		when := e.MigratedAt
 		if when == "" {
@@ -129,7 +156,6 @@ func runHistory(dsn, databaseSchema, format string, limit int) error {
 			line += " · " + e.Format
 		}
 		line += fmt.Sprintf(" · %d functions", e.FunctionCount)
-		fmt.Println(line)
+		_, _ = fmt.Fprintln(w, line)
 	}
-	return nil
 }

--- a/internal/cli/command/history.go
+++ b/internal/cli/command/history.go
@@ -1,0 +1,135 @@
+package command
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/spf13/cobra"
+
+	"github.com/pthm/melange/internal/cli"
+	"github.com/pthm/melange/pkg/migrator"
+)
+
+var (
+	historyDB       string
+	historyDBSchema string
+	historyFormat   string
+	historyLimit    int
+)
+
+var historyCmd = &cobra.Command{
+	Use:   "history",
+	Short: "Show the migration history recorded in the database",
+	Long: `List recent entries from the melange_migrations table — when each migration
+ran, the melange version, the schema checksum, and how many functions it
+installed. An audit trail of how a database's authorization model has evolved.`,
+	Example: `  # Recent migrations
+  melange history --db postgres://localhost/mydb
+
+  # The last 5, as JSON, against a named environment
+  melange history --env production --limit 5 --format json`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		databaseSchema := resolveString(historyDBSchema, cfg.Database.Schema, "public")
+		dsn, err := resolveDSN(historyDB)
+		if err != nil {
+			return err
+		}
+		return runHistory(dsn, databaseSchema, historyFormat, historyLimit)
+	},
+}
+
+func init() {
+	f := historyCmd.Flags()
+	f.StringVar(&historyDB, "db", "", "database URL")
+	f.StringVar(&historyDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
+	f.StringVar(&historyFormat, "format", "text", "output format: text (default) or json")
+	f.IntVar(&historyLimit, "limit", 20, "maximum number of entries to show")
+}
+
+// historyEntry is the JSON/text shape of one migration record. Fields are always
+// present (empty string when a legacy record lacks them) so the JSON schema is
+// stable and matches what the text renderer shows.
+type historyEntry struct {
+	ID             int    `json:"id"`
+	MigratedAt     string `json:"migrated_at"`
+	MelangeVersion string `json:"melange_version"`
+	Checksum       string `json:"schema_checksum"`
+	Format         string `json:"schema_format"`
+	FunctionCount  int    `json:"function_count"`
+}
+
+func runHistory(dsn, databaseSchema, format string, limit int) error {
+	if format != "text" && format != "json" {
+		return cli.ConfigError(fmt.Sprintf("invalid --format %q (want text or json)", format), nil)
+	}
+	if limit < 1 {
+		return cli.ConfigError("--limit must be at least 1", nil)
+	}
+
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return cli.DBConnectError("connecting to database", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+	m.SetDatabaseSchema(databaseSchema)
+
+	records, err := m.GetMigrationHistory(ctx, limit)
+	if err != nil {
+		return cli.GeneralError("reading migration history", err)
+	}
+
+	entries := make([]historyEntry, 0, len(records))
+	for _, r := range records {
+		e := historyEntry{
+			ID:             r.ID,
+			MelangeVersion: r.MelangeVersion,
+			Checksum:       r.SchemaChecksum,
+			Format:         r.SchemaFormat,
+			FunctionCount:  len(r.FunctionNames),
+		}
+		if !r.MigratedAt.IsZero() {
+			e.MigratedAt = r.MigratedAt.Format(time.RFC3339)
+		}
+		entries = append(entries, e)
+	}
+
+	if format == "json" {
+		out, merr := json.MarshalIndent(entries, "", "  ")
+		if merr != nil {
+			return cli.GeneralError("encoding history", merr)
+		}
+		fmt.Println(string(out))
+		return nil
+	}
+
+	if len(entries) == 0 {
+		fmt.Println("No migrations recorded in this database.")
+		return nil
+	}
+	fmt.Println("Migration history (most recent first):")
+	for _, e := range entries {
+		when := e.MigratedAt
+		if when == "" {
+			when = "(unknown time)"
+		}
+		version := e.MelangeVersion
+		if version == "" {
+			version = "unknown"
+		}
+		line := fmt.Sprintf("  %s · melange %s · checksum %s", when, version, shortChecksum(e.Checksum))
+		if e.Format != "" {
+			line += " · " + e.Format
+		}
+		line += fmt.Sprintf(" · %d functions", e.FunctionCount)
+		fmt.Println(line)
+	}
+	return nil
+}

--- a/internal/cli/command/migrate.go
+++ b/internal/cli/command/migrate.go
@@ -3,6 +3,7 @@ package command
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -16,11 +17,12 @@ import (
 )
 
 var (
-	migrateDB       string
-	migrateDBSchema string
-	migrateSchema   string
-	migrateDryRun   bool
-	migrateForce    bool
+	migrateDB                 string
+	migrateDBSchema           string
+	migrateSchema             string
+	migrateDryRun             bool
+	migrateForce              bool
+	migrateIfDeployedChecksum string
 )
 
 var migrateCmd = &cobra.Command{
@@ -37,7 +39,10 @@ var migrateCmd = &cobra.Command{
   melange migrate --db postgres://localhost/mydb --dry-run
 
   # Force re-apply even if schema unchanged
-  melange migrate --db postgres://localhost/mydb --force`,
+  melange migrate --db postgres://localhost/mydb --force
+
+  # Drift-safe apply: abort unless the deployed checksum matches (CI gate)
+  melange migrate --env production --if-deployed-checksum "$CURRENT"`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		// Warn if generate.migration.output is configured
 		if cfg.Generate.Migration.Output != "" && !quiet {
@@ -60,7 +65,14 @@ var migrateCmd = &cobra.Command{
 			return err
 		}
 
-		return runMigrate(dsn, schemaPath, dryRun, force, databaseSchema)
+		// A pointer distinguishes "not set" from an explicit empty value (which
+		// matches a database with no migration recorded).
+		var ifDeployedChecksum *string
+		if cmd.Flags().Changed("if-deployed-checksum") {
+			ifDeployedChecksum = &migrateIfDeployedChecksum
+		}
+
+		return runMigrate(dsn, schemaPath, dryRun, force, databaseSchema, ifDeployedChecksum)
 	},
 }
 
@@ -71,6 +83,7 @@ func init() {
 	f.StringVar(&migrateSchema, "schema", "", "path to schema.fga or fga.mod file")
 	f.BoolVar(&migrateDryRun, "dry-run", false, "output migration SQL without applying")
 	f.BoolVar(&migrateForce, "force", false, "force migration even if schema unchanged")
+	f.StringVar(&migrateIfDeployedChecksum, "if-deployed-checksum", "", "apply only if the deployed schema checksum matches this value (from `melange status --format json`)")
 }
 
 // resolveDSN gets the database DSN from flag or config.
@@ -96,7 +109,7 @@ func resolveDSN(flagDSN string) (string, error) {
 	return dsn, nil
 }
 
-func runMigrate(dsn, schemaPath string, dryRun, force bool, databaseSchema string) error {
+func runMigrate(dsn, schemaPath string, dryRun, force bool, databaseSchema string, ifDeployedChecksum *string) error {
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		return cli.DBConnectError("connecting to database", err)
@@ -106,9 +119,10 @@ func runMigrate(dsn, schemaPath string, dryRun, force bool, databaseSchema strin
 	ctx := context.Background()
 
 	opts := migrator.MigrateOptions{
-		Force:          force,
-		Version:        version.Version,
-		DatabaseSchema: databaseSchema,
+		Force:              force,
+		Version:            version.Version,
+		DatabaseSchema:     databaseSchema,
+		IfDeployedChecksum: ifDeployedChecksum,
 	}
 
 	if dryRun {
@@ -123,6 +137,12 @@ func runMigrate(dsn, schemaPath string, dryRun, force bool, databaseSchema strin
 
 	skipped, err := migrator.MigrateWithOptions(ctx, db, schemaPath, opts)
 	if err != nil {
+		// Drift guard failed — the database is not at the expected checksum.
+		// Preserve the typed error in the chain (like the sibling mappings below).
+		var driftErr *migrator.DeployedModelChangedError
+		if errors.As(err, &driftErr) {
+			return cli.GeneralError("migration aborted", driftErr)
+		}
 		// Classify error
 		errStr := err.Error()
 		if strings.Contains(errStr, "parsing schema") {

--- a/internal/cli/command/migrate.go
+++ b/internal/cli/command/migrate.go
@@ -79,6 +79,13 @@ func resolveDSN(flagDSN string) (string, error) {
 		return flagDSN, nil
 	}
 
+	// A deferred environment-resolution failure (e.g. an unset ${VAR} secret)
+	// becomes an error only now, when a command actually needs to connect. An
+	// explicit --db above bypasses it.
+	if envResolveErr != nil {
+		return "", cli.ConfigError("resolving environment", envResolveErr)
+	}
+
 	dsn, err := cfg.DSN()
 	if err != nil {
 		return "", cli.ConfigError("database configuration", err)

--- a/internal/cli/command/migrate.go
+++ b/internal/cli/command/migrate.go
@@ -49,7 +49,7 @@ var migrateCmd = &cobra.Command{
 		}
 
 		// Resolve values
-		databaseSchema := resolveString(migrateDBSchema, cfg.Database.Schema)
+		databaseSchema := resolveString(migrateDBSchema, cfg.Database.Schema, "public")
 		schemaPath := resolveString(migrateSchema, cfg.Schema)
 		dryRun := resolveBool(migrateDryRun, cfg.Migrate.DryRun)
 		force := resolveBool(migrateForce, cfg.Migrate.Force)
@@ -67,7 +67,7 @@ var migrateCmd = &cobra.Command{
 func init() {
 	f := migrateCmd.Flags()
 	f.StringVar(&migrateDB, "db", "", "database URL")
-	f.StringVar(&migrateDBSchema, "db-schema", "public", "database schema")
+	f.StringVar(&migrateDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
 	f.StringVar(&migrateSchema, "schema", "", "path to schema.fga or fga.mod file")
 	f.BoolVar(&migrateDryRun, "dry-run", false, "output migration SQL without applying")
 	f.BoolVar(&migrateForce, "force", false, "force migration even if schema unchanged")

--- a/internal/cli/command/render_test.go
+++ b/internal/cli/command/render_test.go
@@ -1,0 +1,333 @@
+package command
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pthm/melange/internal/cli"
+	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/pkg/schema"
+)
+
+// These tests pin the text each command prints. The CLI reference documents
+// these formats verbatim, so a change here should be a change there too.
+
+// testSchemaPath is the schema location these fixtures report; the value only
+// appears in output, so one is enough.
+const testSchemaPath = "melange/schema.fga"
+
+func renderStatus(t *testing.T, r statusReport, s *migrator.Status) string {
+	t.Helper()
+	var b strings.Builder
+	printStatusText(&b, r, s, testSchemaPath)
+	return b.String()
+}
+
+func TestPrintStatusText_InSync(t *testing.T) {
+	out := renderStatus(t, statusReport{
+		SchemaFile: "present",
+		TuplesView: "present",
+		Sync:       syncInSync,
+		Deployed: &deployedReport{
+			MelangeVersion: "v0.9.0",
+			MigratedAt:     "2026-07-01T20:46:10Z",
+			Checksum:       "d0c1746f7e26ea40027a24b1c0e0c5f34e279e7c27f6fa17e4611ce2f1ec0962",
+			Format:         "single",
+			ModelRecorded:  true,
+		},
+	}, &migrator.Status{SchemaExists: true, TuplesExists: true})
+
+	for _, want := range []string{
+		"Schema file:  present",
+		"Tuples view:  present",
+		"Deployed:     checksum d0c1746f7e26… · melange v0.9.0 · 2026-07-01T20:46:10Z",
+		"Sync:         in sync — local schema matches deployed",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, "breaking") {
+		t.Errorf("an in-sync status must not print drift detail:\n%s", out)
+	}
+}
+
+func TestPrintStatusText_DriftListsChanges(t *testing.T) {
+	out := renderStatus(t, statusReport{
+		SchemaFile: "present",
+		TuplesView: "present",
+		Sync:       syncDrift,
+		Deployed:   &deployedReport{Checksum: "abc123", ModelRecorded: true},
+		Drift: &driftReport{
+			Additive: 2,
+			Breaking: 1,
+			Changes: []schema.Change{
+				{Class: schema.ClassAdditive, Type: "audit_log", Summary: "type audit_log added"},
+				{Class: schema.ClassAdditive, Type: "document", Relation: "can_export", Summary: "relation document.can_export added"},
+				{Class: schema.ClassBreaking, Type: "document", Relation: "legacy_viewer", Summary: "relation document.legacy_viewer removed"},
+			},
+		},
+	}, &migrator.Status{SchemaExists: true, TuplesExists: true})
+
+	for _, want := range []string{
+		"1 breaking, 2 additive",
+		"+ type audit_log added",
+		"+ relation document.can_export added",
+		"- relation document.legacy_viewer removed",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+// The change list is a summary, not the full diff.
+func TestPrintDriftDetail_CapsTheChangeList(t *testing.T) {
+	changes := make([]schema.Change, 0, 9)
+	for i := range 9 {
+		changes = append(changes, schema.Change{
+			Class:   schema.ClassAdditive,
+			Type:    "document",
+			Summary: string(rune('a'+i)) + " added",
+		})
+	}
+
+	var b strings.Builder
+	printDriftDetail(&b, &driftReport{Additive: 9, Changes: changes})
+	out := b.String()
+
+	if lines := strings.Count(out, " added\n"); lines != maxDriftLines {
+		t.Errorf("printed %d change lines, want %d", lines, maxDriftLines)
+	}
+	if !strings.Contains(out, "… and 4 more (`melange diff` for the full list)") {
+		t.Errorf("missing the truncation hint in:\n%s", out)
+	}
+}
+
+func TestPrintStatusText_NotRecordedHint(t *testing.T) {
+	out := renderStatus(t, statusReport{
+		SchemaFile: "present",
+		TuplesView: "present",
+		Sync:       syncDrift,
+		Deployed:   &deployedReport{Checksum: "abc123", ModelRecorded: false},
+	}, &migrator.Status{SchemaExists: true, TuplesExists: true})
+
+	if !strings.Contains(out, "model DSL not recorded — re-migrate to enable `melange schema pull`") {
+		t.Errorf("a record without a model must say so:\n%s", out)
+	}
+}
+
+func TestPrintStatusText_NotesAndMissingPieces(t *testing.T) {
+	out := renderStatus(t, statusReport{
+		SchemaFile: "missing",
+		TuplesView: "missing",
+		Sync:       syncNotRecorded,
+		Notes:      []string{"could not read migration record: permission denied"},
+	}, &migrator.Status{SchemaExists: false, TuplesExists: false})
+
+	for _, want := range []string{
+		"Deployed:     no migration recorded",
+		"Note:         could not read migration record: permission denied",
+		"No schema found at melange/schema.fga",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderDiff_TreeOutput(t *testing.T) {
+	d := schema.SchemaDiff{Changes: []schema.Change{
+		{Class: schema.ClassAdditive, Type: "audit_log", Summary: "type audit_log added"},
+		{Class: schema.ClassBreaking, Type: "document", Relation: "legacy", Summary: "relation document.legacy removed"},
+	}}
+
+	var b strings.Builder
+	renderDiff(&b, d, "deployed", "melange/schema.fga")
+	out := b.String()
+
+	for _, want := range []string{
+		"Comparing deployed → melange/schema.fga",
+		"  additive  type audit_log added",
+		"  BREAKING  relation document.legacy removed",
+		"1 breaking, 1 additive",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestRenderDiff_EquivalentSchemas(t *testing.T) {
+	var b strings.Builder
+	renderDiff(&b, schema.SchemaDiff{}, "git:main", "melange/schema.fga")
+
+	if !strings.Contains(b.String(), "No changes — schemas are equivalent.") {
+		t.Errorf("unexpected output:\n%s", b.String())
+	}
+}
+
+func TestHistoryEntries_MapsRecords(t *testing.T) {
+	at := time.Date(2026, 7, 2, 20, 46, 10, 0, time.UTC)
+	entries := historyEntries([]migrator.MigrationRecord{
+		{ID: 2, MigratedAt: at, MelangeVersion: "v0.9.1", SchemaChecksum: "550b0008a779aa", SchemaFormat: "single", FunctionNames: []string{"a", "b"}},
+		{ID: 1}, // a legacy row: no timestamp, version, or format
+	})
+
+	if len(entries) != 2 {
+		t.Fatalf("entries = %d, want 2", len(entries))
+	}
+	if entries[0].MigratedAt != "2026-07-02T20:46:10Z" {
+		t.Errorf("MigratedAt = %q, want RFC3339", entries[0].MigratedAt)
+	}
+	if entries[0].FunctionCount != 2 {
+		t.Errorf("FunctionCount = %d, want 2", entries[0].FunctionCount)
+	}
+	// Fields are present-but-empty rather than omitted, so the JSON shape is stable.
+	if entries[1].MigratedAt != "" || entries[1].MelangeVersion != "" || entries[1].Format != "" {
+		t.Errorf("legacy row should carry empty fields, got %+v", entries[1])
+	}
+}
+
+func TestPrintHistory_TextAndEmpty(t *testing.T) {
+	var b strings.Builder
+	printHistory(&b, []historyEntry{{
+		ID: 1, MigratedAt: "2026-07-02T20:46:10Z", MelangeVersion: "v0.9.1",
+		Checksum: "550b0008a779aa40027a24b1c0e0c5f34e279e7c27f6fa17e4611ce2f1ec0962",
+		Format:   "single", FunctionCount: 23,
+	}})
+	want := "  2026-07-02T20:46:10Z · melange v0.9.1 · checksum 550b0008a779… · single · 23 functions"
+	if !strings.Contains(b.String(), want) {
+		t.Errorf("missing %q in:\n%s", want, b.String())
+	}
+
+	var empty strings.Builder
+	printHistory(&empty, nil)
+	if !strings.Contains(empty.String(), "No migrations recorded in this database.") {
+		t.Errorf("unexpected empty output: %q", empty.String())
+	}
+}
+
+// A row written before melange_version and schema_format existed still renders,
+// with the unknowns labeled rather than blank.
+func TestPrintHistory_LegacyRow(t *testing.T) {
+	var b strings.Builder
+	printHistory(&b, []historyEntry{{ID: 1, Checksum: "abc", FunctionCount: 3}})
+	out := b.String()
+
+	for _, want := range []string{"(unknown time)", "melange unknown", "3 functions"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("missing %q in:\n%s", want, out)
+		}
+	}
+	if strings.Contains(out, " ·  · ") {
+		t.Errorf("absent format should be omitted, not left blank:\n%s", out)
+	}
+}
+
+func TestPrintEnvironments_ListsAndMarksActive(t *testing.T) {
+	cfg := &cli.Config{
+		DefaultEnvironment: "local",
+		Environments: map[string]cli.EnvironmentConfig{
+			"production": {Database: cli.DatabaseConfig{URL: "postgres://prod/app"}},
+			"local":      {Database: cli.DatabaseConfig{URL: "postgres://localhost/app"}},
+		},
+	}
+
+	var b strings.Builder
+	if err := printEnvironments(&b, cfg, "production"); err != nil {
+		t.Fatalf("printEnvironments: %v", err)
+	}
+	out := b.String()
+
+	if !strings.Contains(out, "* production") {
+		t.Errorf("the active environment must be marked:\n%s", out)
+	}
+	if !strings.Contains(out, "  local") {
+		t.Errorf("inactive environments must be listed unmarked:\n%s", out)
+	}
+	if strings.Index(out, "local") > strings.Index(out, "production") {
+		t.Errorf("environments should be listed in sorted order:\n%s", out)
+	}
+	if !strings.Contains(out, "Default: local") || !strings.Contains(out, "Active:  production") {
+		t.Errorf("missing the default/active footer:\n%s", out)
+	}
+}
+
+// With no profiles configured, the listing explains how to add one rather than
+// printing an empty section.
+func TestPrintEnvironments_NoneConfigured(t *testing.T) {
+	var b strings.Builder
+	if err := printEnvironments(&b, &cli.Config{}, ""); err != nil {
+		t.Fatalf("printEnvironments: %v", err)
+	}
+	out := b.String()
+
+	if !strings.Contains(out, "No environments defined.") || !strings.Contains(out, "environments:") {
+		t.Errorf("unexpected output:\n%s", out)
+	}
+}
+
+func TestPullContent_HeaderToggle(t *testing.T) {
+	model := &migrator.DeployedModel{
+		DSL:            "model\n  schema 1.1\ntype user\n",
+		Format:         migrator.FormatSingle,
+		SchemaChecksum: "abc123",
+		MigratedAt:     time.Date(2026, 7, 1, 20, 46, 10, 0, time.UTC),
+		MelangeVersion: "v0.9.0",
+	}
+
+	withHeader := pullContent(model, false)
+	if !strings.HasPrefix(withHeader, "# Pulled from a melange-migrated database") {
+		t.Errorf("expected a provenance header, got:\n%s", withHeader)
+	}
+	if !strings.HasSuffix(withHeader, model.DSL) {
+		t.Errorf("the DSL must follow the header verbatim, got:\n%s", withHeader)
+	}
+	if got := pullContent(model, true); got != model.DSL {
+		t.Errorf("--no-header must emit the DSL alone, got:\n%s", got)
+	}
+}
+
+// --format json emits the SchemaDiff itself, so tooling gets the classification
+// rather than having to parse the tree output.
+func TestRenderDiff_JSONOutput(t *testing.T) {
+	orig := diffFormat
+	t.Cleanup(func() { diffFormat = orig })
+	diffFormat = "json"
+
+	d := schema.SchemaDiff{Changes: []schema.Change{
+		{Class: schema.ClassBreaking, Type: "document", Relation: "legacy", Summary: "relation document.legacy removed"},
+	}}
+
+	var b strings.Builder
+	renderDiff(&b, d, "deployed", "melange/schema.fga")
+
+	var decoded schema.SchemaDiff
+	if err := json.Unmarshal([]byte(b.String()), &decoded); err != nil {
+		t.Fatalf("output is not valid JSON: %v\n%s", err, b.String())
+	}
+	if len(decoded.Changes) != 1 || decoded.Changes[0].Class != schema.ClassBreaking {
+		t.Errorf("round-trip lost the change: %+v", decoded)
+	}
+	if strings.Contains(b.String(), "Comparing") {
+		t.Errorf("json output must not carry the tree header:\n%s", b.String())
+	}
+}
+
+func TestValidateHistoryFlags(t *testing.T) {
+	if err := validateHistoryFlags("text", 20); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateHistoryFlags("json", 1); err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if err := validateHistoryFlags("yaml", 20); err == nil || !strings.Contains(err.Error(), "invalid --format") {
+		t.Errorf("error = %v, want an invalid-format error", err)
+	}
+	if err := validateHistoryFlags("text", 0); err == nil || !strings.Contains(err.Error(), "--limit") {
+		t.Errorf("error = %v, want a limit error", err)
+	}
+}

--- a/internal/cli/command/root.go
+++ b/internal/cli/command/root.go
@@ -136,6 +136,7 @@ func init() {
 	statusCmd.GroupID = groupSchema
 	schemaCmd.GroupID = groupSchema
 	diffCmd.GroupID = groupSchema
+	historyCmd.GroupID = groupSchema
 	doctorCmd.GroupID = groupSchema
 	explainCmd.GroupID = groupSchema
 	expandCmd.GroupID = groupSchema
@@ -144,6 +145,7 @@ func init() {
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(diffCmd)
+	rootCmd.AddCommand(historyCmd)
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(explainCmd)
 	rootCmd.AddCommand(expandCmd)

--- a/internal/cli/command/root.go
+++ b/internal/cli/command/root.go
@@ -64,37 +64,14 @@ from OpenFGA schemas, enabling single-query permission checks in PostgreSQL.`,
 		// Resolve the active environment and overlay it onto cfg. Downstream
 		// resolution (resolveDSN, cfg.DSN) operates on the resolved config.
 		baseCfg = cfg
-		explicitEnv := resolveString(envFlag, os.Getenv("MELANGE_ENV"))
-		activeEnv = resolveString(explicitEnv, cfg.DefaultEnvironment)
-
-		// Typo protection: an explicitly named environment must exist. A stale
-		// default_environment is handled leniently below instead.
-		if explicitEnv != "" && !cfg.HasEnvironment(explicitEnv) {
-			return cli.ConfigError("resolving environment",
-				fmt.Errorf("environment %q is not defined in configuration", explicitEnv))
-		}
-
-		resolved, err := cfg.ForEnvironment(activeEnv)
+		res, err := resolveEnvironment(cfg, envFlag, os.Getenv("MELANGE_ENV"))
 		if err != nil {
-			if explicitEnv == "" && activeEnv != "" && !cfg.HasEnvironment(activeEnv) {
-				// Only a *stale* default_environment (naming an environment that
-				// no longer exists) is lenient: warn and use base. A defined
-				// default with an unset secret must NOT silently fall through to
-				// base — it is deferred below so a connecting command fails loud.
-				fmt.Fprintf(os.Stderr, "warning: default_environment %q is not defined; using base config\n", activeEnv)
-				activeEnv = ""
-				resolved, err = cfg.ForEnvironment("")
-			}
-			if err != nil {
-				// Almost always an unset ${VAR} secret. Defer to connect time so
-				// diagnostic commands (env list, config show, validate) still run;
-				// resolveDSN surfaces this for commands that actually connect. Keep
-				// the best-effort resolved config (non-connection overlay such as
-				// schema still applies, and an explicit --db can proceed).
-				envResolveErr = err
-			}
+			return err
 		}
-		cfg = resolved
+		cfg, activeEnv, envResolveErr = res.Config, res.Active, res.Deferred
+		if res.Warning != "" {
+			fmt.Fprintf(os.Stderr, "warning: %s\n", res.Warning)
+		}
 
 		// Surface the target so a command running against a non-base environment
 		// (especially one selected via default_environment) is never silent.
@@ -106,6 +83,52 @@ from OpenFGA schemas, enabling single-query permission checks in PostgreSQL.`,
 	},
 	SilenceUsage:  true, // Don't show usage on errors
 	SilenceErrors: true, // We handle errors ourselves
+}
+
+// envResolution is the outcome of selecting an environment profile and applying
+// it to the loaded configuration.
+type envResolution struct {
+	Config   *cli.Config // configuration with the environment overlaid (best effort)
+	Active   string      // selected environment; empty means the base config
+	Deferred error       // resolution failure to surface when a command connects
+	Warning  string      // non-fatal note for the user
+}
+
+// resolveEnvironment picks the environment profile to run against and overlays
+// it, following the documented precedence: --env, then MELANGE_ENV, then
+// default_environment, then the base config.
+//
+// It distinguishes three failure modes deliberately. An explicitly named
+// environment that does not exist is a hard error, so `--env prod` cannot
+// silently run against a local database after a typo. A *stale*
+// default_environment — one naming a profile that no longer exists — only warns
+// and falls back to base. Anything else (almost always an unset ${VAR} secret)
+// is deferred rather than fatal, so diagnostic commands such as `env list`,
+// `config show`, and `validate` still run; commands that connect surface it
+// through resolveDSN.
+func resolveEnvironment(base *cli.Config, flagEnv, osEnv string) (envResolution, error) {
+	explicit := resolveString(flagEnv, osEnv)
+	active := resolveString(explicit, base.DefaultEnvironment)
+
+	if explicit != "" && !base.HasEnvironment(explicit) {
+		return envResolution{}, cli.ConfigError("resolving environment",
+			fmt.Errorf("environment %q is not defined in configuration", explicit))
+	}
+
+	out := envResolution{Active: active}
+	resolved, err := base.ForEnvironment(active)
+	if err != nil && explicit == "" && active != "" && !base.HasEnvironment(active) {
+		out.Warning = fmt.Sprintf("default_environment %q is not defined; using base config", active)
+		out.Active = ""
+		resolved, err = base.ForEnvironment("")
+	}
+	if err != nil {
+		// Keep the best-effort config: a non-connection overlay (schema, say)
+		// still applies, and an explicit --db can still proceed.
+		out.Deferred = err
+	}
+	out.Config = resolved
+	return out, nil
 }
 
 // Command group IDs

--- a/internal/cli/command/root.go
+++ b/internal/cli/command/root.go
@@ -14,11 +14,15 @@ import (
 
 var (
 	// Global state set during PersistentPreRunE
-	cfg        *cli.Config
-	configPath string
+	cfg           *cli.Config
+	baseCfg       *cli.Config // config before environment overlay (for 'env list')
+	configPath    string
+	activeEnv     string // environment applied to cfg (empty = base config)
+	envResolveErr error  // deferred environment-resolution failure, surfaced at connect time
 
 	// Persistent flags
 	cfgFile       string
+	envFlag       string
 	verbose       int
 	quiet         bool
 	noUpdateCheck bool
@@ -57,6 +61,47 @@ from OpenFGA schemas, enabling single-query permission checks in PostgreSQL.`,
 			return cli.ConfigError("loading configuration", err)
 		}
 
+		// Resolve the active environment and overlay it onto cfg. Downstream
+		// resolution (resolveDSN, cfg.DSN) operates on the resolved config.
+		baseCfg = cfg
+		explicitEnv := resolveString(envFlag, os.Getenv("MELANGE_ENV"))
+		activeEnv = resolveString(explicitEnv, cfg.DefaultEnvironment)
+
+		// Typo protection: an explicitly named environment must exist. A stale
+		// default_environment is handled leniently below instead.
+		if explicitEnv != "" && !cfg.HasEnvironment(explicitEnv) {
+			return cli.ConfigError("resolving environment",
+				fmt.Errorf("environment %q is not defined in configuration", explicitEnv))
+		}
+
+		resolved, err := cfg.ForEnvironment(activeEnv)
+		if err != nil {
+			if explicitEnv == "" && activeEnv != "" && !cfg.HasEnvironment(activeEnv) {
+				// Only a *stale* default_environment (naming an environment that
+				// no longer exists) is lenient: warn and use base. A defined
+				// default with an unset secret must NOT silently fall through to
+				// base — it is deferred below so a connecting command fails loud.
+				fmt.Fprintf(os.Stderr, "warning: default_environment %q is not defined; using base config\n", activeEnv)
+				activeEnv = ""
+				resolved, err = cfg.ForEnvironment("")
+			}
+			if err != nil {
+				// Almost always an unset ${VAR} secret. Defer to connect time so
+				// diagnostic commands (env list, config show, validate) still run;
+				// resolveDSN surfaces this for commands that actually connect. Keep
+				// the best-effort resolved config (non-connection overlay such as
+				// schema still applies, and an explicit --db can proceed).
+				envResolveErr = err
+			}
+		}
+		cfg = resolved
+
+		// Surface the target so a command running against a non-base environment
+		// (especially one selected via default_environment) is never silent.
+		if activeEnv != "" && !quiet {
+			fmt.Fprintf(os.Stderr, "→ environment: %s\n", activeEnv)
+		}
+
 		return nil
 	},
 	SilenceUsage:  true, // Don't show usage on errors
@@ -73,6 +118,7 @@ const (
 func init() {
 	// Persistent flags (available to all commands)
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default: auto-discover melange.yaml)")
+	rootCmd.PersistentFlags().StringVar(&envFlag, "env", "", "environment profile to target (see 'environments' in config)")
 	rootCmd.PersistentFlags().CountVarP(&verbose, "verbose", "v", "increase verbosity (can be repeated)")
 	rootCmd.PersistentFlags().BoolVarP(&quiet, "quiet", "q", false, "suppress non-error output")
 	rootCmd.PersistentFlags().BoolVar(&noUpdateCheck, "no-update-check", false, "disable update check")
@@ -105,10 +151,12 @@ func init() {
 	// Utility commands
 	initCmd.GroupID = groupUtility
 	configCmd.GroupID = groupUtility
+	envCmd.GroupID = groupUtility
 	versionCmd.GroupID = groupUtility
 	licenseCmd.GroupID = groupUtility
 	rootCmd.AddCommand(initCmd)
 	rootCmd.AddCommand(configCmd)
+	rootCmd.AddCommand(envCmd)
 	rootCmd.AddCommand(versionCmd)
 	rootCmd.AddCommand(licenseCmd)
 }

--- a/internal/cli/command/root.go
+++ b/internal/cli/command/root.go
@@ -134,12 +134,14 @@ func init() {
 	validateCmd.GroupID = groupSchema
 	migrateCmd.GroupID = groupSchema
 	statusCmd.GroupID = groupSchema
+	schemaCmd.GroupID = groupSchema
 	doctorCmd.GroupID = groupSchema
 	explainCmd.GroupID = groupSchema
 	expandCmd.GroupID = groupSchema
 	rootCmd.AddCommand(validateCmd)
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(statusCmd)
+	rootCmd.AddCommand(schemaCmd)
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(explainCmd)
 	rootCmd.AddCommand(expandCmd)

--- a/internal/cli/command/root.go
+++ b/internal/cli/command/root.go
@@ -135,6 +135,7 @@ func init() {
 	migrateCmd.GroupID = groupSchema
 	statusCmd.GroupID = groupSchema
 	schemaCmd.GroupID = groupSchema
+	diffCmd.GroupID = groupSchema
 	doctorCmd.GroupID = groupSchema
 	explainCmd.GroupID = groupSchema
 	expandCmd.GroupID = groupSchema
@@ -142,6 +143,7 @@ func init() {
 	rootCmd.AddCommand(migrateCmd)
 	rootCmd.AddCommand(statusCmd)
 	rootCmd.AddCommand(schemaCmd)
+	rootCmd.AddCommand(diffCmd)
 	rootCmd.AddCommand(doctorCmd)
 	rootCmd.AddCommand(explainCmd)
 	rootCmd.AddCommand(expandCmd)

--- a/internal/cli/command/root_test.go
+++ b/internal/cli/command/root_test.go
@@ -1,0 +1,150 @@
+package command
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pthm/melange/internal/cli"
+)
+
+func envConfig() *cli.Config {
+	return &cli.Config{
+		Database: cli.DatabaseConfig{URL: "postgres://localhost/base"},
+		Environments: map[string]cli.EnvironmentConfig{
+			"staging":    {Database: cli.DatabaseConfig{URL: "postgres://staging/app"}},
+			"production": {Database: cli.DatabaseConfig{URL: "postgres://prod/app"}},
+		},
+	}
+}
+
+// --env beats MELANGE_ENV beats default_environment beats the base config.
+func TestResolveEnvironment_Precedence(t *testing.T) {
+	cfg := envConfig()
+	cfg.DefaultEnvironment = "staging"
+
+	cases := []struct {
+		name        string
+		flag, osEnv string
+		wantActive  string
+		wantURL     string
+	}{
+		{"flag wins", "production", "staging", "production", "postgres://prod/app"},
+		{"env var when no flag", "", "production", "production", "postgres://prod/app"},
+		{"default when neither", "", "", "staging", "postgres://staging/app"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			res, err := resolveEnvironment(cfg, tc.flag, tc.osEnv)
+			if err != nil {
+				t.Fatalf("resolveEnvironment: %v", err)
+			}
+			if res.Active != tc.wantActive {
+				t.Errorf("active = %q, want %q", res.Active, tc.wantActive)
+			}
+			if res.Config.Database.URL != tc.wantURL {
+				t.Errorf("url = %q, want %q", res.Config.Database.URL, tc.wantURL)
+			}
+			if res.Deferred != nil || res.Warning != "" {
+				t.Errorf("unexpected deferred=%v warning=%q", res.Deferred, res.Warning)
+			}
+		})
+	}
+}
+
+// With no environments configured at all, behavior is identical to before the
+// feature existed.
+func TestResolveEnvironment_NoEnvironmentsUsesBase(t *testing.T) {
+	base := &cli.Config{Database: cli.DatabaseConfig{URL: "postgres://localhost/base"}}
+
+	res, err := resolveEnvironment(base, "", "")
+	if err != nil {
+		t.Fatalf("resolveEnvironment: %v", err)
+	}
+	if res.Active != "" || res.Config.Database.URL != "postgres://localhost/base" {
+		t.Errorf("got active=%q url=%q, want base config", res.Active, res.Config.Database.URL)
+	}
+}
+
+// Typo protection: `--env prod` must not quietly run against the base (often
+// local) database because the profile is spelled `production`.
+func TestResolveEnvironment_UndefinedExplicitEnvIsFatal(t *testing.T) {
+	for _, tc := range []struct{ name, flag, osEnv string }{
+		{"flag", "prod", ""},
+		{"env var", "", "prod"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := resolveEnvironment(envConfig(), tc.flag, tc.osEnv)
+			if err == nil {
+				t.Fatal("an undefined explicit environment must be an error")
+			}
+			if !strings.Contains(err.Error(), "prod") {
+				t.Errorf("error should name the environment, got %v", err)
+			}
+		})
+	}
+}
+
+// A default_environment left pointing at a deleted profile is the one lenient
+// case: warn and fall back rather than blocking every command.
+func TestResolveEnvironment_StaleDefaultWarnsAndFallsBack(t *testing.T) {
+	cfg := envConfig()
+	cfg.DefaultEnvironment = "removed"
+
+	res, err := resolveEnvironment(cfg, "", "")
+	if err != nil {
+		t.Fatalf("a stale default must not be fatal, got %v", err)
+	}
+	if res.Active != "" {
+		t.Errorf("active = %q, want the base config", res.Active)
+	}
+	if !strings.Contains(res.Warning, "removed") {
+		t.Errorf("warning = %q, want it to name the missing environment", res.Warning)
+	}
+	if res.Config.Database.URL != "postgres://localhost/base" {
+		t.Errorf("url = %q, want the base URL", res.Config.Database.URL)
+	}
+}
+
+// An unset ${VAR} secret is deferred to connect time so diagnostic commands
+// still run, but it must not be lost — resolveDSN reports it later.
+func TestResolveEnvironment_UnsetSecretIsDeferred(t *testing.T) {
+	cfg := &cli.Config{
+		Database: cli.DatabaseConfig{URL: "postgres://localhost/base"},
+		Environments: map[string]cli.EnvironmentConfig{
+			"production": {Database: cli.DatabaseConfig{URL: "${MELANGE_TEST_UNSET_SECRET}"}},
+		},
+		DefaultEnvironment: "production",
+	}
+
+	res, err := resolveEnvironment(cfg, "", "")
+	if err != nil {
+		t.Fatalf("resolution must not fail up front, got %v", err)
+	}
+	if res.Deferred == nil {
+		t.Error("an unset secret must be reported at connect time, not dropped")
+	}
+	if res.Active != "production" {
+		t.Errorf("active = %q; a defined default must not silently fall back to base", res.Active)
+	}
+}
+
+func TestResolveString(t *testing.T) {
+	if got := resolveString("", "", "fallback"); got != "fallback" {
+		t.Errorf("resolveString = %q, want the last non-empty value", got)
+	}
+	if got := resolveString("first", "second"); got != "first" {
+		t.Errorf("resolveString = %q, want the first non-empty value", got)
+	}
+	if got := resolveString(); got != "" {
+		t.Errorf("resolveString() = %q, want empty", got)
+	}
+}
+
+func TestBoolCount(t *testing.T) {
+	if got := boolCount(true, false, true); got != 2 {
+		t.Errorf("boolCount = %d, want 2", got)
+	}
+	if got := boolCount(false, false); got != 0 {
+		t.Errorf("boolCount = %d, want 0", got)
+	}
+}

--- a/internal/cli/command/schema.go
+++ b/internal/cli/command/schema.go
@@ -7,7 +7,7 @@ var schemaCmd = &cobra.Command{
 	Short: "Inspect the model deployed in a database",
 	Long: `Work with the authorization model recorded in a migrated database.
 
-Since v0.9 every migration stores the schema it applied, so a live database
+Every migration stores the schema it applied, so a live database
 can describe itself. Use 'schema pull' to reconstruct the .fga from it.`,
 }
 

--- a/internal/cli/command/schema.go
+++ b/internal/cli/command/schema.go
@@ -1,0 +1,16 @@
+package command
+
+import "github.com/spf13/cobra"
+
+var schemaCmd = &cobra.Command{
+	Use:   "schema",
+	Short: "Inspect the model deployed in a database",
+	Long: `Work with the authorization model recorded in a migrated database.
+
+Since v0.9 every migration stores the schema it applied, so a live database
+can describe itself. Use 'schema pull' to reconstruct the .fga from it.`,
+}
+
+func init() {
+	schemaCmd.AddCommand(schemaPullCmd)
+}

--- a/internal/cli/command/schema_pull.go
+++ b/internal/cli/command/schema_pull.go
@@ -65,10 +65,7 @@ func runSchemaPull(dsn, databaseSchema, output string, noHeader bool) error {
 		return err
 	}
 
-	content := model.DSL
-	if !noHeader {
-		content = pullHeader(model) + content
-	}
+	content := pullContent(model, noHeader)
 
 	if output == "" || output == "-" {
 		fmt.Print(content)
@@ -81,6 +78,15 @@ func runSchemaPull(dsn, databaseSchema, output string, noHeader bool) error {
 		fmt.Fprintf(os.Stderr, "Wrote deployed schema to %s\n", output)
 	}
 	return nil
+}
+
+// pullContent assembles what `schema pull` emits: the recorded DSL, prefixed
+// with the provenance header unless it was suppressed.
+func pullContent(model *migrator.DeployedModel, noHeader bool) string {
+	if noHeader {
+		return model.DSL
+	}
+	return pullHeader(model) + model.DSL
 }
 
 // pullHeader renders the provenance of a pulled schema as '#' comment lines.

--- a/internal/cli/command/schema_pull.go
+++ b/internal/cli/command/schema_pull.go
@@ -1,0 +1,127 @@
+package command
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	_ "github.com/lib/pq"
+	"github.com/spf13/cobra"
+
+	"github.com/pthm/melange/internal/cli"
+	"github.com/pthm/melange/pkg/migrator"
+)
+
+var (
+	schemaPullDB       string
+	schemaPullDBSchema string
+	schemaPullOutput   string
+	schemaPullNoHeader bool
+)
+
+var schemaPullCmd = &cobra.Command{
+	Use:   "pull",
+	Short: "Reconstruct the .fga schema from a migrated database",
+	Long: `Pull writes the OpenFGA DSL recorded by the most recent migration to a file
+or stdout. Use it to recover a schema whose source file was lost, or to see
+exactly what model a database is running.
+
+For a single-file schema the output is valid DSL — it carries a provenance
+header as '#' comments and re-parses as-is; pass --no-header for the bare
+schema. A modular (fga.mod) schema is emitted as the stored manifest + module
+bundle for reference/recovery; that combined form does not re-parse as a single
+.fga, and splitting it back into module files is not supported.
+
+Requires a database migrated by melange v0.9 or later; older databases did not
+record the model, and pull reports that they cannot be recovered.`,
+	Example: `  # Print the deployed schema
+  melange schema pull --db postgres://localhost/mydb
+
+  # Recover it to a file, targeting a named environment
+  melange schema pull --env production -o recovered.fga`,
+	Args: cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		databaseSchema := resolveString(schemaPullDBSchema, cfg.Database.Schema, "public")
+		dsn, err := resolveDSN(schemaPullDB)
+		if err != nil {
+			return err
+		}
+		return runSchemaPull(dsn, databaseSchema, schemaPullOutput, schemaPullNoHeader)
+	},
+}
+
+func init() {
+	f := schemaPullCmd.Flags()
+	f.StringVar(&schemaPullDB, "db", "", "database URL")
+	f.StringVar(&schemaPullDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
+	f.StringVarP(&schemaPullOutput, "output", "o", "", "write to this file (default: stdout)")
+	f.BoolVar(&schemaPullNoHeader, "no-header", false, "omit the provenance header comment")
+}
+
+func runSchemaPull(dsn, databaseSchema, output string, noHeader bool) error {
+	db, err := sql.Open("postgres", dsn)
+	if err != nil {
+		return cli.DBConnectError("connecting to database", err)
+	}
+	defer func() { _ = db.Close() }()
+
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+	m.SetDatabaseSchema(databaseSchema)
+
+	model, err := m.GetDeployedModel(ctx)
+	if err != nil {
+		return cli.GeneralError("reading deployed model", err)
+	}
+	if model == nil {
+		// Distinguish "never migrated" from "migrated before the model was recorded".
+		rec, rerr := m.GetLastMigration(ctx)
+		if rerr == nil && rec != nil {
+			return cli.GeneralError("this database was migrated before melange v0.9, so the model was not recorded — re-run `melange migrate` with a current version to enable schema pull", nil)
+		}
+		return cli.GeneralError("no melange migration found in this database", nil)
+	}
+
+	content := model.DSL
+	if !noHeader {
+		content = pullHeader(model) + content
+	}
+
+	if output == "" || output == "-" {
+		fmt.Print(content)
+		return nil
+	}
+	if err := os.WriteFile(output, []byte(content), 0o644); err != nil { //nolint:gosec // schema is not sensitive
+		return cli.GeneralError("writing schema file", err)
+	}
+	if !quiet {
+		fmt.Fprintf(os.Stderr, "Wrote deployed schema to %s\n", output)
+	}
+	return nil
+}
+
+// pullHeader renders the provenance of a pulled schema as '#' comment lines.
+// It never includes the database URL, which may contain credentials.
+func pullHeader(model *migrator.DeployedModel) string {
+	var b strings.Builder
+	b.WriteString("# Pulled from a melange-migrated database by `melange schema pull`\n")
+	if !model.MigratedAt.IsZero() {
+		fmt.Fprintf(&b, "# Deployed: %s", model.MigratedAt.Format(time.RFC3339))
+		if model.MelangeVersion != "" {
+			fmt.Fprintf(&b, " by melange %s", model.MelangeVersion)
+		}
+		b.WriteString("\n")
+	}
+	if model.SchemaChecksum != "" {
+		fmt.Fprintf(&b, "# Schema checksum: %s\n", model.SchemaChecksum)
+	}
+	if model.Format == migrator.FormatModular {
+		b.WriteString("# Original format: modular (fga.mod). Below is the stored manifest + module\n")
+		b.WriteString("# bundle (--- separated) — NOT a single parseable .fga; for reference/recovery.\n")
+	}
+	b.WriteString("\n")
+	return b.String()
+}

--- a/internal/cli/command/schema_pull.go
+++ b/internal/cli/command/schema_pull.go
@@ -32,8 +32,9 @@ schema. A modular (fga.mod) schema is emitted as the stored manifest + module
 bundle for reference/recovery; that combined form does not re-parse as a single
 .fga, and splitting it back into module files is not supported.
 
-Requires a database migrated by melange v0.9 or later; older databases did not
-record the model, and pull reports that they cannot be recovered.`,
+Requires a database migrated by a melange version that records the deployed
+model; older databases did not record it, and pull reports that they cannot be
+recovered.`,
 	Example: `  # Print the deployed schema
   melange schema pull --db postgres://localhost/mydb
 

--- a/internal/cli/command/schema_pull.go
+++ b/internal/cli/command/schema_pull.go
@@ -1,14 +1,11 @@
 package command
 
 import (
-	"context"
-	"database/sql"
 	"fmt"
 	"os"
 	"strings"
 	"time"
 
-	_ "github.com/lib/pq"
 	"github.com/spf13/cobra"
 
 	"github.com/pthm/melange/internal/cli"
@@ -62,27 +59,9 @@ func init() {
 }
 
 func runSchemaPull(dsn, databaseSchema, output string, noHeader bool) error {
-	db, err := sql.Open("postgres", dsn)
+	model, err := readDeployedModel(dsn, databaseSchema)
 	if err != nil {
-		return cli.DBConnectError("connecting to database", err)
-	}
-	defer func() { _ = db.Close() }()
-
-	ctx := context.Background()
-	m := migrator.NewMigrator(db, "")
-	m.SetDatabaseSchema(databaseSchema)
-
-	model, err := m.GetDeployedModel(ctx)
-	if err != nil {
-		return cli.GeneralError("reading deployed model", err)
-	}
-	if model == nil {
-		// Distinguish "never migrated" from "migrated before the model was recorded".
-		rec, rerr := m.GetLastMigration(ctx)
-		if rerr == nil && rec != nil {
-			return cli.GeneralError("this database was migrated before melange v0.9, so the model was not recorded — re-run `melange migrate` with a current version to enable schema pull", nil)
-		}
-		return cli.GeneralError("no melange migration found in this database", nil)
+		return err
 	}
 
 	content := model.DSL

--- a/internal/cli/command/schema_pull_test.go
+++ b/internal/cli/command/schema_pull_test.go
@@ -1,0 +1,84 @@
+package command
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/pkg/parser"
+)
+
+// TestPullHeader_SingleReparses guards that for a single-file schema the header
+// uses valid DSL comment syntax, so the pulled file (header + schema) parses.
+func TestPullHeader_SingleReparses(t *testing.T) {
+	const dsl = "model\n  schema 1.1\n\ntype user\n"
+	model := &migrator.DeployedModel{
+		DSL:            dsl,
+		Format:         migrator.FormatSingle,
+		SchemaChecksum: "abc123",
+		MelangeVersion: "v0.9.0",
+		MigratedAt:     time.Unix(1_700_000_000, 0).UTC(),
+	}
+
+	header := pullHeader(model)
+	out := header + model.DSL
+
+	// Every header line must be a '#' comment (or blank).
+	for _, line := range strings.Split(header, "\n") {
+		if line != "" && !strings.HasPrefix(line, "#") {
+			t.Errorf("header line is not a comment: %q", line)
+		}
+	}
+	// Provenance details are present, but never the DB URL.
+	if !strings.Contains(out, "abc123") || !strings.Contains(out, "v0.9.0") {
+		t.Error("header should include checksum and version")
+	}
+	// The combined output re-parses.
+	if _, err := parser.ParseSchemaString(out); err != nil {
+		t.Fatalf("pulled single-file schema (with header) should parse: %v", err)
+	}
+}
+
+// TestPullHeader_ModularNotesBundle checks that a modular deployment is honestly
+// labeled as a non-parseable bundle rather than claiming to be a single .fga.
+func TestPullHeader_ModularNotesBundle(t *testing.T) {
+	header := pullHeader(&migrator.DeployedModel{Format: migrator.FormatModular})
+	if !strings.Contains(header, "modular") || !strings.Contains(header, "NOT a single parseable") {
+		t.Errorf("modular header should flag the bundle, got:\n%s", header)
+	}
+}
+
+func TestClassifySync(t *testing.T) {
+	rec := &migrator.MigrationRecord{SchemaChecksum: "deadbeef"}
+	cases := []struct {
+		name          string
+		localChecksum string
+		rec           *migrator.MigrationRecord
+		want          string
+	}{
+		{"no migration record", "deadbeef", nil, syncNotRecorded},
+		{"no local schema", "", rec, syncUnknown},
+		{"matching checksum", "deadbeef", rec, syncInSync},
+		{"differing checksum", "cafe", rec, syncDrift},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := classifySync(tc.localChecksum, tc.rec); got != tc.want {
+				t.Errorf("classifySync = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestPresentMissingAndShortChecksum(t *testing.T) {
+	if presentMissing(true) != "present" || presentMissing(false) != "missing" {
+		t.Error("presentMissing mapping is wrong")
+	}
+	if got := shortChecksum("0123456789abcdef0123"); got != "0123456789ab…" {
+		t.Errorf("shortChecksum = %q", got)
+	}
+	if got := shortChecksum("short"); got != "short" {
+		t.Errorf("shortChecksum should pass through short input, got %q", got)
+	}
+}

--- a/internal/cli/command/status.go
+++ b/internal/cli/command/status.go
@@ -224,7 +224,7 @@ func syncDescription(sync string) string {
 	case syncInSync:
 		return "in sync — local schema matches deployed"
 	case syncDrift:
-		return "drift — local schema differs from deployed (run `melange migrate` to apply)"
+		return "drift — local schema differs from deployed (`melange diff` to see changes, `melange migrate` to apply)"
 	case syncUnknown:
 		return "unknown — no local schema file to compare"
 	default:

--- a/internal/cli/command/status.go
+++ b/internal/cli/command/status.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"io"
+	"os"
 	"os/exec"
 	"strconv"
 	"strings"
@@ -180,7 +182,7 @@ func runStatus(dsn, databaseSchema, schemaPath, format string) error {
 		return nil
 	}
 
-	printStatusText(report, s, schemaPath)
+	printStatusText(os.Stdout, report, s, schemaPath)
 	return nil
 }
 
@@ -375,39 +377,39 @@ func shortChecksum(sum string) string {
 	return sum[:12] + "…"
 }
 
-func printStatusText(r statusReport, s *migrator.Status, schemaPath string) {
-	fmt.Printf("Schema file:  %s\n", r.SchemaFile)
-	fmt.Printf("Tuples view:  %s\n", r.TuplesView)
+func printStatusText(w io.Writer, r statusReport, s *migrator.Status, schemaPath string) {
+	_, _ = fmt.Fprintf(w, "Schema file:  %s\n", r.SchemaFile)
+	_, _ = fmt.Fprintf(w, "Tuples view:  %s\n", r.TuplesView)
 
 	if r.Deployed == nil {
-		fmt.Println("Deployed:     no migration recorded")
+		_, _ = fmt.Fprintln(w, "Deployed:     no migration recorded")
 	} else {
 		d := r.Deployed
-		fmt.Printf("Deployed:     checksum %s", shortChecksum(d.Checksum))
+		_, _ = fmt.Fprintf(w, "Deployed:     checksum %s", shortChecksum(d.Checksum))
 		if d.MelangeVersion != "" {
-			fmt.Printf(" · melange %s", d.MelangeVersion)
+			_, _ = fmt.Fprintf(w, " · melange %s", d.MelangeVersion)
 		}
 		if d.MigratedAt != "" {
-			fmt.Printf(" · %s", d.MigratedAt)
+			_, _ = fmt.Fprintf(w, " · %s", d.MigratedAt)
 		}
-		fmt.Println()
-		fmt.Printf("Sync:         %s\n", syncDescription(r.Sync))
-		printDriftDetail(r.Drift)
+		_, _ = fmt.Fprintln(w)
+		_, _ = fmt.Fprintf(w, "Sync:         %s\n", syncDescription(r.Sync))
+		printDriftDetail(w, r.Drift)
 		if !d.ModelRecorded {
-			fmt.Println("              model DSL not recorded — re-migrate to enable `melange schema pull`")
+			_, _ = fmt.Fprintln(w, "              model DSL not recorded — re-migrate to enable `melange schema pull`")
 		}
 	}
 
 	for _, note := range r.Notes {
-		fmt.Printf("Note:         %s\n", note)
+		_, _ = fmt.Fprintf(w, "Note:         %s\n", note)
 	}
 
 	// Actionable hints, matching the pre-enrichment behavior.
 	if !s.SchemaExists {
-		fmt.Printf("\nNo schema found at %s\n", schemaPath)
+		_, _ = fmt.Fprintf(w, "\nNo schema found at %s\n", schemaPath)
 	} else if !s.TuplesExists {
-		fmt.Println("\nTuples view not found.")
-		fmt.Println("Create melange_tuples before running checks.")
+		_, _ = fmt.Fprintln(w, "\nTuples view not found.")
+		_, _ = fmt.Fprintln(w, "Create melange_tuples before running checks.")
 	}
 }
 
@@ -418,21 +420,21 @@ const maxDriftLines = 5
 
 // printDriftDetail prints the change summary under the Sync line. Nil (no
 // detail available) prints nothing — the Sync line already says drift.
-func printDriftDetail(d *driftReport) {
+func printDriftDetail(w io.Writer, d *driftReport) {
 	if d == nil {
 		return
 	}
-	fmt.Printf("              %d breaking, %d additive\n", d.Breaking, d.Additive)
+	_, _ = fmt.Fprintf(w, "              %d breaking, %d additive\n", d.Breaking, d.Additive)
 	for i, c := range d.Changes {
 		if i == maxDriftLines {
-			fmt.Printf("              … and %d more (`melange diff` for the full list)\n", len(d.Changes)-maxDriftLines)
+			_, _ = fmt.Fprintf(w, "              … and %d more (`melange diff` for the full list)\n", len(d.Changes)-maxDriftLines)
 			break
 		}
 		marker := "+"
 		if c.Class == schema.ClassBreaking {
 			marker = "-"
 		}
-		fmt.Printf("              %s %s\n", marker, c.Summary)
+		_, _ = fmt.Fprintf(w, "              %s %s\n", marker, c.Summary)
 	}
 }
 

--- a/internal/cli/command/status.go
+++ b/internal/cli/command/status.go
@@ -3,32 +3,46 @@ package command
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"fmt"
+	"time"
 
 	_ "github.com/lib/pq"
 	"github.com/spf13/cobra"
 
 	"github.com/pthm/melange/internal/cli"
 	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/pkg/parser"
 )
 
 var (
 	statusDB       string
 	statusDBSchema string
 	statusSchema   string
+	statusFormat   string
+)
+
+// Sync states comparing the local schema file against the deployed model.
+const (
+	syncInSync      = "in_sync"      // local checksum matches the deployed one
+	syncDrift       = "drift"        // local schema differs from deployed
+	syncUnknown     = "unknown"      // no local schema file to compare
+	syncNotRecorded = "not_recorded" // the database has no migration record
 )
 
 var statusCmd = &cobra.Command{
 	Use:   "status",
-	Short: "Show current schema status",
-	Long:  `Show current schema and migration status.`,
+	Short: "Show schema, tuples, and deployed-model status",
+	Long: `Show whether the schema file and melange_tuples view are present, and what
+model the database has deployed — including whether the local schema file is
+in sync with it.`,
 	Example: `  # Check status
   melange status --db postgres://localhost/mydb
 
-  # Use a different database schema
-  melange status --db postgres://localhost/mydb --db-schema myschema`,
+  # Against a named environment, as JSON
+  melange status --env production --format json`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		databaseSchema := resolveString(statusDBSchema, cfg.Database.Schema)
+		databaseSchema := resolveString(statusDBSchema, cfg.Database.Schema, "public")
 		schemaPath := resolveString(statusSchema, cfg.Schema)
 
 		dsn, err := resolveDSN(statusDB)
@@ -36,18 +50,40 @@ var statusCmd = &cobra.Command{
 			return err
 		}
 
-		return runStatus(dsn, databaseSchema, schemaPath)
+		return runStatus(dsn, databaseSchema, schemaPath, statusFormat)
 	},
 }
 
 func init() {
 	f := statusCmd.Flags()
 	f.StringVar(&statusDB, "db", "", "database URL")
-	f.StringVar(&statusDBSchema, "db-schema", "public", "database schema")
+	f.StringVar(&statusDBSchema, "db-schema", "", "database schema (default: config database.schema, else public)")
 	f.StringVar(&statusSchema, "schema", "", "path to schema.fga or fga.mod file")
+	f.StringVar(&statusFormat, "format", "text", "output format: text (default) or json")
 }
 
-func runStatus(dsn, databaseSchema, schemaPath string) error {
+// statusReport is the machine-readable status, shared by text and JSON output.
+type statusReport struct {
+	SchemaFile string          `json:"schema_file"` // present|missing
+	TuplesView string          `json:"tuples_view"` // present|missing
+	Sync       string          `json:"sync"`
+	Deployed   *deployedReport `json:"deployed,omitempty"`
+	Notes      []string        `json:"notes,omitempty"` // non-fatal warnings
+}
+
+type deployedReport struct {
+	MelangeVersion string `json:"melange_version,omitempty"`
+	MigratedAt     string `json:"migrated_at,omitempty"`
+	Checksum       string `json:"schema_checksum"`
+	Format         string `json:"schema_format,omitempty"`
+	ModelRecorded  bool   `json:"model_recorded"` // schema_dsl present → `schema pull` works
+}
+
+func runStatus(dsn, databaseSchema, schemaPath, format string) error {
+	if format != "text" && format != "json" {
+		return cli.GeneralError(fmt.Sprintf("invalid --format %q (want text or json)", format), nil)
+	}
+
 	db, err := sql.Open("postgres", dsn)
 	if err != nil {
 		return cli.DBConnectError("connecting to database", err)
@@ -63,23 +99,135 @@ func runStatus(dsn, databaseSchema, schemaPath string) error {
 		return cli.GeneralError("getting status", err)
 	}
 
-	if s.SchemaExists {
-		fmt.Println("Schema file:  present")
-	} else {
-		fmt.Println("Schema file:  missing")
-	}
-	if s.TuplesExists {
-		fmt.Println("Tuples view:  present")
-	} else {
-		fmt.Println("Tuples view:  missing")
+	report := statusReport{
+		SchemaFile: presentMissing(s.SchemaExists),
+		TuplesView: presentMissing(s.TuplesExists),
+		Sync:       syncNotRecorded,
 	}
 
+	// Local checksum, computed the same way migrate records it, for drift
+	// detection. A present-but-unreadable schema file is surfaced, not silently
+	// treated as "no local schema".
+	localChecksum := ""
+	if s.SchemaExists {
+		content, rerr := parser.ReadSchemaContent(schemaPath)
+		if rerr != nil {
+			report.Notes = append(report.Notes, fmt.Sprintf("could not read local schema %s: %v", schemaPath, rerr))
+		} else {
+			localChecksum = migrator.ComputeSchemaChecksum(string(content))
+		}
+	}
+
+	// Reading the migration record is non-fatal: schema/tuples presence is still
+	// worth reporting even when the record can't be read (e.g. a permissions
+	// error), so status never loses its basic reachability signal.
+	rec, recErr := m.GetLastMigration(ctx)
+	switch {
+	case recErr != nil:
+		report.Notes = append(report.Notes, fmt.Sprintf("could not read migration record: %v", recErr))
+		report.Sync = syncUnknown
+	case rec != nil:
+		report.Sync = classifySync(localChecksum, rec)
+		report.Deployed = &deployedReport{
+			MelangeVersion: rec.MelangeVersion,
+			Checksum:       rec.SchemaChecksum,
+			Format:         rec.SchemaFormat,
+			ModelRecorded:  rec.SchemaDSL != "",
+		}
+		if !rec.MigratedAt.IsZero() {
+			report.Deployed.MigratedAt = rec.MigratedAt.Format(time.RFC3339)
+		}
+	default:
+		report.Sync = classifySync(localChecksum, nil) // not_recorded
+	}
+
+	if format == "json" {
+		out, merr := json.MarshalIndent(report, "", "  ")
+		if merr != nil {
+			return cli.GeneralError("encoding status", merr)
+		}
+		fmt.Println(string(out))
+		return nil
+	}
+
+	printStatusText(report, s, schemaPath)
+	return nil
+}
+
+// classifySync compares a local schema checksum against the deployed record.
+// An empty localChecksum means there is no local schema file to compare.
+func classifySync(localChecksum string, rec *migrator.MigrationRecord) string {
+	switch {
+	case rec == nil:
+		return syncNotRecorded
+	case localChecksum == "":
+		return syncUnknown
+	case localChecksum == rec.SchemaChecksum:
+		return syncInSync
+	default:
+		return syncDrift
+	}
+}
+
+func presentMissing(ok bool) string {
+	if ok {
+		return "present"
+	}
+	return "missing"
+}
+
+// shortChecksum abbreviates a hex checksum for human-readable output.
+func shortChecksum(sum string) string {
+	if len(sum) <= 12 {
+		return sum
+	}
+	return sum[:12] + "…"
+}
+
+func printStatusText(r statusReport, s *migrator.Status, schemaPath string) {
+	fmt.Printf("Schema file:  %s\n", r.SchemaFile)
+	fmt.Printf("Tuples view:  %s\n", r.TuplesView)
+
+	if r.Deployed == nil {
+		fmt.Println("Deployed:     no migration recorded")
+	} else {
+		d := r.Deployed
+		fmt.Printf("Deployed:     checksum %s", shortChecksum(d.Checksum))
+		if d.MelangeVersion != "" {
+			fmt.Printf(" · melange %s", d.MelangeVersion)
+		}
+		if d.MigratedAt != "" {
+			fmt.Printf(" · %s", d.MigratedAt)
+		}
+		fmt.Println()
+		fmt.Printf("Sync:         %s\n", syncDescription(r.Sync))
+		if !d.ModelRecorded {
+			fmt.Println("              model DSL not recorded — re-migrate to enable `melange schema pull`")
+		}
+	}
+
+	for _, note := range r.Notes {
+		fmt.Printf("Note:         %s\n", note)
+	}
+
+	// Actionable hints, matching the pre-enrichment behavior.
 	if !s.SchemaExists {
 		fmt.Printf("\nNo schema found at %s\n", schemaPath)
 	} else if !s.TuplesExists {
 		fmt.Println("\nTuples view not found.")
 		fmt.Println("Create melange_tuples before running checks.")
 	}
+}
 
-	return nil
+func syncDescription(sync string) string {
+	switch sync {
+	case syncInSync:
+		return "in sync — local schema matches deployed"
+	case syncDrift:
+		return "drift — local schema differs from deployed (run `melange migrate` to apply)"
+	case syncUnknown:
+		return "unknown — no local schema file to compare"
+	default:
+		return "not recorded"
+	}
 }

--- a/internal/cli/command/status.go
+++ b/internal/cli/command/status.go
@@ -5,6 +5,9 @@ import (
 	"database/sql"
 	"encoding/json"
 	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
 	"time"
 
 	_ "github.com/lib/pq"
@@ -29,6 +32,11 @@ const (
 	syncDrift       = "drift"        // local schema differs from deployed
 	syncUnknown     = "unknown"      // no local schema file to compare
 	syncNotRecorded = "not_recorded" // the database has no migration record
+
+	// syncDatabaseAhead is drift where the deployed model is not any version of
+	// the local schema git has recorded — someone deployed from elsewhere.
+	// Best-effort: see databaseAhead for what it cannot see.
+	syncDatabaseAhead = "database_ahead"
 )
 
 var statusCmd = &cobra.Command{
@@ -150,7 +158,14 @@ func runStatus(dsn, databaseSchema, schemaPath, format string) error {
 			report.Deployed.MigratedAt = rec.MigratedAt.Format(time.RFC3339)
 		}
 		if report.Sync == syncDrift {
-			report.Drift = driftDetail(rec, schemaPath, &report.Notes)
+			detail, equivalent := driftDetail(rec, schemaPath, &report.Notes)
+			report.Drift = detail
+			// A checksum that moved without a semantic change — reformatting, an
+			// edited comment — is drift worth reporting, but never worth alleging
+			// that someone else migrated this database.
+			if !equivalent && databaseAhead(schemaPath, rec.SchemaChecksum, maxHistoryRevisions) {
+				report.Sync = syncDatabaseAhead
+			}
 		}
 	default:
 		report.Sync = classifySync(localChecksum, nil) // not_recorded
@@ -169,25 +184,152 @@ func runStatus(dsn, databaseSchema, schemaPath, format string) error {
 	return nil
 }
 
+// maxHistoryRevisions caps how far back the database-ahead probe looks. Each
+// revision costs a `git cat-file`, so the window bounds a `status` call against
+// a long-lived schema; a schema with more history than this reports plain drift
+// rather than guessing.
+const maxHistoryRevisions = 50
+
+// databaseAhead reports whether the deployed checksum matches no version of the
+// local schema in the last maxRevisions of git history — meaning the database is
+// running a model that never existed in this checkout, so migrating would
+// overwrite someone else's work rather than move the database forward.
+//
+// It is an advisory and answers false on every uncertainty: a false negative is
+// a missing hint, while a false positive accuses a colleague of a migration they
+// did not perform. So it claims true only when git could search every version of
+// this schema and none of them produced the deployed checksum; each bail-out
+// below names what git cannot see there.
+func databaseAhead(schemaPath, deployedChecksum string, maxRevisions int) bool {
+	// Nothing to search for, or — for a modular schema — a checksum spanning the
+	// manifest and every module, which this single-path search cannot reconstruct.
+	if deployedChecksum == "" || parser.IsModularSchema(schemaPath) {
+		return false
+	}
+	relPath, err := gitRelativePath(schemaPath)
+	if err != nil {
+		return false // not a git repository
+	}
+	// A shallow clone's history stops at the graft boundary, and git reports that
+	// truncation as success — the revision count alone cannot detect it. CI
+	// checkouts are shallow by default, which is exactly where this state would
+	// be read as an alarm.
+	if shallow, serr := exec.Command("git", "rev-parse", "--is-shallow-repository").Output(); serr != nil ||
+		strings.TrimSpace(string(shallow)) != "false" {
+		return false
+	}
+	// ":(top)" anchors the pathspec at the repository root. relPath is
+	// root-relative (as `git cat-file <rev>:<path>` requires), but a bare pathspec
+	// is resolved against the current directory — which would silently match
+	// nothing whenever melange runs from a subdirectory.
+	pathspec := ":(top)" + relPath
+	// An uncommitted edit to the schema is itself a version git cannot see, and
+	// migrating from a dirty working tree is routine in local development — so a
+	// deployed model missing from history may well be one this developer applied
+	// themselves. Only a clean file makes the history search complete.
+	if status, serr := exec.Command("git", "status", "--porcelain", "--", pathspec).Output(); serr != nil || len(status) > 0 { //nolint:gosec // relPath comes from a trusted config/flag
+		return false
+	}
+	// --follow tracks the file across renames, and --name-only reports the path it
+	// had at each revision — which is what reading that revision needs, since the
+	// current path does not exist before the rename. quotepath=false keeps
+	// non-ASCII paths literal instead of C-quoted, which would make every read
+	// fail. One extra revision is requested so a truncated history is detectable.
+	out, err := exec.Command("git", "-c", "core.quotepath=false", "log", "--follow", "--format=%H", "--name-only", //nolint:gosec // relPath comes from a trusted config/flag
+		"-n", strconv.Itoa(maxRevisions+1), "--", pathspec).Output()
+	if err != nil {
+		return false
+	}
+	revisions, commits := parseRevisionPaths(string(out))
+	if commits > maxRevisions {
+		return false // history longer than the window: the search cannot be exhaustive
+	}
+	if len(revisions) == 0 {
+		return false // never committed: nothing to compare against
+	}
+	read := 0
+	for _, r := range revisions {
+		// --filters converts the blob the way a checkout would (end-of-line
+		// conversion, smudge filters), so the bytes compared are the bytes melange
+		// would have checksummed from a working tree — not the raw blob, which
+		// differs under core.autocrlf or a text attribute.
+		content, serr := exec.Command("git", "cat-file", "--filters", r.revision+":"+r.path).Output() //nolint:gosec // revision and path come from git itself
+		if serr != nil {
+			continue // file absent at this revision, or unreadable in a partial clone
+		}
+		read++
+		if migrator.ComputeSchemaChecksum(string(content)) == deployedChecksum {
+			return false
+		}
+	}
+	// Every revision failed to read (a blobless clone offline, say). Absence of
+	// evidence is not evidence here.
+	return read > 0
+}
+
+// revisionPath is a commit and the path the schema had at that commit.
+type revisionPath struct {
+	revision string
+	path     string
+}
+
+// parseRevisionPaths reads `git log --format=%H --name-only` output: a commit
+// hash on its own line, a blank line, then the paths touched. It returns one
+// entry per commit that reported a path — the first only, since the log is
+// filtered to a single pathspec and --follow reports at most one name per commit
+// — plus the number of commits git listed, which is what truncation must be
+// judged on: a commit that reported no path still consumed the window.
+func parseRevisionPaths(out string) (revisions []revisionPath, commits int) {
+	var pending string
+	for _, line := range strings.Split(out, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case line == "":
+			continue
+		case isCommitHash(line):
+			commits++
+			pending = line
+		case pending != "":
+			revisions = append(revisions, revisionPath{revision: pending, path: line})
+			pending = ""
+		}
+	}
+	return revisions, commits
+}
+
+// isCommitHash distinguishes a %H line from a path line. Full hashes are 40 hex
+// characters (SHA-1) or 64 (SHA-256 repositories).
+func isCommitHash(line string) bool {
+	if len(line) != 40 && len(line) != 64 {
+		return false
+	}
+	return strings.TrimLeft(line, "0123456789abcdef") == ""
+}
+
 // driftDetail diffs the deployed model against the local schema so `status` can
 // say what drifted, not just that something did. Every failure to get there
 // (a record predating model storage, an unparseable side) yields nil plus a
 // note: the checksum-level drift verdict already stands on its own.
-func driftDetail(rec *migrator.MigrationRecord, schemaPath string, notes *[]string) *driftReport {
+//
+// The second return says the models were compared and found semantically equal.
+// A nil report alone conflates that with a comparison that could not be made,
+// and callers must not read the latter as proof of equivalence.
+func driftDetail(rec *migrator.MigrationRecord, schemaPath string, notes *[]string) (detail *driftReport, equivalent bool) {
 	deployed, derr := deployedTypesFromRecord(rec)
 	if derr != nil {
 		*notes = append(*notes, fmt.Sprintf("could not read the deployed model for a detailed diff: %v", derr))
-		return nil
+		return nil, false
 	}
 	if deployed == nil {
-		return nil // pre-storage record; the ModelRecorded hint already covers it
+		return nil, false // pre-storage record; the ModelRecorded hint already covers it
 	}
 	local, lerr := parser.ParseSchema(schemaPath)
 	if lerr != nil {
 		*notes = append(*notes, fmt.Sprintf("could not parse local schema for a detailed diff: %v", lerr))
-		return nil
+		return nil, false
 	}
-	return summarizeDrift(deployed, local)
+	detail = summarizeDrift(deployed, local)
+	return detail, detail == nil
 }
 
 // summarizeDrift renders a diff of the two models as a drift report, or nil
@@ -300,6 +442,8 @@ func syncDescription(sync string) string {
 		return "in sync — local schema matches deployed"
 	case syncDrift:
 		return "drift — local schema differs from deployed (`melange diff` to see changes, `melange migrate` to apply)"
+	case syncDatabaseAhead:
+		return "database ahead — deployed model is not any version of your local schema in recent git history; someone else may have migrated it"
 	case syncUnknown:
 		return "unknown — no local schema file to compare"
 	default:

--- a/internal/cli/command/status.go
+++ b/internal/cli/command/status.go
@@ -13,6 +13,7 @@ import (
 	"github.com/pthm/melange/internal/cli"
 	"github.com/pthm/melange/pkg/migrator"
 	"github.com/pthm/melange/pkg/parser"
+	"github.com/pthm/melange/pkg/schema"
 )
 
 var (
@@ -68,7 +69,18 @@ type statusReport struct {
 	TuplesView string          `json:"tuples_view"` // present|missing
 	Sync       string          `json:"sync"`
 	Deployed   *deployedReport `json:"deployed,omitempty"`
+	Drift      *driftReport    `json:"drift,omitempty"`
 	Notes      []string        `json:"notes,omitempty"` // non-fatal warnings
+}
+
+// driftReport is the semantic detail behind a `drift` sync state: what the
+// local schema would change if migrated. Absent when the schemas match, when
+// the deployed model was never recorded, or when either side could not be
+// parsed — status stays a reachability report, so none of those are errors.
+type driftReport struct {
+	Additive int             `json:"additive"`
+	Breaking int             `json:"breaking"`
+	Changes  []schema.Change `json:"changes"`
 }
 
 type deployedReport struct {
@@ -137,6 +149,9 @@ func runStatus(dsn, databaseSchema, schemaPath, format string) error {
 		if !rec.MigratedAt.IsZero() {
 			report.Deployed.MigratedAt = rec.MigratedAt.Format(time.RFC3339)
 		}
+		if report.Sync == syncDrift {
+			report.Drift = driftDetail(rec, schemaPath, &report.Notes)
+		}
 	default:
 		report.Sync = classifySync(localChecksum, nil) // not_recorded
 	}
@@ -152,6 +167,40 @@ func runStatus(dsn, databaseSchema, schemaPath, format string) error {
 
 	printStatusText(report, s, schemaPath)
 	return nil
+}
+
+// driftDetail diffs the deployed model against the local schema so `status` can
+// say what drifted, not just that something did. Every failure to get there
+// (a record predating model storage, an unparseable side) yields nil plus a
+// note: the checksum-level drift verdict already stands on its own.
+func driftDetail(rec *migrator.MigrationRecord, schemaPath string, notes *[]string) *driftReport {
+	deployed, derr := deployedTypesFromRecord(rec)
+	if derr != nil {
+		*notes = append(*notes, fmt.Sprintf("could not read the deployed model for a detailed diff: %v", derr))
+		return nil
+	}
+	if deployed == nil {
+		return nil // pre-storage record; the ModelRecorded hint already covers it
+	}
+	local, lerr := parser.ParseSchema(schemaPath)
+	if lerr != nil {
+		*notes = append(*notes, fmt.Sprintf("could not parse local schema for a detailed diff: %v", lerr))
+		return nil
+	}
+	return summarizeDrift(deployed, local)
+}
+
+// summarizeDrift renders a diff of the two models as a drift report, or nil
+// when they are semantically equivalent. Equivalence with differing checksums
+// is real and worth reporting as such: formatting or comment changes move the
+// checksum without changing behavior.
+func summarizeDrift(deployed, local []schema.TypeDefinition) *driftReport {
+	d := schema.Diff(deployed, local)
+	if d.Empty() {
+		return nil
+	}
+	additive, breaking := d.Counts()
+	return &driftReport{Additive: additive, Breaking: breaking, Changes: d.Changes}
 }
 
 // classifySync compares a local schema checksum against the deployed record.
@@ -201,6 +250,7 @@ func printStatusText(r statusReport, s *migrator.Status, schemaPath string) {
 		}
 		fmt.Println()
 		fmt.Printf("Sync:         %s\n", syncDescription(r.Sync))
+		printDriftDetail(r.Drift)
 		if !d.ModelRecorded {
 			fmt.Println("              model DSL not recorded — re-migrate to enable `melange schema pull`")
 		}
@@ -216,6 +266,31 @@ func printStatusText(r statusReport, s *migrator.Status, schemaPath string) {
 	} else if !s.TuplesExists {
 		fmt.Println("\nTuples view not found.")
 		fmt.Println("Create melange_tuples before running checks.")
+	}
+}
+
+// maxDriftLines caps the change list in text output. A full model rewrite can
+// produce hundreds of changes; status is a summary, and `melange diff` prints
+// the complete list.
+const maxDriftLines = 5
+
+// printDriftDetail prints the change summary under the Sync line. Nil (no
+// detail available) prints nothing — the Sync line already says drift.
+func printDriftDetail(d *driftReport) {
+	if d == nil {
+		return
+	}
+	fmt.Printf("              %d breaking, %d additive\n", d.Breaking, d.Additive)
+	for i, c := range d.Changes {
+		if i == maxDriftLines {
+			fmt.Printf("              … and %d more (`melange diff` for the full list)\n", len(d.Changes)-maxDriftLines)
+			break
+		}
+		marker := "+"
+		if c.Class == schema.ClassBreaking {
+			marker = "-"
+		}
+		fmt.Printf("              %s %s\n", marker, c.Summary)
 	}
 }
 

--- a/internal/cli/command/status_test.go
+++ b/internal/cli/command/status_test.go
@@ -1,0 +1,128 @@
+package command
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/pthm/melange/pkg/migrator"
+	"github.com/pthm/melange/pkg/schema"
+)
+
+// model builds a one-type model whose viewer relation grants the given subject
+// types, which is enough shape to produce every class of drift under test.
+func model(subjectTypes ...string) []schema.TypeDefinition {
+	rels := []schema.RelationDefinition{{Name: "viewer"}}
+	for _, st := range subjectTypes {
+		rels[0].SubjectTypeRefs = append(rels[0].SubjectTypeRefs, schema.SubjectTypeRef{Type: st})
+	}
+	return []schema.TypeDefinition{
+		{Name: "user"},
+		{Name: "document", Relations: rels},
+	}
+}
+
+func TestSummarizeDrift_Additive(t *testing.T) {
+	deployed := model("user")
+	local := append(model("user"), schema.TypeDefinition{Name: "folder"})
+
+	d := summarizeDrift(deployed, local)
+	if d == nil {
+		t.Fatal("expected drift detail for an added type")
+	}
+	if d.Breaking != 0 {
+		t.Errorf("added type must not be breaking, got %d breaking", d.Breaking)
+	}
+	if d.Additive != 1 {
+		t.Errorf("additive = %d, want 1", d.Additive)
+	}
+	if len(d.Changes) != 1 {
+		t.Fatalf("changes = %d, want 1", len(d.Changes))
+	}
+}
+
+func TestSummarizeDrift_Breaking(t *testing.T) {
+	deployed := append(model("user"), schema.TypeDefinition{Name: "folder"})
+	local := model("user")
+
+	d := summarizeDrift(deployed, local)
+	if d == nil {
+		t.Fatal("expected drift detail for a removed type")
+	}
+	if d.Breaking != 1 {
+		t.Errorf("breaking = %d, want 1 (removing a type narrows access)", d.Breaking)
+	}
+}
+
+// Equivalent models with different checksums are real: reformatting or a
+// comment edit moves the checksum without changing behavior. Status must not
+// invent changes to explain that.
+func TestSummarizeDrift_EquivalentModelsReportNoDetail(t *testing.T) {
+	if d := summarizeDrift(model("user"), model("user")); d != nil {
+		t.Errorf("equivalent models should produce no drift detail, got %+v", d)
+	}
+}
+
+func TestDeployedTypesFromRecord_PrefersModelJSON(t *testing.T) {
+	encoded, err := schema.MarshalModel(model("user"))
+	if err != nil {
+		t.Fatalf("MarshalModel: %v", err)
+	}
+	// A DSL that would parse to something different, so preferring the JSON is
+	// observable rather than merely plausible.
+	rec := &migrator.MigrationRecord{
+		SchemaDSL: "model\n  schema 1.1\ntype user\n",
+		ModelJSON: encoded,
+	}
+
+	types, err := deployedTypesFromRecord(rec)
+	if err != nil {
+		t.Fatalf("deployedTypesFromRecord: %v", err)
+	}
+	if len(types) != 2 {
+		t.Fatalf("types = %d, want 2 from model_json (not the 1-type DSL)", len(types))
+	}
+}
+
+func TestDeployedTypesFromRecord_FallsBackToDSL(t *testing.T) {
+	rec := &migrator.MigrationRecord{
+		SchemaDSL: "model\n  schema 1.1\ntype user\n",
+		ModelJSON: nil, // never written, or written empty
+	}
+
+	types, err := deployedTypesFromRecord(rec)
+	if err != nil {
+		t.Fatalf("deployedTypesFromRecord: %v", err)
+	}
+	if len(types) != 1 || types[0].Name != "user" {
+		t.Fatalf("types = %+v, want the single type parsed from the DSL", types)
+	}
+}
+
+func TestDeployedTypesFromRecord_PreStorageRecordIsNotAnError(t *testing.T) {
+	types, err := deployedTypesFromRecord(&migrator.MigrationRecord{SchemaChecksum: "abc"})
+	if err != nil {
+		t.Fatalf("a record without a DSL must not error, got %v", err)
+	}
+	if types != nil {
+		t.Errorf("types = %+v, want nil", types)
+	}
+}
+
+func TestDeployedTypesFromRecord_CorruptDSLErrors(t *testing.T) {
+	rec := &migrator.MigrationRecord{SchemaDSL: "this is not a schema"}
+	if _, err := deployedTypesFromRecord(rec); err == nil {
+		t.Error("expected an error for an unparseable recorded DSL")
+	}
+}
+
+// The drift block is omitted from JSON when absent, so consumers that only
+// check `sync` are unaffected by this addition.
+func TestStatusReport_DriftOmittedWhenAbsent(t *testing.T) {
+	out, err := json.Marshal(statusReport{Sync: syncInSync})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	if got := string(out); got != `{"schema_file":"","tuples_view":"","sync":"in_sync"}` {
+		t.Errorf("unexpected JSON: %s", got)
+	}
+}

--- a/internal/cli/command/status_test.go
+++ b/internal/cli/command/status_test.go
@@ -458,3 +458,29 @@ func TestDatabaseAhead_UnreadableRevisionsAreInconclusive(t *testing.T) {
 		t.Error("no revision could be read, so the search proves nothing and must fall back to drift")
 	}
 }
+
+// A local schema that does not parse leaves the checksum-level drift verdict
+// standing, with a note explaining why there is no detail.
+func TestDriftDetail_UnparseableLocalSchemaNotes(t *testing.T) {
+	dir := tempDir(t)
+	t.Chdir(dir)
+	writeFile(t, "broken.fga", "this is not a schema")
+
+	encoded, err := schema.MarshalModel(model("user"))
+	if err != nil {
+		t.Fatalf("MarshalModel: %v", err)
+	}
+
+	var notes []string
+	detail, equivalent := driftDetail(&migrator.MigrationRecord{
+		SchemaDSL: "model\n  schema 1.1\ntype user\n",
+		ModelJSON: encoded,
+	}, "broken.fga", &notes)
+
+	if detail != nil || equivalent {
+		t.Errorf("detail = %+v, equivalent = %v; want nil, false", detail, equivalent)
+	}
+	if len(notes) != 1 || !strings.Contains(notes[0], "could not parse local schema") {
+		t.Errorf("notes = %v, want one naming the parse failure", notes)
+	}
+}

--- a/internal/cli/command/status_test.go
+++ b/internal/cli/command/status_test.go
@@ -2,6 +2,11 @@ package command
 
 import (
 	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/pthm/melange/pkg/migrator"
@@ -124,5 +129,332 @@ func TestStatusReport_DriftOmittedWhenAbsent(t *testing.T) {
 	}
 	if got := string(out); got != `{"schema_file":"","tuples_view":"","sync":"in_sync"}` {
 		t.Errorf("unexpected JSON: %s", got)
+	}
+}
+
+// gitRun runs a git command in the current working directory, failing the test
+// on error.
+func gitRun(t *testing.T, args ...string) {
+	t.Helper()
+	if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+}
+
+// requireGit skips the test when git is unavailable — every probe test shells
+// out to it.
+func requireGit(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not installed")
+	}
+}
+
+// tempDir returns a temporary directory with symlinks resolved: on macOS
+// t.TempDir() lives under /var, which is a link to /private/var, and `git
+// rev-parse --show-toplevel` reports the resolved path — an unresolved cwd makes
+// every repo-relative path wrong.
+func tempDir(t *testing.T) string {
+	t.Helper()
+	dir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolving temp dir: %v", err)
+	}
+	return dir
+}
+
+// writeFile writes a file relative to the current working directory.
+func writeFile(t *testing.T, path, content string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("writing %s: %v", path, err)
+	}
+}
+
+// gitRepoWithSchema creates a git repo containing schemaPath at each of the
+// given contents, one commit per version, and chdirs into it. Returns the
+// checksums in commit order.
+func gitRepoWithSchema(t *testing.T, schemaPath string, versions ...string) []string {
+	t.Helper()
+	requireGit(t)
+	t.Chdir(tempDir(t))
+	// Isolate from the developer's global config: commit.gpgsign, hooks, or
+	// core.autocrlf would otherwise fail or skew these tests.
+	t.Setenv("GIT_CONFIG_GLOBAL", os.DevNull)
+	t.Setenv("GIT_CONFIG_SYSTEM", os.DevNull)
+	gitRun(t, "init")
+	gitRun(t, "config", "user.email", "test@example.com")
+	gitRun(t, "config", "user.name", "Test")
+
+	checksums := make([]string, 0, len(versions))
+	for i, content := range versions {
+		writeFile(t, schemaPath, content)
+		gitRun(t, "add", schemaPath)
+		gitRun(t, "commit", "-m", fmt.Sprintf("version %d", i))
+		checksums = append(checksums, migrator.ComputeSchemaChecksum(content))
+	}
+	return checksums
+}
+
+const (
+	schemaV1 = "model\n  schema 1.1\ntype user\n"
+	schemaV2 = "model\n  schema 1.1\ntype user\ntype folder\n"
+)
+
+// unknownChecksum is the checksum of a schema no test repo ever commits: the
+// deployed model that this checkout cannot account for.
+var unknownChecksum = migrator.ComputeSchemaChecksum("model\n  schema 1.1\ntype nobody_has_this\n")
+
+// A deployed checksum matching an older committed version means the database is
+// simply behind: ordinary drift, not "ahead".
+func TestDatabaseAhead_DeployedVersionIsInHistory(t *testing.T) {
+	checksums := gitRepoWithSchema(t, "schema.fga", schemaV1, schemaV2)
+
+	if databaseAhead("schema.fga", checksums[0], maxHistoryRevisions) {
+		t.Error("a deployed checksum found in git history is drift, not database_ahead")
+	}
+}
+
+func TestDatabaseAhead_DeployedModelUnknownLocally(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1, schemaV2)
+
+	if !databaseAhead("schema.fga", unknownChecksum, maxHistoryRevisions) {
+		t.Error("a deployed checksum absent from git history should report database_ahead")
+	}
+}
+
+// Outside a git repo the probe cannot answer, and must not accuse.
+func TestDatabaseAhead_OutsideGitRepoStaysDrift(t *testing.T) {
+	requireGit(t)
+	t.Chdir(tempDir(t))
+	writeFile(t, "schema.fga", schemaV1)
+
+	if databaseAhead("schema.fga", unknownChecksum, maxHistoryRevisions) {
+		t.Error("outside a git repo the probe must fall back to drift")
+	}
+}
+
+// A modular schema's checksum spans the manifest and every module, which the
+// single-path probe cannot reconstruct, so it never claims to know.
+func TestDatabaseAhead_ModularSchemaStaysDrift(t *testing.T) {
+	gitRepoWithSchema(t, "fga.mod", "schema: 1.2\ncontents:\n  - core.fga\n")
+
+	if databaseAhead("fga.mod", unknownChecksum, maxHistoryRevisions) {
+		t.Error("modular schemas must fall back to drift")
+	}
+}
+
+// An uncommitted schema has no history to search; that is not evidence of a
+// foreign deployment.
+func TestDatabaseAhead_UncommittedSchemaStaysDrift(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1)
+	writeFile(t, "other.fga", schemaV2)
+
+	if databaseAhead("other.fga", unknownChecksum, maxHistoryRevisions) {
+		t.Error("an uncommitted schema must fall back to drift")
+	}
+}
+
+func TestSyncDescription_CoversEveryState(t *testing.T) {
+	for _, state := range []string{syncInSync, syncDrift, syncUnknown, syncDatabaseAhead} {
+		if got := syncDescription(state); got == "" || got == "not recorded" {
+			t.Errorf("syncDescription(%q) = %q, want a state-specific description", state, got)
+		}
+	}
+	if got := syncDescription(syncNotRecorded); got != "not recorded" {
+		t.Errorf("syncDescription(%q) = %q, want \"not recorded\"", syncNotRecorded, got)
+	}
+}
+
+// A schema that was renamed still has its earlier versions in history; --follow
+// finds them, so a deployment from before the rename is drift, not "ahead".
+func TestDatabaseAhead_FollowsRenames(t *testing.T) {
+	checksums := gitRepoWithSchema(t, "schema.fga", schemaV1)
+	gitRun(t, "mv", "schema.fga", "authz.fga")
+	// Change the content in the same commit as the rename: the pre-rename
+	// checksum then exists only under the old path, so finding it proves the
+	// search followed the rename rather than reading the current path.
+	writeFile(t, "authz.fga", schemaV2)
+	gitRun(t, "add", "-A")
+	gitRun(t, "commit", "-m", "rename and extend schema")
+
+	if databaseAhead("authz.fga", checksums[0], maxHistoryRevisions) {
+		t.Error("a version committed under the old name must not report database_ahead")
+	}
+}
+
+// More history than the window means the search could not be exhaustive: the
+// deployed model may sit just past the cutoff, so the probe must not accuse.
+func TestDatabaseAhead_TruncatedHistoryIsInconclusive(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1, schemaV2, schemaV1+"\n")
+
+	if databaseAhead("schema.fga", unknownChecksum, 2) {
+		t.Error("a history longer than the window must fall back to drift")
+	}
+	// The same checksum is conclusive once the window covers every revision.
+	if !databaseAhead("schema.fga", unknownChecksum, 10) {
+		t.Error("with the whole history searched, an unknown checksum is database_ahead")
+	}
+}
+
+func TestParseRevisionPaths(t *testing.T) {
+	const sha1 = "1111111111111111111111111111111111111111"
+	const sha2 = "2222222222222222222222222222222222222222"
+	out := sha1 + "\n\nauthz.fga\n" + sha2 + "\n\nschema.fga\n"
+
+	got, commits := parseRevisionPaths(out)
+	want := []revisionPath{{sha1, "authz.fga"}, {sha2, "schema.fga"}}
+	if len(got) != len(want) {
+		t.Fatalf("parsed %d revisions, want %d: %+v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("revision %d = %+v, want %+v", i, got[i], want[i])
+		}
+	}
+	if commits != 2 {
+		t.Errorf("commits = %d, want 2", commits)
+	}
+}
+
+// A commit with no path line (possible when git filters differently than
+// expected) must not pair the next commit hash with a stale path — and must
+// still count against the window, which truncation is judged on.
+func TestParseRevisionPaths_SkipsCommitsWithoutPaths(t *testing.T) {
+	const sha1 = "1111111111111111111111111111111111111111"
+	const sha2 = "2222222222222222222222222222222222222222"
+
+	got, commits := parseRevisionPaths(sha1 + "\n\n" + sha2 + "\n\nschema.fga\n")
+	if len(got) != 1 || got[0].revision != sha2 {
+		t.Errorf("got %+v, want only the commit that reported a path", got)
+	}
+	if commits != 2 {
+		t.Errorf("commits = %d, want 2 (both commits consumed the window)", commits)
+	}
+}
+
+// Migrating from a dirty working tree is routine in local development, so the
+// deployed model may be an uncommitted version this developer applied. Git
+// cannot see it either way; the probe must not read that as a foreign
+// deployment.
+func TestDatabaseAhead_UncommittedEditsAreInconclusive(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1)
+	writeFile(t, "schema.fga", schemaV2)
+
+	if databaseAhead("schema.fga", unknownChecksum, maxHistoryRevisions) {
+		t.Error("a modified working tree must fall back to drift")
+	}
+}
+
+// Git pathspecs resolve against the current directory, while the schema path is
+// repository-root-relative — so the probe must anchor its pathspec or it
+// silently finds no history whenever melange runs from a subdirectory.
+func TestDatabaseAhead_WorksFromASubdirectory(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1)
+	if err := os.Mkdir("services", 0o750); err != nil {
+		t.Fatalf("creating subdirectory: %v", err)
+	}
+	t.Chdir("services")
+
+	if !databaseAhead("../schema.fga", unknownChecksum, maxHistoryRevisions) {
+		t.Error("the probe must find the schema's history when run from a subdirectory")
+	}
+}
+
+// A shallow clone's history stops at the graft boundary and git reports that as
+// success, so the revision count cannot detect it. CI checkouts are shallow by
+// default — precisely where a false alarm would be believed.
+func TestDatabaseAhead_ShallowCloneIsInconclusive(t *testing.T) {
+	checksums := gitRepoWithSchema(t, "schema.fga", schemaV1, schemaV2)
+	origin, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	shallow := filepath.Join(tempDir(t), "shallow")
+	gitRun(t, "clone", "--depth", "1", "file://"+origin, shallow)
+	t.Chdir(shallow)
+
+	// checksums[0] is the first version, which the shallow clone cannot see.
+	if databaseAhead("schema.fga", checksums[0], maxHistoryRevisions) {
+		t.Error("a shallow clone cannot prove absence and must fall back to drift")
+	}
+}
+
+// git C-quotes non-ASCII paths under the default core.quotepath, which makes
+// every revision unreadable. The all-reads-failed guard keeps that from becoming
+// an accusation, but it also makes the probe useless — so assert it still
+// reaches a verdict, not merely that it stays quiet.
+func TestDatabaseAhead_NonASCIISchemaPath(t *testing.T) {
+	checksums := gitRepoWithSchema(t, "schéma.fga", schemaV1, schemaV2)
+
+	if databaseAhead("schéma.fga", checksums[0], maxHistoryRevisions) {
+		t.Error("a committed version under a non-ASCII path must be found")
+	}
+	if !databaseAhead("schéma.fga", unknownChecksum, maxHistoryRevisions) {
+		t.Error("the probe must read revisions under a non-ASCII path, not give up on them")
+	}
+}
+
+// End-of-line conversion means the blob and the working tree differ while git
+// still reports the file clean; comparing raw blobs would mismatch every
+// revision on a CRLF checkout.
+func TestDatabaseAhead_EOLNormalizedSchema(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1)
+	gitRun(t, "config", "core.autocrlf", "true")
+	writeFile(t, ".gitattributes", "*.fga text\n")
+	gitRun(t, "add", ".gitattributes")
+	gitRun(t, "commit", "-m", "normalize eol")
+
+	// What a checkout under these settings produces is what melange checksums.
+	deployed := migrator.ComputeSchemaChecksum(strings.ReplaceAll(schemaV1, "\n", "\r\n"))
+	if databaseAhead("schema.fga", deployed, maxHistoryRevisions) {
+		t.Error("an eol-normalized version of a committed schema must be found")
+	}
+}
+
+// A record that predates model storage cannot be compared, which the caller
+// must not read as "the models are equal" — that would suppress the
+// database-ahead escalation.
+func TestDriftDetail_PreStorageRecordIsNotEquivalent(t *testing.T) {
+	var notes []string
+	detail, equivalent := driftDetail(&migrator.MigrationRecord{SchemaChecksum: "abc"}, "schema.fga", &notes)
+	if detail != nil || equivalent {
+		t.Errorf("detail = %+v, equivalent = %v; want nil, false", detail, equivalent)
+	}
+	if len(notes) != 0 {
+		t.Errorf("a pre-storage record needs no note (model_recorded covers it), got %v", notes)
+	}
+}
+
+func TestDriftDetail_UnparseableRecordedDSLNotesAndIsNotEquivalent(t *testing.T) {
+	var notes []string
+	rec := &migrator.MigrationRecord{SchemaDSL: "not a schema"}
+	detail, equivalent := driftDetail(rec, "schema.fga", &notes)
+	if detail != nil || equivalent {
+		t.Errorf("detail = %+v, equivalent = %v; want nil, false", detail, equivalent)
+	}
+	if len(notes) != 1 {
+		t.Errorf("notes = %v, want one explaining the failure", notes)
+	}
+}
+
+// Every revision failing to read is not proof of anything. A required smudge
+// filter that exits non-zero reproduces it hermetically: `git log` still lists
+// the revisions, but reading their content fails — the same shape as a blobless
+// clone with no network.
+func TestDatabaseAhead_UnreadableRevisionsAreInconclusive(t *testing.T) {
+	gitRepoWithSchema(t, "schema.fga", schemaV1)
+	writeFile(t, ".gitattributes", "*.fga filter=fail\n")
+	gitRun(t, "add", ".gitattributes")
+	gitRun(t, "-c", "filter.fail.clean=cat", "commit", "-m", "add filter attribute")
+	// clean passes so the working tree still reads as unmodified; only reading a
+	// committed revision back out fails.
+	gitRun(t, "config", "filter.fail.clean", "cat")
+	gitRun(t, "config", "filter.fail.smudge", "exit 1")
+	gitRun(t, "config", "filter.fail.required", "true")
+
+	if databaseAhead("schema.fga", unknownChecksum, maxHistoryRevisions) {
+		t.Error("no revision could be read, so the search proves nothing and must fall back to drift")
 	}
 }

--- a/internal/cli/config.go
+++ b/internal/cli/config.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/viper"
@@ -26,6 +27,24 @@ type Config struct {
 	Generate GenerateConfig `mapstructure:"generate"`
 	Migrate  MigrateConfig  `mapstructure:"migrate"`
 	Doctor   DoctorConfig   `mapstructure:"doctor"`
+
+	// DefaultEnvironment names the environment applied when neither the --env
+	// flag nor MELANGE_ENV selects one. Empty means "use the base config".
+	DefaultEnvironment string `mapstructure:"default_environment"`
+
+	// Environments are named connection profiles. Each overlays the base
+	// configuration (see ForEnvironment); a field an environment leaves unset
+	// falls through to the base. Absent map ⇒ behavior identical to before
+	// environments existed.
+	Environments map[string]EnvironmentConfig `mapstructure:"environments"`
+}
+
+// EnvironmentConfig is a named connection profile overlaid onto the base
+// Config by ForEnvironment. Typically only Database is set; Schema is available
+// for the uncommon case of an environment that reads a different schema file.
+type EnvironmentConfig struct {
+	Database DatabaseConfig `mapstructure:"database"`
+	Schema   string         `mapstructure:"schema"`
 }
 
 // DatabaseConfig holds database connection settings.
@@ -114,6 +133,288 @@ func LoadConfig(explicitConfigPath string) (*Config, string, error) {
 	}
 
 	return &cfg, configPath, nil
+}
+
+// envRefPattern matches ${VAR} references (braced form only). We deliberately
+// do not honor bare $VAR so that literal '$' characters in passwords or DSNs
+// pass through untouched — only the explicit ${...} syntax is expanded.
+var envRefPattern = regexp.MustCompile(`\$\{([A-Za-z_][A-Za-z0-9_]*)\}`)
+
+// expandEnvRefs replaces every ${VAR} in s with the value of the OS environment
+// variable VAR. The name of every referenced variable that is not set is
+// appended to *missing so callers can fail loud rather than silently substitute
+// an empty string. Bare $VAR and literal $ are left as-is.
+func expandEnvRefs(s string, missing *[]string) string {
+	return envRefPattern.ReplaceAllStringFunc(s, func(match string) string {
+		name := match[2 : len(match)-1]
+		val, ok := os.LookupEnv(name)
+		if !ok {
+			*missing = append(*missing, name)
+			return ""
+		}
+		return val
+	})
+}
+
+// expandDatabaseRefs returns db with ${VAR} references expanded in every string
+// field, so environment profiles can reference secrets like
+// `url: ${PROD_DATABASE_URL}` instead of committing credentials. Unset variable
+// names are collected into *missing.
+func expandDatabaseRefs(db DatabaseConfig, missing *[]string) DatabaseConfig {
+	db.URL = expandEnvRefs(db.URL, missing)
+	db.Host = expandEnvRefs(db.Host, missing)
+	db.Name = expandEnvRefs(db.Name, missing)
+	db.User = expandEnvRefs(db.User, missing)
+	db.Password = expandEnvRefs(db.Password, missing)
+	db.SSLMode = expandEnvRefs(db.SSLMode, missing)
+	db.Schema = expandEnvRefs(db.Schema, missing)
+	return db
+}
+
+// overlayDatabase returns base with the environment's fields overlaid. Any field
+// over sets replaces base's; unset fields fall through. When the environment
+// specifies any connection identity (URL, host, or name), the base URL is
+// dropped first: DSN prefers URL, so a stale base URL would otherwise shadow a
+// discrete override. Melange does not decompose a base URL into fields, so an
+// environment that overrides a URL-based base with discrete fields must supply a
+// complete connection (including user); DSN() reports a clear error otherwise.
+func overlayDatabase(base, over DatabaseConfig) DatabaseConfig {
+	out := base
+	if over.URL != "" || over.Host != "" || over.Name != "" {
+		out.URL = ""
+	}
+
+	if over.URL != "" {
+		out.URL = over.URL
+	}
+	if over.Host != "" {
+		out.Host = over.Host
+	}
+	if over.Port != 0 {
+		out.Port = over.Port
+	}
+	if over.Name != "" {
+		out.Name = over.Name
+	}
+	if over.User != "" {
+		out.User = over.User
+	}
+	if over.Password != "" {
+		out.Password = over.Password
+	}
+	if over.SSLMode != "" {
+		out.SSLMode = over.SSLMode
+	}
+	if over.Schema != "" {
+		out.Schema = over.Schema
+	}
+	return out
+}
+
+// resolveDatabase overlays over onto base and expands ${VAR} references,
+// recording unset variable names into *missing. Because a base URL is dropped
+// whenever the environment specifies its own connection (see overlayDatabase),
+// only references on surviving fields are expanded and required — selecting an
+// environment never fails on an unrelated unset base/local secret it replaces.
+func resolveDatabase(base, over DatabaseConfig, missing *[]string) DatabaseConfig {
+	return expandDatabaseRefs(overlayDatabase(base, over), missing)
+}
+
+// HasEnvironment reports whether the named environment profile is defined.
+func (c *Config) HasEnvironment(name string) bool {
+	_, ok := c.Environments[name]
+	return ok
+}
+
+// lookupEnvironment returns the named environment profile. An undefined name is
+// an error — failing loud prevents `--env prod` from silently running against
+// the base (often local) database after a typo.
+func (c *Config) lookupEnvironment(name string) (EnvironmentConfig, error) {
+	env, ok := c.Environments[name]
+	if !ok {
+		return EnvironmentConfig{}, fmt.Errorf("environment %q is not defined in configuration", name)
+	}
+	return env, nil
+}
+
+// ForEnvironment returns a copy of the config with the named environment
+// overlaid and ${VAR} references expanded. An empty envName returns the base
+// config (still with ${VAR} expansion applied, so the base database block may
+// reference secrets too).
+//
+// A non-empty envName that is not defined is an error (returned with a nil
+// config). An unset ${VAR} reference is also an error — an unset secret must
+// fail loud rather than silently resolve and retarget the command — but there
+// the returned config is still populated best-effort (unset references expand to
+// empty), so callers may use its non-connection fields (e.g. Schema) and honor
+// an explicit --db while any DSN attempt fails loud.
+func (c *Config) ForEnvironment(envName string) (*Config, error) {
+	resolved := *c
+
+	over := DatabaseConfig{}
+	schemaSource := c.Schema
+
+	if envName != "" {
+		env, err := c.lookupEnvironment(envName)
+		if err != nil {
+			return nil, err
+		}
+		over = env.Database
+		if env.Schema != "" {
+			schemaSource = env.Schema
+		}
+	}
+
+	// Track database refs separately: only an unresolved *database* reference
+	// blocks a connection. An unresolved schema reference is not a DSN failure —
+	// it surfaces when the schema is loaded, and can be overridden by --schema.
+	var dbMissing, schemaMissing []string
+	resolved.Database = resolveDatabase(c.Database, over, &dbMissing)
+	resolved.Schema = expandEnvRefs(schemaSource, &schemaMissing)
+
+	if len(dbMissing) > 0 {
+		// Return the best-effort config (unset refs expanded to empty) alongside
+		// the error so callers can still use non-connection fields (e.g. Schema)
+		// and honor an explicit --db, while DSN attempts fail loud.
+		return &resolved, fmt.Errorf("unset environment variable(s) referenced in database configuration: %s",
+			strings.Join(dedupeStrings(dbMissing), ", "))
+	}
+
+	return &resolved, nil
+}
+
+// dedupeStrings returns names with duplicates removed, preserving first-seen order.
+func dedupeStrings(names []string) []string {
+	seen := make(map[string]bool, len(names))
+	out := names[:0:0]
+	for _, n := range names {
+		if !seen[n] {
+			seen[n] = true
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// EnvironmentSummary returns a redacted, human-readable connection target for
+// the named environment (or the base config when name == ""). Unlike
+// ForEnvironment it does not expand ${VAR} references — a listing should show
+// what is configured, not whatever happens to be in the current shell — and it
+// redacts any URL password. Returns an error only when name is a non-empty
+// environment that is not defined.
+func (c *Config) EnvironmentSummary(name string) (string, error) {
+	db := c.Database
+	if name != "" {
+		env, err := c.lookupEnvironment(name)
+		if err != nil {
+			return "", err
+		}
+		db = overlayDatabase(c.Database, env.Database)
+	}
+
+	switch {
+	case db.URL != "":
+		return redactURL(db.URL), nil
+	case db.Host != "" || db.Name != "":
+		host := db.Host
+		if host == "" {
+			host = "localhost"
+		}
+		port := db.Port
+		if port == 0 {
+			port = 5432
+		}
+		target := fmt.Sprintf("%s:%d", host, port)
+		if db.Name != "" {
+			target += "/" + db.Name
+		}
+		return target, nil
+	default:
+		return "(no connection configured)", nil
+	}
+}
+
+// Redacted returns a copy of the config safe to print: every database password
+// (discrete field and URL userinfo) across the base block and all environment
+// profiles is masked. Used by `config show` so resolved ${VAR} secrets are not
+// echoed in cleartext.
+func (c *Config) Redacted() *Config {
+	out := *c
+	out.Database = redactDatabase(c.Database)
+	if c.Environments != nil {
+		envs := make(map[string]EnvironmentConfig, len(c.Environments))
+		for name, env := range c.Environments {
+			env.Database = redactDatabase(env.Database)
+			envs[name] = env
+		}
+		out.Environments = envs
+	}
+	return &out
+}
+
+// redactDatabase masks the password in both the URL and the discrete Password
+// field of db.
+func redactDatabase(db DatabaseConfig) DatabaseConfig {
+	if db.URL != "" {
+		db.URL = redactURL(db.URL)
+	}
+	if db.Password != "" {
+		db.Password = "****"
+	}
+	return db
+}
+
+// urlPasswordParam matches a password (or pgpassword) query parameter so its
+// value can be masked. PostgreSQL URLs may carry credentials in the query string
+// (e.g. ?password=secret) as well as in the userinfo.
+var urlPasswordParam = regexp.MustCompile(`(?i)([?&](?:password|pgpassword)=)[^&]*`)
+
+// redactURL replaces any URL password with **** for safe display, covering both
+// the userinfo (user:pass@host) and password query parameters. A string that
+// does not parse as a URL (e.g. an unexpanded ${VAR} reference) or carries no
+// password is returned unchanged — the reference itself is not a secret.
+func redactURL(raw string) string {
+	if _, err := url.Parse(raw); err != nil {
+		return raw
+	}
+	out := redactUserinfoPassword(raw)
+	return urlPasswordParam.ReplaceAllString(out, "${1}****")
+}
+
+// redactUserinfoPassword masks the password in a URL's userinfo segment.
+//
+// It operates on the raw bytes rather than the value returned by
+// url.User.Password(): that accessor returns a *decoded* password, which does
+// not match the raw bytes when the password is percent-encoded (e.g. p%40ss),
+// so a naive replace would fail to redact and leak the credential.
+func redactUserinfoPassword(raw string) string {
+	schemeEnd := strings.Index(raw, "://")
+	if schemeEnd < 0 {
+		return raw
+	}
+	afterScheme := raw[schemeEnd+3:]
+
+	// Bound the userinfo to the authority (up to the path/query/fragment), then
+	// split at the LAST '@' within it — matching url.Parse, which treats the
+	// final '@' as the userinfo delimiter so an unescaped '@' in the password
+	// does not leak.
+	authority := afterScheme
+	if end := strings.IndexAny(afterScheme, "/?#"); end >= 0 {
+		authority = afterScheme[:end]
+	}
+	at := strings.LastIndex(authority, "@")
+	if at < 0 {
+		return raw
+	}
+	userinfo := authority[:at]
+
+	colon := strings.Index(userinfo, ":")
+	if colon < 0 || colon == len(userinfo)-1 {
+		// No password, or an empty one (user:@host) — nothing to redact, and
+		// masking an empty password would misrepresent the config.
+		return raw
+	}
+	return raw[:schemeEnd+3] + userinfo[:colon] + ":****" + afterScheme[at:]
 }
 
 // setDefaults registers the out-of-box values for every config key. These

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -344,6 +344,333 @@ func TestDSN_MissingUser(t *testing.T) {
 	assert.Contains(t, err.Error(), "database.user is required")
 }
 
+func TestForEnvironment_EmptyReturnsBase(t *testing.T) {
+	cfg := &Config{
+		Schema:   "schema.fga",
+		Database: DatabaseConfig{URL: "postgres://localhost/dev"},
+	}
+
+	resolved, err := cfg.ForEnvironment("")
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://localhost/dev", resolved.Database.URL)
+	assert.Equal(t, "schema.fga", resolved.Schema)
+}
+
+func TestForEnvironment_UndefinedIsError(t *testing.T) {
+	cfg := &Config{Database: DatabaseConfig{URL: "postgres://localhost/dev"}}
+
+	_, err := cfg.ForEnvironment("production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `environment "production" is not defined`)
+}
+
+func TestForEnvironment_OverlayFallsThroughToBase(t *testing.T) {
+	cfg := &Config{
+		Database: DatabaseConfig{
+			Host: "base-host", Port: 5432, Name: "base", User: "base-user", SSLMode: "prefer",
+		},
+		Environments: map[string]EnvironmentConfig{
+			"staging": {Database: DatabaseConfig{Host: "staging-host", Name: "app"}},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("staging")
+	require.NoError(t, err)
+	// Overridden fields win.
+	assert.Equal(t, "staging-host", resolved.Database.Host)
+	assert.Equal(t, "app", resolved.Database.Name)
+	// Unset fields fall through to base.
+	assert.Equal(t, 5432, resolved.Database.Port)
+	assert.Equal(t, "base-user", resolved.Database.User)
+	assert.Equal(t, "prefer", resolved.Database.SSLMode)
+}
+
+func TestForEnvironment_DiscreteFieldsDropInheritedBaseURL(t *testing.T) {
+	// Base uses a URL; the environment specifies a discrete connection. The
+	// inherited URL must not shadow the discrete fields (DSN prefers URL).
+	cfg := &Config{
+		// Port/SSLMode mirror the defaults viper applies to the base block.
+		Database: DatabaseConfig{URL: "postgres://localhost:5432/dev", Port: 5432, SSLMode: "prefer"},
+		Environments: map[string]EnvironmentConfig{
+			"staging": {Database: DatabaseConfig{Host: "staging-host", Name: "app", User: "melange"}},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("staging")
+	require.NoError(t, err)
+	assert.Empty(t, resolved.Database.URL)
+
+	dsn, err := resolved.DSN()
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://melange@staging-host:5432/app?sslmode=prefer", dsn)
+}
+
+func TestForEnvironment_DiscreteOverrideOnURLBaseNeedsFullConnection(t *testing.T) {
+	// Base is a URL; an environment overrides only the host. Melange does not
+	// decompose the base URL, so the dropped URL means the discrete connection
+	// is incomplete and DSN() reports a clear error (predictable over clever).
+	cfg := &Config{
+		Database: DatabaseConfig{URL: "postgres://melange:pw@localhost:5432/app"},
+		Environments: map[string]EnvironmentConfig{
+			"staging": {Database: DatabaseConfig{Host: "staging.db"}},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("staging")
+	require.NoError(t, err)
+	assert.Empty(t, resolved.Database.URL)
+	_, err = resolved.DSN()
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is required when database.url is not set")
+}
+
+func TestForEnvironment_RefURLBaseReplacedByDiscreteEnv(t *testing.T) {
+	// Base URL is an unset ${VAR}, but the environment supplies a complete
+	// discrete connection. The dead base reference must not be required.
+	cfg := &Config{
+		// Port/SSLMode mirror the defaults viper applies to the base block.
+		Database: DatabaseConfig{URL: "${UNSET_BASE_URL_XYZ}", Port: 5432, SSLMode: "prefer"},
+		Environments: map[string]EnvironmentConfig{
+			"staging": {Database: DatabaseConfig{Host: "staging.db", Name: "app", User: "melange"}},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("staging")
+	require.NoError(t, err)
+	dsn, err := resolved.DSN()
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://melange@staging.db:5432/app?sslmode=prefer", dsn)
+}
+
+func TestForEnvironment_URLOverridesBase(t *testing.T) {
+	cfg := &Config{
+		Database: DatabaseConfig{Host: "base", Name: "base", User: "base"},
+		Environments: map[string]EnvironmentConfig{
+			"production": {Database: DatabaseConfig{URL: "postgres://prod/app"}},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("production")
+	require.NoError(t, err)
+	dsn, err := resolved.DSN()
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://prod/app", dsn)
+}
+
+func TestForEnvironment_ExpandsVarRefs(t *testing.T) {
+	t.Setenv("PROD_DATABASE_URL", "postgres://prod-user:pw@prod.db/app")
+	cfg := &Config{
+		Environments: map[string]EnvironmentConfig{
+			"production": {Database: DatabaseConfig{URL: "${PROD_DATABASE_URL}"}},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("production")
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://prod-user:pw@prod.db/app", resolved.Database.URL)
+}
+
+func TestForEnvironment_OverridesSchema(t *testing.T) {
+	cfg := &Config{
+		Schema: "base.fga",
+		Environments: map[string]EnvironmentConfig{
+			"legacy": {Schema: "legacy.fga"},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("legacy")
+	require.NoError(t, err)
+	assert.Equal(t, "legacy.fga", resolved.Schema)
+}
+
+func TestExpandEnvRefs_BracedOnly(t *testing.T) {
+	t.Setenv("MY_VAR", "value")
+	var missing []string
+	// Braced form expands.
+	assert.Equal(t, "prefix-value-suffix", expandEnvRefs("prefix-${MY_VAR}-suffix", &missing))
+	// Bare $VAR and literal $ are left untouched (avoid mangling passwords).
+	assert.Equal(t, "p@ss$MY_VAR", expandEnvRefs("p@ss$MY_VAR", &missing))
+	assert.Equal(t, "pa$sword", expandEnvRefs("pa$sword", &missing))
+	assert.Empty(t, missing)
+
+	// Unset braced form expands to empty and is reported as missing.
+	assert.Equal(t, "a--b", expandEnvRefs("a-${UNSET_VAR_XYZ}-b", &missing))
+	assert.Equal(t, []string{"UNSET_VAR_XYZ"}, missing)
+}
+
+func TestForEnvironment_OverriddenBaseSecretNotRequired(t *testing.T) {
+	// Base URL references an unset local secret, but production overrides the
+	// URL entirely. The unset base secret must NOT be required.
+	t.Setenv("PROD_DATABASE_URL", "postgres://prod/app")
+	// Deliberately do NOT set LOCAL_DATABASE_URL.
+	cfg := &Config{
+		Database: DatabaseConfig{URL: "${LOCAL_DATABASE_URL}"},
+		Environments: map[string]EnvironmentConfig{
+			"production": {Database: DatabaseConfig{URL: "${PROD_DATABASE_URL}"}},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("production")
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://prod/app", resolved.Database.URL)
+
+	// The base config on its own, however, does require its secret.
+	_, err = cfg.ForEnvironment("")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "LOCAL_DATABASE_URL")
+}
+
+func TestForEnvironment_UnsetVarIsError(t *testing.T) {
+	cfg := &Config{
+		Environments: map[string]EnvironmentConfig{
+			"production": {Database: DatabaseConfig{URL: "${DEFINITELY_UNSET_VAR_ABC}"}},
+		},
+	}
+	_, err := cfg.ForEnvironment("production")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unset environment variable")
+	assert.Contains(t, err.Error(), "DEFINITELY_UNSET_VAR_ABC")
+}
+
+func TestForEnvironment_UnsetVarReturnsBestEffortConfig(t *testing.T) {
+	// On an unset connection secret the error is returned, but the config is
+	// still populated best-effort so non-connection overlay (schema) survives —
+	// an explicit --db can then proceed with the right schema.
+	cfg := &Config{
+		Schema: "base.fga",
+		Environments: map[string]EnvironmentConfig{
+			"production": {
+				Schema:   "prod.fga",
+				Database: DatabaseConfig{URL: "${DEFINITELY_UNSET_VAR_ABC}"},
+			},
+		},
+	}
+
+	resolved, err := cfg.ForEnvironment("production")
+	require.Error(t, err)
+	require.NotNil(t, resolved)
+	assert.Equal(t, "prod.fga", resolved.Schema) // overlay preserved
+	assert.Empty(t, resolved.Database.URL)       // unset secret expanded to empty
+}
+
+func TestForEnvironment_ExpandsSchemaRef(t *testing.T) {
+	t.Setenv("SCHEMA_DIR", "/etc/authz")
+	cfg := &Config{
+		Schema: "base.fga",
+		Environments: map[string]EnvironmentConfig{
+			"prod": {Schema: "${SCHEMA_DIR}/prod.fga"},
+		},
+	}
+	resolved, err := cfg.ForEnvironment("prod")
+	require.NoError(t, err)
+	assert.Equal(t, "/etc/authz/prod.fga", resolved.Schema)
+}
+
+func TestForEnvironment_UnsetSchemaRefDoesNotBlockConnection(t *testing.T) {
+	// An unset schema reference must NOT be treated as a database-resolution
+	// error: the DSN is valid and the schema can be overridden by --schema.
+	cfg := &Config{
+		Database: DatabaseConfig{URL: "postgres://localhost/dev"},
+		Environments: map[string]EnvironmentConfig{
+			"prod": {Schema: "${UNSET_SCHEMA_PATH_XYZ}"},
+		},
+	}
+	resolved, err := cfg.ForEnvironment("prod")
+	require.NoError(t, err) // no error: only database refs block
+	assert.Equal(t, "postgres://localhost/dev", resolved.Database.URL)
+}
+
+func TestEnvironmentSummary_RedactsAndKeepsRefs(t *testing.T) {
+	cfg := &Config{
+		Database: DatabaseConfig{URL: "postgres://localhost/dev"},
+		Environments: map[string]EnvironmentConfig{
+			"production": {Database: DatabaseConfig{URL: "${PROD_DATABASE_URL}"}},
+			"staging":    {Database: DatabaseConfig{Host: "staging.db", Name: "app"}},
+			"withpw":     {Database: DatabaseConfig{URL: "postgres://user:secret@host/db"}},
+		},
+	}
+
+	base, err := cfg.EnvironmentSummary("")
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://localhost/dev", base)
+
+	// ${VAR} references are shown literally, not expanded.
+	prod, err := cfg.EnvironmentSummary("production")
+	require.NoError(t, err)
+	assert.Equal(t, "${PROD_DATABASE_URL}", prod)
+
+	// Discrete fields render as host:port/name.
+	staging, err := cfg.EnvironmentSummary("staging")
+	require.NoError(t, err)
+	assert.Equal(t, "staging.db:5432/app", staging)
+
+	// Passwords are redacted.
+	withpw, err := cfg.EnvironmentSummary("withpw")
+	require.NoError(t, err)
+	assert.Equal(t, "postgres://user:****@host/db", withpw)
+
+	_, err = cfg.EnvironmentSummary("missing")
+	require.Error(t, err)
+}
+
+func TestRedactURL(t *testing.T) {
+	cases := map[string]string{
+		// Plain password.
+		"postgres://user:secret@host/db": "postgres://user:****@host/db",
+		// Percent-encoded password must still be redacted (regression: the
+		// decoded value would not match the raw bytes).
+		"postgres://user:p%40ss@host:5432/db?sslmode=require": "postgres://user:****@host:5432/db?sslmode=require",
+		// Unescaped '@' in the password: split at the LAST '@', not the first,
+		// so nothing leaks.
+		"postgres://user:p@ss@host/db": "postgres://user:****@host/db",
+		// Password carried as a query parameter must be masked too.
+		"postgres://host/db?password=secret":              "postgres://host/db?password=****",
+		"postgres://host/db?user=app&password=s3cr3t&x=1": "postgres://host/db?user=app&password=****&x=1",
+		// Both userinfo and query password.
+		"postgres://u:pw@host/db?password=q": "postgres://u:****@host/db?password=****",
+		// No password — returned unchanged.
+		"postgres://user@host/db": "postgres://user@host/db",
+		// No userinfo — returned unchanged.
+		"postgres://host:5432/db": "postgres://host:5432/db",
+		// Unparseable / reference — returned unchanged.
+		"${PROD_DATABASE_URL}": "${PROD_DATABASE_URL}",
+	}
+	for in, want := range cases {
+		assert.Equal(t, want, redactURL(in), "redactURL(%q)", in)
+	}
+}
+
+func TestLoadConfig_ParsesEnvironments(t *testing.T) {
+	root := t.TempDir()
+	require.NoError(t, os.Mkdir(filepath.Join(root, ".git"), 0o755))
+
+	configPath := filepath.Join(root, "melange.yaml")
+	require.NoError(t, os.WriteFile(configPath, []byte(`
+schema: melange/schema.fga
+database:
+  url: postgres://localhost/dev
+default_environment: local
+environments:
+  local:
+    database:
+      url: postgres://localhost/dev
+  production:
+    database:
+      url: ${PROD_DATABASE_URL}
+`), 0o644))
+
+	oldCwd, err := os.Getwd()
+	require.NoError(t, err)
+	defer func() { _ = os.Chdir(oldCwd) }()
+	require.NoError(t, os.Chdir(root))
+
+	cfg, _, err := LoadConfig("")
+	require.NoError(t, err)
+	assert.Equal(t, "local", cfg.DefaultEnvironment)
+	require.Contains(t, cfg.Environments, "production")
+	assert.Equal(t, "${PROD_DATABASE_URL}", cfg.Environments["production"].Database.URL)
+}
+
 func TestLoadConfig_MigrateAndGenerateMigrationDefaults(t *testing.T) {
 	root := t.TempDir()
 	err := os.Mkdir(filepath.Join(root, ".git"), 0o755)

--- a/internal/cli/config_test.go
+++ b/internal/cli/config_test.go
@@ -1,8 +1,10 @@
 package cli
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -693,4 +695,77 @@ func TestLoadConfig_MigrateAndGenerateMigrationDefaults(t *testing.T) {
 	assert.Equal(t, "melange", cfg.Generate.Migration.Name)
 	assert.Equal(t, "split", cfg.Generate.Migration.Format)
 	assert.Empty(t, cfg.Generate.Migration.Output)
+}
+
+// `config show` prints the resolved configuration, so every password — in the
+// base block and in every profile, as a discrete field or inside a URL — must
+// be masked unless --reveal-secrets was passed.
+func TestRedacted_MasksEverySecret(t *testing.T) {
+	cfg := &Config{
+		Database: DatabaseConfig{
+			URL:      "postgres://admin:basesecret@localhost:5432/app",
+			Password: "basefield",
+		},
+		Environments: map[string]EnvironmentConfig{
+			"production": {Database: DatabaseConfig{URL: "postgres://app:prodsecret@prod/app?sslmode=require"}},
+			"staging":    {Database: DatabaseConfig{Host: "staging", Password: "stagingfield"}},
+			"query":      {Database: DatabaseConfig{URL: "postgres://prod/app?password=querysecret&sslmode=require"}},
+		},
+	}
+
+	got := cfg.Redacted()
+
+	for _, secret := range []string{"basesecret", "basefield", "prodsecret", "stagingfield", "querysecret"} {
+		if strings.Contains(fmt.Sprintf("%+v", got), secret) {
+			t.Errorf("secret %q survived redaction: %+v", secret, got)
+		}
+	}
+	if !strings.Contains(got.Database.URL, "admin") || !strings.Contains(got.Database.URL, "localhost:5432/app") {
+		t.Errorf("redaction should keep the non-secret parts of the URL, got %q", got.Database.URL)
+	}
+	if !strings.Contains(got.Environments["query"].Database.URL, "sslmode=require") {
+		t.Errorf("redaction should keep other query parameters, got %q", got.Environments["query"].Database.URL)
+	}
+
+	// The original must not be mutated — `config show` redacts a copy while the
+	// live config keeps the credentials it needs to connect.
+	if cfg.Database.Password != "basefield" || cfg.Environments["staging"].Database.Password != "stagingfield" {
+		t.Error("Redacted mutated the original config")
+	}
+}
+
+// An unexpanded ${VAR} reference is not a secret, and mangling it would make
+// `config show` misleading about what the file actually says.
+func TestRedacted_LeavesUnexpandedReferences(t *testing.T) {
+	cfg := &Config{Database: DatabaseConfig{URL: "${PROD_DATABASE_URL}"}}
+
+	if got := cfg.Redacted().Database.URL; got != "${PROD_DATABASE_URL}" {
+		t.Errorf("URL = %q, want the reference unchanged", got)
+	}
+}
+
+func TestRedacted_NoEnvironments(t *testing.T) {
+	cfg := &Config{Database: DatabaseConfig{Password: "secret"}}
+
+	got := cfg.Redacted()
+	if got.Database.Password != "****" {
+		t.Errorf("password = %q, want masked", got.Database.Password)
+	}
+	if got.Environments != nil {
+		t.Errorf("environments = %+v, want nil preserved", got.Environments)
+	}
+}
+
+func TestHasEnvironment(t *testing.T) {
+	cfg := &Config{Environments: map[string]EnvironmentConfig{"production": {}}}
+
+	if !cfg.HasEnvironment("production") {
+		t.Error("HasEnvironment(production) = false, want true")
+	}
+	if cfg.HasEnvironment("prod") {
+		t.Error("HasEnvironment(prod) = true; a near-miss must not match")
+	}
+	if (&Config{}).HasEnvironment("anything") {
+		t.Error("HasEnvironment on a config without environments = true, want false")
+	}
 }

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -223,6 +223,7 @@ func (d *Doctor) Run(ctx context.Context) (*Report, error) {
 	if err := d.checkMigrationState(ctx, report); err != nil {
 		return nil, fmt.Errorf("checking migration state: %w", err)
 	}
+	d.checkDeployedModel(report)
 	if err := d.checkGeneratedFunctions(ctx, report); err != nil {
 		return nil, fmt.Errorf("checking generated functions: %w", err)
 	}
@@ -442,6 +443,107 @@ func (d *Doctor) checkMigrationState(ctx context.Context, report *Report) error 
 	}
 
 	return nil
+}
+
+// checkDeployedModel reports whether the database has recorded its authorization
+// model, and — when the local schema differs — whether the pending change is
+// breaking. It reuses the record checkMigrationState already fetched into
+// d.lastMigration, so it issues no further queries.
+func (d *Doctor) checkDeployedModel(report *Report) {
+	// Only meaningful once a migration has been recorded.
+	rec := d.lastMigration
+	if rec == nil {
+		return
+	}
+
+	if rec.SchemaDSL == "" {
+		report.AddCheck(CheckResult{
+			Category: "Deployed Model",
+			Name:     "recorded",
+			Status:   StatusWarn,
+			Message:  "Deployed model not recorded",
+			Details:  "This database was migrated before model storage existed.",
+			FixHint:  "Re-run 'melange migrate' to record it (enables 'schema pull' and 'diff')",
+		})
+		return
+	}
+
+	deployedTypes, err := schema.UnmarshalModel(rec.ModelJSON)
+	if err != nil {
+		// Degrade to a warning rather than aborting: doctor must still run
+		// against the broken deployment it exists to diagnose.
+		report.AddCheck(CheckResult{
+			Category: "Deployed Model",
+			Name:     "recorded",
+			Status:   StatusWarn,
+			Message:  "Deployed model could not be decoded",
+			Details:  err.Error(),
+			FixHint:  "Re-run 'melange migrate' to rewrite the stored model",
+		})
+		return
+	}
+	// Fall back to parsing the stored DSL when the JSON model is absent (older or
+	// partial records), mirroring `melange diff`. A modular DSL is a non-parseable
+	// bundle; on a parse failure deployedTypes stays empty and the drift advisory
+	// below is skipped rather than run against an empty model.
+	if len(deployedTypes) == 0 && rec.SchemaDSL != "" {
+		if parsed, perr := parser.ParseSchemaString(rec.SchemaDSL); perr == nil {
+			deployedTypes = parsed
+		}
+	}
+
+	version := rec.MelangeVersion
+	if version == "" {
+		version = "unknown version"
+	}
+	report.AddCheck(CheckResult{
+		Category: "Deployed Model",
+		Name:     "recorded",
+		Status:   StatusPass,
+		Message:  fmt.Sprintf("Deployed model recorded (melange %s)", version),
+	})
+
+	// Breaking-drift advisory: classify a pending local change against the
+	// deployed model. schema.Diff over the parsed types is the source of truth —
+	// an empty diff means the local schema is in sync. Skip when either side has
+	// no parsed model: without a previous model to compare, a removed relation
+	// would misreport as additive (a false-safe advisory), so no advisory is
+	// safer than a wrong one.
+	if d.parsedTypes == nil || len(deployedTypes) == 0 {
+		return
+	}
+	diff := schema.Diff(deployedTypes, d.parsedTypes)
+	if diff.Empty() {
+		return
+	}
+	additive, breaking := diff.Counts()
+	if breaking == 0 {
+		report.AddCheck(CheckResult{
+			Category: "Deployed Model",
+			Name:     "drift_safety",
+			Status:   StatusPass,
+			Message:  fmt.Sprintf("Local changes vs deployed are additive (%d)", additive),
+		})
+		return
+	}
+	report.AddCheck(CheckResult{
+		Category: "Deployed Model",
+		Name:     "drift_safety",
+		Status:   StatusWarn,
+		Message:  fmt.Sprintf("Local schema has %d breaking change(s) vs deployed", breaking),
+		Details:  breakingDetails(diff),
+		FixHint:  "Review with 'melange diff'; migrating will apply these changes",
+	})
+}
+
+// breakingDetails lists a diff's breaking changes, one bullet per line.
+func breakingDetails(diff schema.SchemaDiff) string {
+	summaries := diff.BreakingSummaries()
+	lines := make([]string, 0, len(summaries))
+	for _, s := range summaries {
+		lines = append(lines, "- "+s)
+	}
+	return strings.Join(lines, "\n")
 }
 
 // checkGeneratedFunctions validates that expected functions exist.

--- a/pkg/migrator/api.go
+++ b/pkg/migrator/api.go
@@ -43,12 +43,22 @@ func Migrate(ctx context.Context, db Execer, schemaPath string) error {
 		return fmt.Errorf("no schema found at %s", m.SchemaPath())
 	}
 
+	// Read the raw content so the migration record is self-describing (schema
+	// checksum, DSL, and model), the same as MigrateWithOptions and the CLI.
+	content, err := parser.ReadSchemaContent(schemaPath)
+	if err != nil {
+		return fmt.Errorf("reading schema: %w", err)
+	}
+
 	types, err := parser.ParseSchema(m.SchemaPath())
 	if err != nil {
 		return fmt.Errorf("parsing schema: %w", err)
 	}
 
-	return m.MigrateWithTypes(ctx, types)
+	return m.MigrateWithTypesAndOptions(ctx, types, InternalMigrateOptions{
+		SchemaContent: string(content),
+		SchemaFormat:  schemaFormat(schemaPath),
+	})
 }
 
 // MigrateFromString parses schema content and applies it to the database.
@@ -71,8 +81,13 @@ func MigrateFromString(ctx context.Context, db Execer, content string) error {
 		return fmt.Errorf("parsing schema: %w", err)
 	}
 
+	// An embedded string is always a single (non-modular) schema. Passing the
+	// content records a self-describing migration (checksum, DSL, model).
 	m := NewMigrator(db, "")
-	return m.MigrateWithTypes(ctx, types)
+	return m.MigrateWithTypesAndOptions(ctx, types, InternalMigrateOptions{
+		SchemaContent: content,
+		SchemaFormat:  FormatSingle,
+	})
 }
 
 // MigrateWithOptions performs migration with control over dry-run and skip behavior.
@@ -129,10 +144,27 @@ func MigrateWithOptions(ctx context.Context, db Execer, schemaPath string, opts 
 		Force:         opts.Force,
 		Version:       opts.Version,
 		SchemaContent: string(schemaContent),
+		SchemaFormat:  schemaFormat(m.SchemaPath()),
 	}
 
 	// Skip detection (both phases) happens inside migrateWithTypesAndOptions;
 	// its skipped result covers the phase 1 fast path and the phase 2 no-op
 	// that dev builds rely on (see shouldSkipMigration).
 	return m.migrateWithTypesAndOptions(ctx, types, internalOpts)
+}
+
+// Schema format values recorded in melange_migrations.schema_format and
+// surfaced on DeployedModel.Format.
+const (
+	FormatSingle  = "single"  // a single .fga file
+	FormatModular = "modular" // an fga.mod manifest
+)
+
+// schemaFormat classifies how a schema was authored, for the deployed-model
+// record.
+func schemaFormat(path string) string {
+	if parser.IsModularSchema(path) {
+		return FormatModular
+	}
+	return FormatSingle
 }

--- a/pkg/migrator/api.go
+++ b/pkg/migrator/api.go
@@ -140,11 +140,12 @@ func MigrateWithOptions(ctx context.Context, db Execer, schemaPath string, opts 
 
 	// Convert to internal MigrateOptions
 	internalOpts := InternalMigrateOptions{
-		DryRun:        opts.DryRun,
-		Force:         opts.Force,
-		Version:       opts.Version,
-		SchemaContent: string(schemaContent),
-		SchemaFormat:  schemaFormat(m.SchemaPath()),
+		DryRun:             opts.DryRun,
+		Force:              opts.Force,
+		Version:            opts.Version,
+		SchemaContent:      string(schemaContent),
+		SchemaFormat:       schemaFormat(m.SchemaPath()),
+		IfDeployedChecksum: opts.IfDeployedChecksum,
 	}
 
 	// Skip detection (both phases) happens inside migrateWithTypesAndOptions;

--- a/pkg/migrator/ddl.go
+++ b/pkg/migrator/ddl.go
@@ -19,6 +19,10 @@ func migrationsDDL(databaseSchema string) string {
 -- - schema_checksum: SHA256 of the schema.fga content
 -- - codegen_version: Version of the SQL generation logic
 -- - function_names: All generated function names (for orphan detection)
+-- - schema_dsl: The OpenFGA DSL that produced this migration (source for
+--   "melange schema pull"; the exact content that was checksummed)
+-- - schema_format: "single" or "modular" (fga.mod)
+-- - model_json: The parsed model as JSON (machine-readable form for diffing)
 --
 -- The migrator checks the most recent record to determine if re-migration
 -- is needed. If both checksum and codegen_version match, migration is skipped
@@ -30,7 +34,10 @@ CREATE TABLE IF NOT EXISTS %[1]s (
     melange_version TEXT NOT NULL DEFAULT '',
     schema_checksum VARCHAR(64) NOT NULL,
     codegen_version TEXT NOT NULL,
-    function_names TEXT[] NOT NULL
+    function_names TEXT[] NOT NULL,
+    schema_dsl TEXT NOT NULL DEFAULT '',
+    schema_format VARCHAR(16) NOT NULL DEFAULT '',
+    model_json JSONB NOT NULL DEFAULT '{}'::jsonb
 );
 
 -- Lookup by checksum for change detection
@@ -104,6 +111,7 @@ func migrationsTableDDL(databaseSchema string) []string {
 		addMelangeVersionColumn(databaseSchema),
 		addFunctionChecksumsColumn(databaseSchema),
 		widenVersionColumnsDDL(databaseSchema),
+		addSchemaModelColumns(databaseSchema),
 	}
 }
 
@@ -120,5 +128,27 @@ func addFunctionChecksumsColumn(databaseSchema string) string {
 	return fmt.Sprintf(`
 ALTER TABLE %s
 ADD COLUMN IF NOT EXISTS function_checksums JSONB NOT NULL DEFAULT '{}';
+`, table)
+}
+
+// addSchemaModelColumns returns a query to add the deployed-model columns
+// (schema_dsl, schema_format, model_json) to existing melange_migrations tables.
+// These columns were introduced after the original DDL, so they are applied
+// separately via ADD COLUMN IF NOT EXISTS to preserve compatibility with
+// databases migrated by earlier versions.
+//
+// Together they make the database self-describing: schema_dsl is the source of
+// truth for `melange schema pull`, schema_format records single vs. modular, and
+// model_json is the machine-readable form used for diffing.
+func addSchemaModelColumns(databaseSchema string) string {
+	table := sqldsl.PrefixIdent("melange_migrations", databaseSchema)
+
+	return fmt.Sprintf(`
+ALTER TABLE %[1]s
+ADD COLUMN IF NOT EXISTS schema_dsl TEXT NOT NULL DEFAULT '';
+ALTER TABLE %[1]s
+ADD COLUMN IF NOT EXISTS schema_format VARCHAR(16) NOT NULL DEFAULT '';
+ALTER TABLE %[1]s
+ADD COLUMN IF NOT EXISTS model_json JSONB NOT NULL DEFAULT '{}'::jsonb;
 `, table)
 }

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -452,17 +452,24 @@ func (m *Migrator) getLastMigration(ctx context.Context, db Execer) (*MigrationR
 		return nil, err
 	}
 
-	// id, migrated_at, and the original columns are always present. Optional
-	// columns are appended to the SELECT and to the scan targets together.
+	// id, migrated_at, and the original three columns are always present.
+	// melange_version, function_checksums, and the model columns were each added
+	// later, so probe for them; a database migrated by an old version that lacks
+	// one must still read cleanly (status now depends on this).
 	var (
-		rec           MigrationRecord
-		checksumsJSON sql.NullString
-		schemaDSL     sql.NullString
-		schemaFormat  sql.NullString
-		modelJSON     sql.NullString
+		rec            MigrationRecord
+		melangeVersion sql.NullString
+		checksumsJSON  sql.NullString
+		schemaDSL      sql.NullString
+		schemaFormat   sql.NullString
+		modelJSON      sql.NullString
 	)
-	selects := []string{"id", "migrated_at", "melange_version", "schema_checksum", "codegen_version", "function_names"}
-	targets := []any{&rec.ID, &rec.MigratedAt, &rec.MelangeVersion, &rec.SchemaChecksum, &rec.CodegenVersion, pq.Array(&rec.FunctionNames)}
+	selects := []string{"id", "migrated_at", "schema_checksum", "codegen_version", "function_names"}
+	targets := []any{&rec.ID, &rec.MigratedAt, &rec.SchemaChecksum, &rec.CodegenVersion, pq.Array(&rec.FunctionNames)}
+	if cols["melange_version"] {
+		selects = append(selects, "melange_version")
+		targets = append(targets, &melangeVersion)
+	}
 	if cols["function_checksums"] {
 		selects = append(selects, "function_checksums::TEXT")
 		targets = append(targets, &checksumsJSON)
@@ -496,6 +503,7 @@ func (m *Migrator) getLastMigration(ctx context.Context, db Execer) (*MigrationR
 			return nil, fmt.Errorf("unmarshaling function checksums: %w", err)
 		}
 	}
+	rec.MelangeVersion = melangeVersion.String
 	rec.SchemaDSL = schemaDSL.String
 	rec.SchemaFormat = schemaFormat.String
 	if modelJSON.Valid && modelJSON.String != "" && modelJSON.String != "{}" {

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"sort"
 	"strings"
+	"time"
 
 	"github.com/lib/pq"
 
@@ -83,10 +84,20 @@ type InternalMigrateOptions struct {
 	// SchemaContent is the raw schema text used for checksum calculation to detect schema changes.
 	// If empty, skip-if-unchanged optimization is disabled.
 	SchemaContent string
+
+	// SchemaFormat records how the schema was authored: "single" for a .fga
+	// file or "modular" for an fga.mod manifest. Stored alongside the DSL so
+	// `melange schema pull` can annotate its output.
+	SchemaFormat string
 }
 
 // MigrationRecord represents a row in the melange_migrations table.
 type MigrationRecord struct {
+	// ID and MigratedAt identify the row and when it was written. Populated by
+	// reads (getLastMigration); ignored on writes (the DB assigns them).
+	ID         int
+	MigratedAt time.Time
+
 	MelangeVersion string
 	SchemaChecksum string
 	CodegenVersion string
@@ -97,6 +108,14 @@ type MigrationRecord struct {
 	// older versions; callers should treat nil as "no checksum data available" and
 	// fall back to full-mode generation.
 	FunctionChecksums map[string]string
+
+	// SchemaDSL, SchemaFormat, and ModelJSON make the database self-describing.
+	// They are populated only when the corresponding columns exist and were
+	// written by a version that records the model. On older records SchemaDSL is
+	// "" (treat as "no model recorded") and ModelJSON is nil.
+	SchemaDSL    string
+	SchemaFormat string
+	ModelJSON    []byte
 }
 
 // Migrator handles loading authorization schemas into PostgreSQL.
@@ -402,6 +421,11 @@ func (m *Migrator) GetLastMigration(ctx context.Context) (*MigrationRecord, erro
 }
 
 // getLastMigration returns the most recent migration record, or nil if none exists.
+//
+// Optional columns (function_checksums, schema_dsl, schema_format, model_json)
+// were added after the original DDL, so the SELECT is built from the columns
+// that actually exist. This keeps reads compatible with databases migrated by
+// any earlier version without a branch per column combination.
 func (m *Migrator) getLastMigration(ctx context.Context, db Execer) (*MigrationRecord, error) {
 	// First check if the migrations table exists
 	var tableExists bool
@@ -423,75 +447,141 @@ func (m *Migrator) getLastMigration(ctx context.Context, db Execer) (*MigrationR
 		return nil, nil // No migrations table yet
 	}
 
-	// Check if function_checksums column exists (may be absent on older installations)
-	var hasChecksumsCol bool
-	err = db.QueryRowContext(ctx, fmt.Sprintf(
-		`
-			SELECT EXISTS (
-				SELECT 1 FROM information_schema.columns
-				WHERE table_name = 'melange_migrations'
-				AND column_name = 'function_checksums'
-				AND table_schema = %s
-			)
-		`,
-		m.postgresSchema(),
-	)).Scan(&hasChecksumsCol)
+	cols, err := m.migrationColumns(ctx, db)
 	if err != nil {
-		return nil, fmt.Errorf("checking function_checksums column: %w", err)
+		return nil, err
 	}
 
-	var rec MigrationRecord
-	if hasChecksumsCol {
-		var checksumsJSON sql.NullString
-		err = db.QueryRowContext(ctx, fmt.Sprintf(
-			`
-				SELECT melange_version, schema_checksum, codegen_version, function_names, function_checksums::TEXT
-				FROM %s
-				ORDER BY id DESC
-				LIMIT 1
-			`,
-			m.prefixIdent("melange_migrations"),
-		)).Scan(&rec.MelangeVersion, &rec.SchemaChecksum, &rec.CodegenVersion, pq.Array(&rec.FunctionNames), &checksumsJSON)
-		if err == sql.ErrNoRows {
-			return nil, nil
+	// id, migrated_at, and the original columns are always present. Optional
+	// columns are appended to the SELECT and to the scan targets together.
+	var (
+		rec           MigrationRecord
+		checksumsJSON sql.NullString
+		schemaDSL     sql.NullString
+		schemaFormat  sql.NullString
+		modelJSON     sql.NullString
+	)
+	selects := []string{"id", "migrated_at", "melange_version", "schema_checksum", "codegen_version", "function_names"}
+	targets := []any{&rec.ID, &rec.MigratedAt, &rec.MelangeVersion, &rec.SchemaChecksum, &rec.CodegenVersion, pq.Array(&rec.FunctionNames)}
+	if cols["function_checksums"] {
+		selects = append(selects, "function_checksums::TEXT")
+		targets = append(targets, &checksumsJSON)
+	}
+	if cols["schema_dsl"] {
+		selects = append(selects, "schema_dsl")
+		targets = append(targets, &schemaDSL)
+	}
+	if cols["schema_format"] {
+		selects = append(selects, "schema_format")
+		targets = append(targets, &schemaFormat)
+	}
+	if cols["model_json"] {
+		selects = append(selects, "model_json::TEXT")
+		targets = append(targets, &modelJSON)
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY id DESC LIMIT 1",
+		strings.Join(selects, ", "), m.prefixIdent("melange_migrations"))
+	err = db.QueryRowContext(ctx, query).Scan(targets...)
+	if err == sql.ErrNoRows {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("querying last migration: %w", err)
+	}
+
+	if checksumsJSON.Valid && checksumsJSON.String != "" {
+		rec.FunctionChecksums = make(map[string]string)
+		if err := json.Unmarshal([]byte(checksumsJSON.String), &rec.FunctionChecksums); err != nil {
+			return nil, fmt.Errorf("unmarshaling function checksums: %w", err)
 		}
-		if err != nil {
-			return nil, fmt.Errorf("querying last migration: %w", err)
-		}
-		if checksumsJSON.Valid && checksumsJSON.String != "" {
-			rec.FunctionChecksums = make(map[string]string)
-			if err := json.Unmarshal([]byte(checksumsJSON.String), &rec.FunctionChecksums); err != nil {
-				return nil, fmt.Errorf("unmarshaling function checksums: %w", err)
-			}
-		}
-	} else {
-		err = db.QueryRowContext(ctx, fmt.Sprintf(
-			`
-				SELECT melange_version, schema_checksum, codegen_version, function_names
-				FROM %s
-				ORDER BY id DESC
-				LIMIT 1
-			`,
-			m.prefixIdent("melange_migrations"),
-		)).Scan(&rec.MelangeVersion, &rec.SchemaChecksum, &rec.CodegenVersion, pq.Array(&rec.FunctionNames))
-		if err == sql.ErrNoRows {
-			return nil, nil
-		}
-		if err != nil {
-			return nil, fmt.Errorf("querying last migration: %w", err)
-		}
+	}
+	rec.SchemaDSL = schemaDSL.String
+	rec.SchemaFormat = schemaFormat.String
+	if modelJSON.Valid && modelJSON.String != "" && modelJSON.String != "{}" {
+		rec.ModelJSON = []byte(modelJSON.String)
 	}
 	return &rec, nil
 }
 
+// migrationColumns returns the set of column names present in the
+// melange_migrations table, used to build a compatible SELECT.
+func (m *Migrator) migrationColumns(ctx context.Context, db Execer) (map[string]bool, error) {
+	rows, err := db.QueryContext(ctx, fmt.Sprintf(
+		`
+			SELECT column_name FROM information_schema.columns
+			WHERE table_name = 'melange_migrations'
+			AND table_schema = %s
+		`,
+		m.postgresSchema(),
+	))
+	if err != nil {
+		return nil, fmt.Errorf("listing melange_migrations columns: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	cols := make(map[string]bool)
+	for rows.Next() {
+		var name string
+		if err := rows.Scan(&name); err != nil {
+			return nil, fmt.Errorf("scanning column name: %w", err)
+		}
+		cols[name] = true
+	}
+	return cols, rows.Err()
+}
+
+// DeployedModel is the authorization model recorded by the most recent
+// migration — the source for `melange schema pull`, drift detection, and diffs.
+type DeployedModel struct {
+	DSL            string                  // OpenFGA DSL that produced the deployment
+	Format         string                  // "single" or "modular"
+	Types          []schema.TypeDefinition // parsed model (nil if only DSL was recorded)
+	SchemaChecksum string
+	MelangeVersion string
+	MigratedAt     time.Time
+}
+
+// GetDeployedModel returns the model recorded by the most recent migration, or
+// nil if none has been recorded — either because the database has never been
+// migrated or because it was migrated before model storage existed (SchemaDSL
+// empty). Callers surface a "re-run migrate to record the model" hint for nil.
+func (m *Migrator) GetDeployedModel(ctx context.Context) (*DeployedModel, error) {
+	rec, err := m.GetLastMigration(ctx)
+	if err != nil {
+		return nil, err
+	}
+	if rec == nil || rec.SchemaDSL == "" {
+		return nil, nil
+	}
+	types, err := schema.UnmarshalModel(rec.ModelJSON)
+	if err != nil {
+		return nil, fmt.Errorf("decoding deployed model: %w", err)
+	}
+	return &DeployedModel{
+		DSL:            rec.SchemaDSL,
+		Format:         rec.SchemaFormat,
+		Types:          types,
+		SchemaChecksum: rec.SchemaChecksum,
+		MelangeVersion: rec.MelangeVersion,
+		MigratedAt:     rec.MigratedAt,
+	}, nil
+}
+
 // migrationRecordMatches reports whether the last migration was recorded with
 // the same schema checksum and codegen version as the current run.
+//
+// A record written before model storage existed (SchemaDSL empty) never
+// matches: falling through lets phase 2 backfill schema_dsl/model_json without
+// re-applying the generated functions, so a plain rerun after upgrading makes
+// GetDeployedModel / schema pull work without --force.
 func migrationRecordMatches(lastMigration *MigrationRecord, schemaChecksum string) bool {
 	if lastMigration == nil {
 		return false
 	}
 	return lastMigration.SchemaChecksum == schemaChecksum &&
-		lastMigration.CodegenVersion == CodegenVersion()
+		lastMigration.CodegenVersion == CodegenVersion() &&
+		lastMigration.SchemaDSL != ""
 }
 
 // shouldSkipMigration returns true if the schema and codegen version are unchanged.
@@ -602,10 +692,31 @@ func (m *Migrator) applyMigrationsDDL(ctx context.Context, db Execer) error {
 	return nil
 }
 
+// migrationWrite carries the fields persisted to a new melange_migrations row.
+type migrationWrite struct {
+	MelangeVersion    string
+	SchemaChecksum    string
+	FunctionNames     []string
+	FunctionChecksums map[string]string
+	SchemaDSL         string
+	SchemaFormat      string
+	ModelJSON         []byte
+}
+
+// modelJSONOrEmpty returns the model JSON, substituting an empty JSON object for
+// the NOT NULL model_json column when no model was captured (e.g. embedded-string
+// migrations without content).
+func (w migrationWrite) modelJSONOrEmpty() []byte {
+	if len(w.ModelJSON) == 0 {
+		return []byte("{}")
+	}
+	return w.ModelJSON
+}
+
 // recordMigrationOnly inserts a migration record without re-applying functions.
 // Used when phase 2 skip determines the generated SQL is identical to what's
 // already installed — only the melange version or schema checksum changed.
-func (m *Migrator) recordMigrationOnly(ctx context.Context, melangeVersion, schemaChecksum string, functionNames []string, functionChecksums map[string]string) error {
+func (m *Migrator) recordMigrationOnly(ctx context.Context, w migrationWrite) error {
 	if txer, ok := m.db.(interface {
 		BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 	}); ok {
@@ -618,7 +729,7 @@ func (m *Migrator) recordMigrationOnly(ctx context.Context, melangeVersion, sche
 		if err := m.applyMigrationsDDL(ctx, tx); err != nil {
 			return err
 		}
-		if err := m.insertMigrationRecord(ctx, tx, melangeVersion, schemaChecksum, functionNames, functionChecksums); err != nil {
+		if err := m.insertMigrationRecord(ctx, tx, w); err != nil {
 			return err
 		}
 		return tx.Commit()
@@ -627,22 +738,23 @@ func (m *Migrator) recordMigrationOnly(ctx context.Context, melangeVersion, sche
 	if err := m.applyMigrationsDDL(ctx, m.db); err != nil {
 		return err
 	}
-	return m.insertMigrationRecord(ctx, m.db, melangeVersion, schemaChecksum, functionNames, functionChecksums)
+	return m.insertMigrationRecord(ctx, m.db, w)
 }
 
 // insertMigrationRecord records the migration in melange_migrations.
-func (m *Migrator) insertMigrationRecord(ctx context.Context, db Execer, melangeVersion, schemaChecksum string, functionNames []string, functionChecksums map[string]string) error {
-	checksumsJSON, err := json.Marshal(functionChecksums)
+func (m *Migrator) insertMigrationRecord(ctx context.Context, db Execer, w migrationWrite) error {
+	checksumsJSON, err := json.Marshal(w.FunctionChecksums)
 	if err != nil {
 		return fmt.Errorf("marshaling function checksums: %w", err)
 	}
 	_, err = db.ExecContext(ctx, fmt.Sprintf(
 		`
-			INSERT INTO %s (melange_version, schema_checksum, codegen_version, function_names, function_checksums)
-			VALUES ($1, $2, $3, $4, $5)
+			INSERT INTO %s (melange_version, schema_checksum, codegen_version, function_names, function_checksums, schema_dsl, schema_format, model_json)
+			VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
 		`,
 		m.prefixIdent("melange_migrations"),
-	), melangeVersion, schemaChecksum, CodegenVersion(), pq.Array(functionNames), string(checksumsJSON))
+	), w.MelangeVersion, w.SchemaChecksum, CodegenVersion(), pq.Array(w.FunctionNames), string(checksumsJSON),
+		w.SchemaDSL, w.SchemaFormat, string(w.modelJSONOrEmpty()))
 	if err != nil {
 		return fmt.Errorf("inserting migration record: %w", err)
 	}
@@ -722,9 +834,24 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 	namedFunctions = append(namedFunctions, collectDispatcherFunctions(generatedSQL, listSQL)...)
 	functionChecksums := ComputeFunctionChecksums(namedFunctions)
 
+	// Serialize the parsed model so the migration record is self-describing.
+	modelJSON, err := schema.MarshalModel(types)
+	if err != nil {
+		return false, fmt.Errorf("marshaling model: %w", err)
+	}
+	write := migrationWrite{
+		MelangeVersion:    opts.Version,
+		SchemaChecksum:    schemaChecksum,
+		FunctionNames:     expectedFunctions,
+		FunctionChecksums: functionChecksums,
+		SchemaDSL:         opts.SchemaContent,
+		SchemaFormat:      opts.SchemaFormat,
+		ModelJSON:         modelJSON,
+	}
+
 	// 8. Handle dry-run mode
 	if opts.DryRun != nil {
-		m.outputDryRun(opts.DryRun, opts.Version, schemaChecksum, generatedSQL, listSQL, expectedFunctions)
+		m.outputDryRun(opts.DryRun, write, generatedSQL, listSQL)
 		return false, nil
 	}
 
@@ -738,7 +865,7 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 		if migrationRecordMatches(lastMigration, schemaChecksum) {
 			return true, nil
 		}
-		return false, m.recordMigrationOnly(ctx, opts.Version, schemaChecksum, expectedFunctions, functionChecksums)
+		return false, m.recordMigrationOnly(ctx, write)
 	}
 
 	// 10. Apply everything atomically
@@ -779,7 +906,7 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 
 		// Record migration
 		if schemaChecksum != "" {
-			if err := m.insertMigrationRecord(ctx, tx, opts.Version, schemaChecksum, expectedFunctions, functionChecksums); err != nil {
+			if err := m.insertMigrationRecord(ctx, tx, write); err != nil {
 				return false, err
 			}
 		}
@@ -805,7 +932,7 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 		return false, err
 	}
 	if schemaChecksum != "" {
-		if err := m.insertMigrationRecord(ctx, m.db, opts.Version, schemaChecksum, expectedFunctions, functionChecksums); err != nil {
+		if err := m.insertMigrationRecord(ctx, m.db, write); err != nil {
 			return false, err
 		}
 	}
@@ -813,7 +940,11 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 }
 
 // outputDryRun writes the migration SQL to the provided writer.
-func (m *Migrator) outputDryRun(w io.Writer, melangeVersion, schemaChecksum string, generatedSQL GeneratedSQL, listSQL ListGeneratedSQL, expectedFunctions []string) {
+func (m *Migrator) outputDryRun(w io.Writer, write migrationWrite, generatedSQL GeneratedSQL, listSQL ListGeneratedSQL) {
+	melangeVersion := write.MelangeVersion
+	schemaChecksum := write.SchemaChecksum
+	expectedFunctions := write.FunctionNames
+
 	// Header
 	_, _ = fmt.Fprintf(w, "-- Melange Migration (dry-run)\n")
 	if melangeVersion != "" {
@@ -939,10 +1070,31 @@ func (m *Migrator) outputDryRun(w io.Writer, melangeVersion, schemaChecksum stri
 	// Format as SQL array literal
 	quotedFunctions := make([]string, len(sortedFunctions))
 	for i, fn := range sortedFunctions {
-		quotedFunctions[i] = fmt.Sprintf("'%s'", fn)
+		quotedFunctions[i] = sqldsl.Lit(fn).SQL()
 	}
-	_, _ = fmt.Fprintf(w, "INSERT INTO %s (melange_version, schema_checksum, codegen_version, function_names)\n", m.prefixIdent("melange_migrations"))
-	_, _ = fmt.Fprintf(w, "VALUES ('%s', '%s', '%s', ARRAY[%s]);\n", melangeVersion, schemaChecksum, CodegenVersion(), strings.Join(quotedFunctions, ", "))
+
+	// Emit every persisted column — including function_checksums and the
+	// deployed-model columns — so a separately-applied dry-run script records a
+	// migration identical to a normal migrate. Without function_checksums a later
+	// real migrate could not take the phase-2 "skip-apply" fast path. sqldsl.Lit
+	// escapes single quotes, so multi-line DSL and JSON are safe; the JSON text is
+	// cast to the JSONB columns implicitly.
+	checksumsJSON, err := json.Marshal(write.FunctionChecksums)
+	if err != nil {
+		// FunctionChecksums is a plain map[string]string; marshaling cannot fail.
+		checksumsJSON = []byte("{}")
+	}
+	_, _ = fmt.Fprintf(w, "INSERT INTO %s (melange_version, schema_checksum, codegen_version, function_names, function_checksums, schema_dsl, schema_format, model_json)\n", m.prefixIdent("melange_migrations"))
+	_, _ = fmt.Fprintf(w, "VALUES (%s, %s, %s, ARRAY[%s], %s, %s, %s, %s);\n",
+		sqldsl.Lit(melangeVersion).SQL(),
+		sqldsl.Lit(schemaChecksum).SQL(),
+		sqldsl.Lit(CodegenVersion()).SQL(),
+		strings.Join(quotedFunctions, ", "),
+		sqldsl.Lit(string(checksumsJSON)).SQL(),
+		sqldsl.Lit(write.SchemaDSL).SQL(),
+		sqldsl.Lit(write.SchemaFormat).SQL(),
+		sqldsl.Lit(string(write.modelJSONOrEmpty())).SQL(),
+	)
 }
 
 func (m *Migrator) prefixIdent(identifier string) string {

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -141,21 +141,6 @@ func driftGuardError(expected *string, rec *MigrationRecord) error {
 	return nil
 }
 
-// driftGuardInTx re-evaluates the drift guard against the latest record visible
-// to db (a transaction). Read-committed visibility means a migration committed
-// since the up-front check is seen here, so a concurrent change that lands while
-// this migration applies is caught before the record is written.
-func (m *Migrator) driftGuardInTx(ctx context.Context, db Execer, expected *string) error {
-	if expected == nil {
-		return nil
-	}
-	rec, err := m.getLastMigration(ctx, db)
-	if err != nil {
-		return err
-	}
-	return driftGuardError(expected, rec)
-}
-
 // MigrationRecord represents a row in the melange_migrations table.
 type MigrationRecord struct {
 	// ID and MigratedAt identify the row and when it was written. Populated by
@@ -493,20 +478,9 @@ func (m *Migrator) GetLastMigration(ctx context.Context) (*MigrationRecord, erro
 // any earlier version without a branch per column combination.
 func (m *Migrator) getLastMigration(ctx context.Context, db Execer) (*MigrationRecord, error) {
 	// First check if the migrations table exists
-	var tableExists bool
-	err := db.QueryRowContext(ctx, fmt.Sprintf(
-		`
-			SELECT EXISTS (
-				SELECT 1 FROM pg_class c
-				JOIN pg_namespace n ON n.oid = c.relnamespace
-				WHERE c.relname = 'melange_migrations'
-				AND n.nspname = %s
-			)
-		`,
-		m.postgresSchema(),
-	)).Scan(&tableExists)
+	tableExists, err := m.migrationTableExists(ctx, db)
 	if err != nil {
-		return nil, fmt.Errorf("checking melange_migrations table: %w", err)
+		return nil, err
 	}
 	if !tableExists {
 		return nil, nil // No migrations table yet
@@ -577,6 +551,44 @@ func (m *Migrator) getLastMigration(ctx context.Context, db Execer) (*MigrationR
 	return &rec, nil
 }
 
+// migrationTableExists reports whether the melange_migrations table exists in
+// the configured schema. Used to distinguish an un-migrated database from one
+// whose columns are merely hidden by privileges (which would make an
+// information_schema probe misleadingly return nothing).
+func (m *Migrator) migrationTableExists(ctx context.Context, db Execer) (bool, error) {
+	var exists bool
+	err := db.QueryRowContext(ctx, fmt.Sprintf(
+		`
+			SELECT EXISTS (
+				SELECT 1 FROM pg_class c
+				JOIN pg_namespace n ON n.oid = c.relnamespace
+				WHERE c.relname = 'melange_migrations'
+				AND n.nspname = %s
+			)
+		`,
+		m.postgresSchema(),
+	)).Scan(&exists)
+	if err != nil {
+		return false, fmt.Errorf("checking melange_migrations table: %w", err)
+	}
+	return exists, nil
+}
+
+// driftGuardInTx re-evaluates the drift guard against the latest record visible
+// to db (a transaction). Read-committed visibility means a migration committed
+// since the up-front check is seen here, so a concurrent change that lands while
+// this migration applies is caught before the record is written.
+func (m *Migrator) driftGuardInTx(ctx context.Context, db Execer, expected *string) error {
+	if expected == nil {
+		return nil
+	}
+	rec, err := m.getLastMigration(ctx, db)
+	if err != nil {
+		return err
+	}
+	return driftGuardError(expected, rec)
+}
+
 // migrationColumns returns the set of column names present in the
 // melange_migrations table, used to build a compatible SELECT.
 func (m *Migrator) migrationColumns(ctx context.Context, db Execer) (map[string]bool, error) {
@@ -639,6 +651,68 @@ func (m *Migrator) GetDeployedModel(ctx context.Context) (*DeployedModel, error)
 		MelangeVersion: rec.MelangeVersion,
 		MigratedAt:     rec.MigratedAt,
 	}, nil
+}
+
+// GetMigrationHistory returns up to limit migration records, most recent first.
+// It reads a lightweight subset (no DSL or model JSON) suitable for an audit
+// listing, and tolerates databases migrated by older versions that lack the
+// melange_version or schema_format columns. Returns nil when no migrations table
+// exists.
+func (m *Migrator) GetMigrationHistory(ctx context.Context, limit int) ([]MigrationRecord, error) {
+	if limit < 1 {
+		return nil, fmt.Errorf("limit must be at least 1, got %d", limit)
+	}
+	exists, err := m.migrationTableExists(ctx, m.db)
+	if err != nil {
+		return nil, err
+	}
+	if !exists {
+		return nil, nil
+	}
+	cols, err := m.migrationColumns(ctx, m.db)
+	if err != nil {
+		return nil, err
+	}
+
+	selects := []string{"id", "migrated_at", "schema_checksum", "codegen_version", "function_names"}
+	hasVersion := cols["melange_version"]
+	hasFormat := cols["schema_format"]
+	if hasVersion {
+		selects = append(selects, "melange_version")
+	}
+	if hasFormat {
+		selects = append(selects, "schema_format")
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM %s ORDER BY id DESC LIMIT $1",
+		strings.Join(selects, ", "), m.prefixIdent("melange_migrations"))
+	rows, err := m.db.QueryContext(ctx, query, limit)
+	if err != nil {
+		return nil, fmt.Errorf("querying migration history: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var history []MigrationRecord
+	for rows.Next() {
+		var (
+			rec                MigrationRecord
+			melangeVer, format sql.NullString
+		)
+		targets := []any{&rec.ID, &rec.MigratedAt, &rec.SchemaChecksum, &rec.CodegenVersion, pq.Array(&rec.FunctionNames)}
+		if hasVersion {
+			targets = append(targets, &melangeVer)
+		}
+		if hasFormat {
+			targets = append(targets, &format)
+		}
+		if err := rows.Scan(targets...); err != nil {
+			return nil, fmt.Errorf("scanning migration row: %w", err)
+		}
+		rec.MelangeVersion = melangeVer.String
+		rec.SchemaFormat = format.String
+		history = append(history, rec)
+	}
+	return history, rows.Err()
 }
 
 // migrationRecordMatches reports whether the last migration was recorded with

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -70,6 +70,19 @@ type MigrateOptions struct {
 
 	// DatabaseSchema is the Postgres schema where the objects will be created.
 	DatabaseSchema string
+
+	// IfDeployedChecksum, when non-nil, makes migration a compare-and-swap: it
+	// proceeds only if the currently-deployed schema checksum equals the pointed-to
+	// value, otherwise it aborts with *DeployedModelChangedError without applying
+	// anything. An empty string matches a database with no migration recorded. It
+	// is enforced in dry-run too, so a drift-gated preview aborts rather than
+	// printing SQL against a drifted database.
+	//
+	// The checksum is verified up front and again inside the apply transaction, so
+	// a migration committed while this one runs aborts it. It is not a hard lock:
+	// two migrations that verify at the exact same instant could both proceed, but
+	// concurrent migrations against one database are unsupported regardless.
+	IfDeployedChecksum *string
 }
 
 // InternalMigrateOptions extends MigrateOptions with internal fields.
@@ -89,6 +102,58 @@ type InternalMigrateOptions struct {
 	// file or "modular" for an fga.mod manifest. Stored alongside the DSL so
 	// `melange schema pull` can annotate its output.
 	SchemaFormat string
+
+	// IfDeployedChecksum is the compare-and-swap precondition; see MigrateOptions.
+	IfDeployedChecksum *string
+}
+
+// DeployedModelChangedError is returned by migrate when --if-deployed-checksum
+// does not match the currently-deployed schema checksum: the database drifted
+// from the expected state, so nothing was applied.
+type DeployedModelChangedError struct {
+	Expected string // checksum the caller expected to be deployed
+	Actual   string // checksum actually deployed ("" when no migration is recorded)
+}
+
+func (e *DeployedModelChangedError) Error() string {
+	actual := e.Actual
+	if actual == "" {
+		actual = "none (no migration recorded)"
+	}
+	return fmt.Sprintf("deployed model changed: expected checksum %s but database has %s; nothing was applied",
+		e.Expected, actual)
+}
+
+// driftGuardError returns a *DeployedModelChangedError when expected is non-nil
+// and does not match the deployed checksum (rec's checksum, or "" when rec is
+// nil). It returns nil when the guard is unset or satisfied.
+func driftGuardError(expected *string, rec *MigrationRecord) error {
+	if expected == nil {
+		return nil
+	}
+	deployed := ""
+	if rec != nil {
+		deployed = rec.SchemaChecksum
+	}
+	if deployed != *expected {
+		return &DeployedModelChangedError{Expected: *expected, Actual: deployed}
+	}
+	return nil
+}
+
+// driftGuardInTx re-evaluates the drift guard against the latest record visible
+// to db (a transaction). Read-committed visibility means a migration committed
+// since the up-front check is seen here, so a concurrent change that lands while
+// this migration applies is caught before the record is written.
+func (m *Migrator) driftGuardInTx(ctx context.Context, db Execer, expected *string) error {
+	if expected == nil {
+		return nil
+	}
+	rec, err := m.getLastMigration(ctx, db)
+	if err != nil {
+		return err
+	}
+	return driftGuardError(expected, rec)
 }
 
 // MigrationRecord represents a row in the melange_migrations table.
@@ -723,8 +788,10 @@ func (w migrationWrite) modelJSONOrEmpty() []byte {
 
 // recordMigrationOnly inserts a migration record without re-applying functions.
 // Used when phase 2 skip determines the generated SQL is identical to what's
-// already installed — only the melange version or schema checksum changed.
-func (m *Migrator) recordMigrationOnly(ctx context.Context, w migrationWrite) error {
+// already installed — only the melange version or schema checksum changed. The
+// drift guard is re-verified in-transaction before the insert, like the full
+// apply path, so a concurrent change is not overwritten.
+func (m *Migrator) recordMigrationOnly(ctx context.Context, w migrationWrite, ifDeployed *string) error {
 	if txer, ok := m.db.(interface {
 		BeginTx(ctx context.Context, opts *sql.TxOptions) (*sql.Tx, error)
 	}); ok {
@@ -737,6 +804,9 @@ func (m *Migrator) recordMigrationOnly(ctx context.Context, w migrationWrite) er
 		if err := m.applyMigrationsDDL(ctx, tx); err != nil {
 			return err
 		}
+		if err := m.driftGuardInTx(ctx, tx, ifDeployed); err != nil {
+			return err
+		}
 		if err := m.insertMigrationRecord(ctx, tx, w); err != nil {
 			return err
 		}
@@ -744,6 +814,9 @@ func (m *Migrator) recordMigrationOnly(ctx context.Context, w migrationWrite) er
 	}
 
 	if err := m.applyMigrationsDDL(ctx, m.db); err != nil {
+		return err
+	}
+	if err := m.driftGuardInTx(ctx, m.db, ifDeployed); err != nil {
 		return err
 	}
 	return m.insertMigrationRecord(ctx, m.db, w)
@@ -802,14 +875,28 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 		schemaChecksum = ComputeSchemaChecksum(opts.SchemaContent)
 	}
 
-	// 3. Fetch last migration record (needed for both skip phases)
+	// 3. Fetch last migration record (needed for the drift guard and both skip
+	// phases). The guard needs it even under --force and --dry-run.
 	var lastMigration *MigrationRecord
-	if !opts.Force && opts.DryRun == nil && schemaChecksum != "" {
+	if opts.IfDeployedChecksum != nil ||
+		(!opts.Force && opts.DryRun == nil && schemaChecksum != "") {
 		lastMigration, err = m.getLastMigration(ctx, m.db)
 		if err != nil {
 			return false, fmt.Errorf("checking last migration: %w", err)
 		}
-		// Phase 1 skip: schema + codegen version unchanged → skip entirely
+	}
+
+	// Drift guard: --if-deployed-checksum makes migrate a compare-and-swap. Abort
+	// early if the database isn't at the expected checksum — including in dry-run,
+	// so a drift-gated preview fails rather than printing SQL against a drifted
+	// database. The apply path re-checks inside its transaction (see below) to
+	// catch drift committed while this migration runs.
+	if err := driftGuardError(opts.IfDeployedChecksum, lastMigration); err != nil {
+		return false, err
+	}
+
+	// Phase 1 skip: schema + codegen version unchanged → skip entirely
+	if !opts.Force && opts.DryRun == nil && schemaChecksum != "" {
 		if shouldSkipMigration(lastMigration, schemaChecksum) {
 			return true, nil
 		}
@@ -873,7 +960,7 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 		if migrationRecordMatches(lastMigration, schemaChecksum) {
 			return true, nil
 		}
-		return false, m.recordMigrationOnly(ctx, write)
+		return false, m.recordMigrationOnly(ctx, write, opts.IfDeployedChecksum)
 	}
 
 	// 10. Apply everything atomically
@@ -912,6 +999,12 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 			return false, err
 		}
 
+		// Re-verify the drift guard inside the transaction before recording, so a
+		// migration committed while we were applying aborts this one (rollback).
+		if err := m.driftGuardInTx(ctx, tx, opts.IfDeployedChecksum); err != nil {
+			return false, err
+		}
+
 		// Record migration
 		if schemaChecksum != "" {
 			if err := m.insertMigrationRecord(ctx, tx, write); err != nil {
@@ -922,8 +1015,13 @@ func (m *Migrator) migrateWithTypesAndOptions(ctx context.Context, types []TypeD
 		return false, tx.Commit()
 	}
 
-	// Fall back to non-transactional (for *sql.Conn)
+	// Fall back to non-transactional (for *sql.Conn). Without a transaction there
+	// is no rollback, so the drift guard is re-checked BEFORE any function is
+	// applied — a failure then leaves nothing applied, matching the error.
 	if err := m.applyMigrationsDDL(ctx, m.db); err != nil {
+		return false, err
+	}
+	if err := m.driftGuardInTx(ctx, m.db, opts.IfDeployedChecksum); err != nil {
 		return false, err
 	}
 	currentFunctions, err := m.getCurrentFunctions(ctx, m.db)

--- a/pkg/migrator/migrator_test.go
+++ b/pkg/migrator/migrator_test.go
@@ -407,6 +407,17 @@ func TestMigrateNoSchemaFile(t *testing.T) {
 	})
 }
 
+func TestDeployedModelChangedError(t *testing.T) {
+	e := &DeployedModelChangedError{Expected: "aaa", Actual: "bbb"}
+	if !strings.Contains(e.Error(), "aaa") || !strings.Contains(e.Error(), "bbb") {
+		t.Errorf("error should mention both checksums, got %q", e.Error())
+	}
+	empty := &DeployedModelChangedError{Expected: "aaa", Actual: ""}
+	if !strings.Contains(empty.Error(), "no migration recorded") {
+		t.Errorf("empty actual should be described, got %q", empty.Error())
+	}
+}
+
 func TestMigrationsDDL(t *testing.T) {
 	t.Run("no schema uses unqualified table name", func(t *testing.T) {
 		sql := migrationsDDL("")

--- a/pkg/migrator/migrator_test.go
+++ b/pkg/migrator/migrator_test.go
@@ -111,6 +111,7 @@ func TestShouldSkipMigration(t *testing.T) {
 		rec := &MigrationRecord{
 			SchemaChecksum: checksum,
 			CodegenVersion: CodegenVersion(),
+			SchemaDSL:      "model", // model already recorded
 		}
 		if !shouldSkipMigration(rec, checksum) {
 			t.Error("should skip when checksum and codegen version match")
@@ -122,9 +123,22 @@ func TestShouldSkipMigration(t *testing.T) {
 		rec := &MigrationRecord{
 			SchemaChecksum: checksum,
 			CodegenVersion: CodegenVersion(),
+			SchemaDSL:      "model",
 		}
 		if shouldSkipMigration(rec, checksum) {
 			t.Error("dev builds must fall through to phase 2: codegen can change without a version bump")
+		}
+	})
+
+	t.Run("matching but model not recorded does not skip (backfill)", func(t *testing.T) {
+		withVersion(t, "v9.9.9")
+		rec := &MigrationRecord{
+			SchemaChecksum: checksum,
+			CodegenVersion: CodegenVersion(),
+			// SchemaDSL empty: an older record with no deployed model.
+		}
+		if shouldSkipMigration(rec, checksum) {
+			t.Error("should not skip when the deployed model has not been recorded")
 		}
 	})
 
@@ -274,8 +288,27 @@ func TestOutputDryRun(t *testing.T) {
 		}
 		expected := []string{"check_repo_viewer", "check_permission"}
 
-		m.outputDryRun(&buf, "v0.5.0", "abc123", gen, listSQL, expected)
+		m.outputDryRun(&buf, migrationWrite{
+			MelangeVersion: "v0.5.0",
+			SchemaChecksum: "abc123",
+			FunctionNames:  expected,
+			SchemaDSL:      "model\n  schema 1.1\n-- it's fine", // embedded quote exercises escaping
+			SchemaFormat:   "single",
+			ModelJSON:      []byte(`[{"Name":"user"}]`),
+		}, gen, listSQL)
 		output := buf.String()
+
+		// Deployed-model columns are emitted so an applied dry-run script is
+		// self-describing; the embedded single quote must be doubled.
+		if !strings.Contains(output, "function_checksums, schema_dsl, schema_format, model_json") {
+			t.Error("INSERT should include function_checksums and the deployed-model columns")
+		}
+		if !strings.Contains(output, "-- it''s fine") {
+			t.Errorf("single quotes in DSL should be escaped, got:\n%s", output)
+		}
+		if !strings.Contains(output, `[{"Name":"user"}]`) {
+			t.Error("INSERT should include the model JSON")
+		}
 
 		// Header
 		if !strings.Contains(output, "-- Melange Migration (dry-run)") {
@@ -324,7 +357,7 @@ func TestOutputDryRun(t *testing.T) {
 
 	t.Run("omits version when empty", func(t *testing.T) {
 		var buf bytes.Buffer
-		m.outputDryRun(&buf, "", "abc", GeneratedSQL{}, ListGeneratedSQL{}, nil)
+		m.outputDryRun(&buf, migrationWrite{SchemaChecksum: "abc"}, GeneratedSQL{}, ListGeneratedSQL{})
 		output := buf.String()
 
 		if strings.Contains(output, "-- Melange version:") {
@@ -335,7 +368,7 @@ func TestOutputDryRun(t *testing.T) {
 	t.Run("sorts function names in migration record", func(t *testing.T) {
 		var buf bytes.Buffer
 		expected := []string{"check_z_viewer", "check_a_owner", "check_m_editor"}
-		m.outputDryRun(&buf, "", "abc", GeneratedSQL{}, ListGeneratedSQL{}, expected)
+		m.outputDryRun(&buf, migrationWrite{SchemaChecksum: "abc", FunctionNames: expected}, GeneratedSQL{}, ListGeneratedSQL{})
 		output := buf.String()
 
 		// Should appear sorted in the INSERT
@@ -428,13 +461,40 @@ func TestAddFunctionChecksumsColumn(t *testing.T) {
 	})
 }
 
+func TestAddSchemaModelColumns(t *testing.T) {
+	t.Run("adds all three columns", func(t *testing.T) {
+		sql := addSchemaModelColumns("")
+		for _, col := range []string{"schema_dsl", "schema_format", "model_json"} {
+			if !strings.Contains(sql, "ADD COLUMN IF NOT EXISTS "+col) {
+				t.Errorf("should add column %q, got:\n%s", col, sql)
+			}
+		}
+	})
+
+	t.Run("with schema qualifies table name", func(t *testing.T) {
+		sql := addSchemaModelColumns("authz")
+		if !strings.Contains(sql, `ALTER TABLE "authz"."melange_migrations"`) {
+			t.Errorf("should schema-qualify table name, got:\n%s", sql)
+		}
+	})
+}
+
+func TestMigrationsDDL_IncludesModelColumns(t *testing.T) {
+	sql := migrationsDDL("")
+	for _, col := range []string{"schema_dsl", "schema_format", "model_json"} {
+		if !strings.Contains(sql, col) {
+			t.Errorf("base DDL should define column %q, got:\n%s", col, sql)
+		}
+	}
+}
+
 func TestOutputDryRun_DatabaseSchema(t *testing.T) {
 	t.Run("with schema shows hint comment", func(t *testing.T) {
 		m := NewMigrator(nil, "")
 		m.SetDatabaseSchema("authz")
 
 		var buf bytes.Buffer
-		m.outputDryRun(&buf, "", "abc", GeneratedSQL{}, ListGeneratedSQL{}, nil)
+		m.outputDryRun(&buf, migrationWrite{SchemaChecksum: "abc"}, GeneratedSQL{}, ListGeneratedSQL{})
 		output := buf.String()
 
 		if !strings.Contains(output, "Database schema: authz") {
@@ -452,7 +512,7 @@ func TestOutputDryRun_DatabaseSchema(t *testing.T) {
 		m := NewMigrator(nil, "")
 
 		var buf bytes.Buffer
-		m.outputDryRun(&buf, "", "abc", GeneratedSQL{}, ListGeneratedSQL{}, nil)
+		m.outputDryRun(&buf, migrationWrite{SchemaChecksum: "abc"}, GeneratedSQL{}, ListGeneratedSQL{})
 		output := buf.String()
 
 		if !strings.Contains(output, "public") {

--- a/pkg/schema/diff.go
+++ b/pkg/schema/diff.go
@@ -44,6 +44,17 @@ func (d SchemaDiff) HasBreaking() bool {
 	return false
 }
 
+// BreakingSummaries returns the human-readable summaries of the breaking changes.
+func (d SchemaDiff) BreakingSummaries() []string {
+	var out []string
+	for _, c := range d.Changes {
+		if c.Class == ClassBreaking {
+			out = append(out, c.Summary)
+		}
+	}
+	return out
+}
+
 // Counts returns how many additive and breaking changes there are.
 func (d SchemaDiff) Counts() (additive, breaking int) {
 	for _, c := range d.Changes {

--- a/pkg/schema/diff.go
+++ b/pkg/schema/diff.go
@@ -1,0 +1,443 @@
+package schema
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// ChangeClass classifies a schema change by its access impact.
+type ChangeClass string
+
+const (
+	// ClassAdditive widens access or is otherwise safe to apply: a new type or
+	// relation, a new grant, or a removed restriction. Nobody loses access.
+	ClassAdditive ChangeClass = "additive"
+	// ClassBreaking narrows access or removes structure: a removed type or
+	// relation, a removed grant, or a new restriction. Someone may lose access.
+	ClassBreaking ChangeClass = "breaking"
+)
+
+// Change is a single difference between two schemas.
+type Change struct {
+	Class    ChangeClass `json:"class"`
+	Type     string      `json:"type"`               // object type name
+	Relation string      `json:"relation,omitempty"` // empty for type-level changes
+	Summary  string      `json:"summary"`            // human-readable description
+}
+
+// SchemaDiff is the set of changes turning an "old" schema into a "new" one.
+type SchemaDiff struct {
+	Changes []Change `json:"changes"`
+}
+
+// Empty reports whether the two schemas are equivalent.
+func (d SchemaDiff) Empty() bool { return len(d.Changes) == 0 }
+
+// HasBreaking reports whether any change narrows access.
+func (d SchemaDiff) HasBreaking() bool {
+	for _, c := range d.Changes {
+		if c.Class == ClassBreaking {
+			return true
+		}
+	}
+	return false
+}
+
+// Counts returns how many additive and breaking changes there are.
+func (d SchemaDiff) Counts() (additive, breaking int) {
+	for _, c := range d.Changes {
+		if c.Class == ClassBreaking {
+			breaking++
+		} else {
+			additive++
+		}
+	}
+	return additive, breaking
+}
+
+// Diff compares two parsed models and returns the changes turning old into new,
+// each classified additive (safe) or breaking (narrows access). Comparison is
+// order-independent: relations are compared as sets of grant and exclusion
+// terms, so re-ordering subject types or implied relations is not a change.
+//
+// The comparison is over melange's PARSED model — the same structures it
+// compiles to SQL — so the diff reflects actual runtime behavior, including any
+// flattening the parser applies to complex nesting (e.g. `(this or X) and Y`).
+//
+// Classification accounts for implied-by closure, intersection subsumption, and
+// exclusion polarity (widening a relation used in — or implying one used in — a
+// `but not` narrows the excluder), but is a conservative heuristic. Its members
+// are compared structurally in a few spots: intersection member tokens are not
+// resolved through implication, wildcard (`[t:*]`) and specific (`[t]`) grants
+// are distinct capabilities, and exclusions nested inside intersection members
+// are not subsumed. So a change of those rare shapes may over-report — an extra
+// additive or breaking line — but it never UNDER-reports breaking relative to
+// melange's compiled model, which is what makes it safe as a CI gate.
+func Diff(oldModel, newModel []TypeDefinition) SchemaDiff {
+	oldTypes := indexTypes(oldModel)
+	newTypes := indexTypes(newModel)
+
+	var changes []Change
+
+	for name, nt := range newTypes {
+		ot, existed := oldTypes[name]
+		if !existed {
+			changes = append(changes, Change{ClassAdditive, name, "", fmt.Sprintf("type %s added", name)})
+			continue
+		}
+		changes = append(changes, diffRelations(name, ot, nt)...)
+	}
+	for name := range oldTypes {
+		if _, still := newTypes[name]; !still {
+			changes = append(changes, Change{ClassBreaking, name, "", fmt.Sprintf("type %s removed", name)})
+		}
+	}
+
+	sortChanges(changes)
+	return SchemaDiff{Changes: changes}
+}
+
+func diffRelations(typeName string, oldT, newT TypeDefinition) []Change {
+	oldRels := indexRelations(oldT)
+	newRels := indexRelations(newT)
+
+	// Transitive implied-by closure per side, so a grant that is removed but
+	// still reachable through another relation (e.g. dropping `or owner` from
+	// `viewer` when `editor` is already implied by `owner`) is not a change.
+	oldImpliers := typeImpliers(oldT)
+	newImpliers := typeImpliers(newT)
+
+	// Relations whose widening narrows an excluder: those used as an exclusion
+	// (`but not X`), plus every relation that transitively implies one — widening
+	// an implier widens the excluded relation too. Grant additions to any of
+	// these are breaking.
+	exclRefs := map[string]bool{}
+	for name := range exclusionRefs(oldT, newT) {
+		exclRefs[name] = true
+		for _, impl := range oldImpliers[name] {
+			exclRefs[impl] = true
+		}
+		for _, impl := range newImpliers[name] {
+			exclRefs[impl] = true
+		}
+	}
+
+	var changes []Change
+	for name, nr := range newRels {
+		or, existed := oldRels[name]
+		if !existed {
+			changes = append(changes, Change{
+				ClassAdditive, typeName, name,
+				fmt.Sprintf("relation %s.%s added", typeName, name),
+			})
+			continue
+		}
+		changes = append(changes, diffRelation(typeName, or, nr, oldImpliers, newImpliers, exclRefs)...)
+	}
+	for name := range oldRels {
+		if _, still := newRels[name]; !still {
+			changes = append(changes, Change{
+				ClassBreaking, typeName, name,
+				fmt.Sprintf("relation %s.%s removed", typeName, name),
+			})
+		}
+	}
+	return changes
+}
+
+// typeImpliers returns, for each relation in the type, the set of relations that
+// transitively imply it (its computed-userset closure).
+func typeImpliers(t TypeDefinition) map[string][]string {
+	graph := make(map[string][]string, len(t.Relations))
+	for _, r := range t.Relations {
+		graph[r.Name] = append(graph[r.Name], r.ImpliedBy...)
+	}
+	return computeTransitiveClosure(graph)
+}
+
+// exclusionRefs returns the set of relation names referenced by any exclusion
+// (`but not X`) across the given type definitions.
+func exclusionRefs(types ...TypeDefinition) map[string]bool {
+	refs := map[string]bool{}
+	for _, t := range types {
+		for _, r := range t.Relations {
+			for _, ex := range r.ExcludedRelations {
+				refs[ex] = true
+			}
+			for _, ep := range r.ExcludedParentRelations {
+				refs[ep.Relation] = true
+			}
+			for _, g := range r.ExcludedIntersectionGroups {
+				for _, rel := range g.Relations {
+					refs[rel] = true
+				}
+			}
+			for _, g := range r.IntersectionGroups {
+				for _, excls := range g.Exclusions {
+					for _, ex := range excls {
+						refs[ex] = true
+					}
+				}
+			}
+		}
+	}
+	return refs
+}
+
+// andSet is a conjunction of requirement tokens — an AND of atoms. A relation
+// grants access when ANY of its grant sets is fully satisfied (an OR of ANDs, i.e.
+// disjunctive normal form), and excludes when ANY of its exclusion sets holds.
+type andSet map[string]bool
+
+// diffRelation compares one relation via its grant and exclusion sets, using
+// implication (subset covering) rather than exact equality — so loosening an
+// intersection (`a and b` → `a`) widens access and reads as additive, while
+// tightening it reads as breaking.
+func diffRelation(typeName string, oldR, newR RelationDefinition, oldImpliers, newImpliers map[string][]string, exclRefs map[string]bool) []Change {
+	label := typeName + "." + newR.Name
+	var changes []Change
+
+	oldG, newG := grantSets(oldR, oldImpliers), grantSets(newR, newImpliers)
+	// A grant path is lost when no surviving grant set implies it — that narrows
+	// access. `[t]` (specific) and `[t:*]` (public) are distinct grant
+	// capabilities: adding either widens (additive), removing either narrows
+	// (breaking). Swapping `[t]` for `[t:*]` therefore reports both, which is the
+	// conservative, fail-safe result since the specific-grant capability is lost.
+	for _, g := range uncovered(oldG, newG) {
+		changes = append(changes, Change{ClassBreaking, typeName, newR.Name, label + " no longer grants " + renderAndSet(g)})
+	}
+	// Adding a grant widens access — additive — unless this relation is used as
+	// an exclusion elsewhere, in which case widening it narrows the excluder, so
+	// it is (conservatively) breaking.
+	for _, g := range uncovered(newG, oldG) {
+		if exclRefs[newR.Name] {
+			changes = append(changes, Change{
+				ClassBreaking, typeName, newR.Name,
+				label + " grants " + renderAndSet(g) + " (used in an exclusion — widens who is excluded)",
+			})
+		} else {
+			changes = append(changes, Change{ClassAdditive, typeName, newR.Name, label + " grants " + renderAndSet(g)})
+		}
+	}
+
+	// Exclusions are the reverse: a new exclusion not implied by an old one
+	// narrows access (breaking); an old one no longer implied widens it.
+	oldX, newX := exclusionSets(oldR), exclusionSets(newR)
+	for _, x := range uncovered(newX, oldX) {
+		changes = append(changes, Change{ClassBreaking, typeName, newR.Name, label + " excludes " + renderAndSet(x)})
+	}
+	for _, x := range uncovered(oldX, newX) {
+		changes = append(changes, Change{ClassAdditive, typeName, newR.Name, label + " no longer excludes " + renderAndSet(x)})
+	}
+	return changes
+}
+
+// uncovered returns the sets in `sets` that no set in `others` covers. A set o
+// covers s when o ⊆ s: o requires no more than s, so satisfying s satisfies o —
+// o grants at least everything s does, making s redundant given o.
+func uncovered(sets, others []andSet) []andSet {
+	var out []andSet
+	for _, s := range sets {
+		isCovered := false
+		for _, o := range others {
+			if subsetOf(o, s) {
+				isCovered = true
+				break
+			}
+		}
+		if !isCovered {
+			out = append(out, s)
+		}
+	}
+	sort.Slice(out, func(i, j int) bool { return renderAndSet(out[i]) < renderAndSet(out[j]) })
+	return out
+}
+
+// subsetOf reports whether every token of a is in b (a ⊆ b) — a requires no more
+// than b, so satisfying b satisfies a.
+func subsetOf(a, b andSet) bool {
+	if len(a) > len(b) {
+		return false
+	}
+	for k := range a {
+		if !b[k] {
+			return false
+		}
+	}
+	return true
+}
+
+// grantSets returns the relation's grant paths, one andSet per OR alternative.
+// Simple grants (implied relations via the closure, TTU) are singleton sets;
+// each intersection group is the set of its ANDed members.
+//
+// The parser encodes `this and X` (e.g. `viewer: [user] and editor`) as an
+// intersection group that references the relation's own name, with the direct
+// subject types in SubjectTypeRefs. Those direct grants are therefore standalone
+// ONLY when no intersection group self-references; otherwise they belong to the
+// intersection (handled in intersectionGrantSets), so treating them as standalone
+// would miss the tightening — a breaking change — entirely.
+func grantSets(r RelationDefinition, impliers map[string][]string) []andSet {
+	var sets []andSet
+	if !hasSelfIntersection(r) {
+		for _, ref := range r.SubjectTypeRefs {
+			sets = append(sets, andSet{subjectTypeToken(ref): true})
+		}
+	}
+	for _, impl := range impliers[r.Name] {
+		sets = append(sets, andSet{impl: true})
+	}
+	for _, p := range r.ParentRelations {
+		sets = append(sets, andSet{ttuToken(p): true})
+	}
+	for _, g := range r.IntersectionGroups {
+		sets = append(sets, intersectionGrantSets(g, r)...)
+	}
+	return sets
+}
+
+// hasSelfIntersection reports whether any of the relation's intersection groups
+// references the relation itself (the `this and X` shape).
+func hasSelfIntersection(r RelationDefinition) bool {
+	for _, g := range r.IntersectionGroups {
+		for _, rel := range g.Relations {
+			if rel == r.Name {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// exclusionSets returns the relation's exclusion conditions, one andSet each.
+func exclusionSets(r RelationDefinition) []andSet {
+	sets := make([]andSet, 0, len(r.ExcludedRelations)+len(r.ExcludedParentRelations)+len(r.ExcludedIntersectionGroups))
+	for _, ex := range r.ExcludedRelations {
+		sets = append(sets, andSet{ex: true})
+	}
+	for _, ep := range r.ExcludedParentRelations {
+		sets = append(sets, andSet{ttuToken(ep): true})
+	}
+	for _, g := range r.ExcludedIntersectionGroups {
+		sets = append(sets, intersectionMembers(g))
+	}
+	return sets
+}
+
+// intersectionGrantSets expands one grant intersection group into andSets. A
+// self-reference (`this`) is the relation's direct subject types, which are an
+// OR — so the group distributes into one andSet per subject type.
+func intersectionGrantSets(g IntersectionGroup, r RelationDefinition) []andSet {
+	base := andSet{}
+	selfRef := false
+	for _, rel := range g.Relations {
+		if rel == r.Name {
+			selfRef = true
+			continue
+		}
+		base[intersectionMemberToken(rel, g)] = true
+	}
+	for _, p := range g.ParentRelations {
+		base[ttuToken(p)] = true
+	}
+
+	if !selfRef || len(r.SubjectTypeRefs) == 0 {
+		return []andSet{base}
+	}
+	out := make([]andSet, 0, len(r.SubjectTypeRefs))
+	for _, ref := range r.SubjectTypeRefs {
+		s := andSet{subjectTypeToken(ref): true}
+		for k := range base {
+			s[k] = true
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+// intersectionMembers returns the ANDed member tokens of an intersection group
+// (used for exclusion groups, which do not self-reference).
+func intersectionMembers(g IntersectionGroup) andSet {
+	s := andSet{}
+	for _, rel := range g.Relations {
+		s[intersectionMemberToken(rel, g)] = true
+	}
+	for _, p := range g.ParentRelations {
+		s[ttuToken(p)] = true
+	}
+	return s
+}
+
+// intersectionMemberToken renders one intersection member, folding in any
+// per-member exclusion (`editor but not owner`).
+func intersectionMemberToken(rel string, g IntersectionGroup) string {
+	if excls := g.Exclusions[rel]; len(excls) > 0 {
+		sorted := append([]string(nil), excls...)
+		sort.Strings(sorted)
+		return rel + " but not " + strings.Join(sorted, ",")
+	}
+	return rel
+}
+
+// renderAndSet formats an andSet: a bare token when singleton, else `(a and b)`.
+func renderAndSet(s andSet) string {
+	toks := make([]string, 0, len(s))
+	for k := range s {
+		toks = append(toks, k)
+	}
+	sort.Strings(toks)
+	if len(toks) == 1 {
+		return toks[0]
+	}
+	return "(" + strings.Join(toks, " and ") + ")"
+}
+
+func subjectTypeToken(ref SubjectTypeRef) string {
+	switch {
+	case ref.Wildcard:
+		return "[" + ref.Type + ":*]"
+	case ref.Relation != "":
+		return "[" + ref.Type + "#" + ref.Relation + "]"
+	default:
+		return "[" + ref.Type + "]"
+	}
+}
+
+func ttuToken(p ParentRelationCheck) string {
+	return p.Relation + " from " + p.LinkingRelation
+}
+
+func indexTypes(types []TypeDefinition) map[string]TypeDefinition {
+	m := make(map[string]TypeDefinition, len(types))
+	for _, t := range types {
+		m[t.Name] = t
+	}
+	return m
+}
+
+func indexRelations(t TypeDefinition) map[string]RelationDefinition {
+	m := make(map[string]RelationDefinition, len(t.Relations))
+	for _, r := range t.Relations {
+		m[r.Name] = r
+	}
+	return m
+}
+
+// sortChanges orders changes deterministically: by type, then relation, then
+// breaking-before-additive, then summary.
+func sortChanges(changes []Change) {
+	sort.SliceStable(changes, func(i, j int) bool {
+		a, b := changes[i], changes[j]
+		if a.Type != b.Type {
+			return a.Type < b.Type
+		}
+		if a.Relation != b.Relation {
+			return a.Relation < b.Relation
+		}
+		if a.Class != b.Class {
+			return a.Class == ClassBreaking // breaking first
+		}
+		return a.Summary < b.Summary
+	})
+}

--- a/pkg/schema/diff_test.go
+++ b/pkg/schema/diff_test.go
@@ -1,0 +1,326 @@
+package schema_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pthm/melange/pkg/parser"
+	"github.com/pthm/melange/pkg/schema"
+)
+
+func mustParse(t *testing.T, dsl string) []schema.TypeDefinition {
+	t.Helper()
+	types, err := parser.ParseSchemaString(dsl)
+	if err != nil {
+		t.Fatalf("parsing schema: %v\n%s", err, dsl)
+	}
+	return types
+}
+
+const diffBase = `model
+  schema 1.1
+type user
+type org
+type document
+  relations
+    define owner: [user]
+    define editor: [user] or owner
+    define viewer: [user] or editor
+    define blocked: [user]
+`
+
+// diffFor parses base and a variant and returns the changes from base → variant.
+func diffFor(t *testing.T, variant string) schema.SchemaDiff {
+	t.Helper()
+	return schema.Diff(mustParse(t, diffBase), mustParse(t, variant))
+}
+
+// hasChange reports whether any change of the given class has a summary
+// containing substr.
+func hasChange(d schema.SchemaDiff, class schema.ChangeClass, substr string) bool {
+	for _, c := range d.Changes {
+		if c.Class == class && strings.Contains(c.Summary, substr) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestDiff_Identical(t *testing.T) {
+	if d := diffFor(t, diffBase); !d.Empty() {
+		t.Errorf("identical schemas should not diff, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_OrderIndependent(t *testing.T) {
+	// Reordering subject types is not a change.
+	reordered := strings.Replace(diffBase, "define owner: [user]", "define owner: [user, org]", 1)
+	widened := strings.Replace(diffBase, "define owner: [user]", "define owner: [org, user]", 1)
+	if d := schema.Diff(mustParse(t, reordered), mustParse(t, widened)); !d.Empty() {
+		t.Errorf("reordered subject types should be equal, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_TypeAdded(t *testing.T) {
+	d := diffFor(t, diffBase+"\ntype folder\n")
+	if !hasChange(d, schema.ClassAdditive, "type folder added") {
+		t.Errorf("expected additive type-added, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_TypeRemoved(t *testing.T) {
+	// Drop the org type.
+	variant := strings.Replace(diffBase, "type org\n", "", 1)
+	d := diffFor(t, variant)
+	if !hasChange(d, schema.ClassBreaking, "type org removed") {
+		t.Errorf("expected breaking type-removed, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_RelationAddedAndRemoved(t *testing.T) {
+	added := strings.Replace(diffBase,
+		"define blocked: [user]",
+		"define blocked: [user]\n    define auditor: [user]", 1)
+	if d := diffFor(t, added); !hasChange(d, schema.ClassAdditive, "document.auditor added") {
+		t.Errorf("expected additive relation-added, got %+v", d.Changes)
+	}
+
+	removed := strings.Replace(diffBase, "    define blocked: [user]\n", "", 1)
+	if d := diffFor(t, removed); !hasChange(d, schema.ClassBreaking, "document.blocked removed") {
+		t.Errorf("expected breaking relation-removed, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_GrantAddedIsAdditive(t *testing.T) {
+	// viewer gains a direct subject type.
+	subj := strings.Replace(diffBase, "define viewer: [user] or editor", "define viewer: [user, org] or editor", 1)
+	if d := diffFor(t, subj); !hasChange(d, schema.ClassAdditive, "grants [org]") {
+		t.Errorf("expected additive grant [org], got %+v", d.Changes)
+	}
+
+	// viewer gains a genuinely new implied relation (not already in its closure).
+	base := `model
+  schema 1.1
+type user
+type document
+  relations
+    define editor: [user]
+    define reviewer: [user]
+    define viewer: [user] or editor
+`
+	widened := strings.Replace(base, "define viewer: [user] or editor", "define viewer: [user] or editor or reviewer", 1)
+	if d := schema.Diff(mustParse(t, base), mustParse(t, widened)); !hasChange(d, schema.ClassAdditive, "grants reviewer") {
+		t.Errorf("expected additive grant reviewer, got %+v", d.Changes)
+	}
+}
+
+// TestDiff_RedundantImpliedRemovalIsNotBreaking guards the closure case: dropping
+// a union member that is still reachable through another relation is not a change.
+func TestDiff_RedundantImpliedRemovalIsNotBreaking(t *testing.T) {
+	base := `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+    define editor: [user] or owner
+    define viewer: editor or owner
+`
+	// owner still reaches viewer via editor, so removing "or owner" changes nothing.
+	trimmed := strings.Replace(base, "define viewer: editor or owner", "define viewer: editor", 1)
+	if d := schema.Diff(mustParse(t, base), mustParse(t, trimmed)); !d.Empty() {
+		t.Errorf("removing a redundant implied grant should be a no-op, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_GrantRemovedIsBreaking(t *testing.T) {
+	// viewer loses its implied editor path.
+	variant := strings.Replace(diffBase, "define viewer: [user] or editor", "define viewer: [user]", 1)
+	d := diffFor(t, variant)
+	if !hasChange(d, schema.ClassBreaking, "no longer grants editor") {
+		t.Errorf("expected breaking grant-removal, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_RestrictionAddedIsBreaking(t *testing.T) {
+	variant := strings.Replace(diffBase, "define viewer: [user] or editor", "define viewer: ([user] or editor) but not blocked", 1)
+	d := diffFor(t, variant)
+	if !hasChange(d, schema.ClassBreaking, "excludes blocked") {
+		t.Errorf("expected breaking exclusion-added, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_RestrictionRemovedIsAdditive(t *testing.T) {
+	// base has the exclusion, variant drops it → additive.
+	withExcl := strings.Replace(diffBase, "define viewer: [user] or editor", "define viewer: ([user] or editor) but not blocked", 1)
+	d := schema.Diff(mustParse(t, withExcl), mustParse(t, diffBase))
+	if !hasChange(d, schema.ClassAdditive, "no longer excludes blocked") {
+		t.Errorf("expected additive exclusion-removed, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_WildcardWideningIsAdditive(t *testing.T) {
+	// Making a direct grant public (`[user]` → `[user:*]`) widens access.
+	base := `model
+  schema 1.1
+type user
+type document
+  relations
+    define viewer: [user]
+`
+	public := strings.Replace(base, "define viewer: [user]", "define viewer: [user, user:*]", 1)
+	if d := schema.Diff(mustParse(t, base), mustParse(t, public)); d.HasBreaking() {
+		t.Errorf("widening [user] to [user:*] should be additive, got %+v", d.Changes)
+	}
+	// Removing the wildcard narrows access → breaking.
+	if d := schema.Diff(mustParse(t, public), mustParse(t, base)); !d.HasBreaking() {
+		t.Errorf("removing [user:*] should be breaking, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_IntersectionAlternativeAddedIsAdditive(t *testing.T) {
+	// A relation defined as an intersection gains an OR'd alternative group —
+	// this widens access, so it must be additive (regression: was breaking).
+	base := `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+    define editor: [user]
+    define auditor: [user]
+    define can_x: owner and editor
+`
+	widened := strings.Replace(base,
+		"define can_x: owner and editor",
+		"define can_x: (owner and editor) or (auditor and editor)", 1)
+
+	if d := schema.Diff(mustParse(t, base), mustParse(t, widened)); d.HasBreaking() {
+		t.Errorf("adding an OR'd intersection alternative should be additive, got %+v", d.Changes)
+	}
+	// And the reverse narrows access → breaking.
+	if d := schema.Diff(mustParse(t, widened), mustParse(t, base)); !d.HasBreaking() {
+		t.Errorf("removing an OR'd intersection alternative should be breaking, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_IntersectionLoosenedIsAdditive(t *testing.T) {
+	// Loosening an intersection (`owner and editor` → `owner`) widens access:
+	// owner alone now suffices, and nobody who had access loses it.
+	base := `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+    define editor: [user]
+    define can_x: owner and editor
+`
+	loosened := strings.Replace(base, "define can_x: owner and editor", "define can_x: owner", 1)
+
+	if d := schema.Diff(mustParse(t, base), mustParse(t, loosened)); d.HasBreaking() {
+		t.Errorf("loosening an intersection should be additive, got %+v", d.Changes)
+	}
+	// Tightening (the reverse) narrows access → breaking.
+	if d := schema.Diff(mustParse(t, loosened), mustParse(t, base)); !d.HasBreaking() {
+		t.Errorf("tightening an intersection should be breaking, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_WeakenedExclusionIsAdditive(t *testing.T) {
+	// Weakening an exclusion (`but not (a and b)` excludes less than `but not a`)
+	// widens access.
+	strict := `model
+  schema 1.1
+type user
+type document
+  relations
+    define a: [user]
+    define b: [user]
+    define grantee: [user]
+    define viewer: grantee but not a
+`
+	weak := strings.Replace(strict, "define viewer: grantee but not a", "define viewer: grantee but not (a and b)", 1)
+
+	if d := schema.Diff(mustParse(t, strict), mustParse(t, weak)); d.HasBreaking() {
+		t.Errorf("weakening an exclusion should be additive, got %+v", d.Changes)
+	}
+	if d := schema.Diff(mustParse(t, weak), mustParse(t, strict)); !d.HasBreaking() {
+		t.Errorf("strengthening an exclusion should be breaking, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_IntersectingDirectGrantIsBreaking(t *testing.T) {
+	// `viewer: [user]` -> `viewer: [user] and editor` requires editor in addition
+	// to the direct grant, so someone with only [user] loses access — breaking.
+	// (The parser encodes the direct `[user]` as a self-reference in the group.)
+	base := `model
+  schema 1.1
+type user
+type document
+  relations
+    define editor: [user]
+    define viewer: [user]
+`
+	tightened := strings.Replace(base, "define viewer: [user]", "define viewer: [user] and editor", 1)
+	if d := schema.Diff(mustParse(t, base), mustParse(t, tightened)); !d.HasBreaking() {
+		t.Errorf("intersecting a direct grant with `and editor` should be breaking, got %+v", d.Changes)
+	}
+	// Dropping the intersection widens access.
+	if d := schema.Diff(mustParse(t, tightened), mustParse(t, base)); d.HasBreaking() {
+		t.Errorf("dropping the intersection should be additive, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_WideningAnExclusionRelationIsBreaking(t *testing.T) {
+	// `blocked` is used in `viewer: ... but not blocked`. Widening `blocked`
+	// (adding [user]) blocks more subjects, so some viewers lose access.
+	base := `model
+  schema 1.1
+type user
+type document
+  relations
+    define blocked: [user]
+    define grantee: [user]
+    define viewer: grantee but not blocked
+`
+	widened := strings.Replace(base, "define blocked: [user]", "define blocked: [user, user:*]", 1)
+	if d := schema.Diff(mustParse(t, base), mustParse(t, widened)); !d.HasBreaking() {
+		t.Errorf("widening a relation used as an exclusion should be breaking, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_WideningAnImplierOfAnExclusionIsBreaking(t *testing.T) {
+	// `blocked: owner` and `viewer: grantee but not blocked`. Widening `owner`
+	// widens `blocked` (which owner implies), so viewers who become owners lose
+	// access — breaking, even though `owner` is not named in the exclusion.
+	base := `model
+  schema 1.1
+type user
+type org
+type document
+  relations
+    define owner: [user]
+    define blocked: owner
+    define grantee: [user]
+    define viewer: grantee but not blocked
+`
+	widened := strings.Replace(base, "define owner: [user]", "define owner: [user, org]", 1)
+	if d := schema.Diff(mustParse(t, base), mustParse(t, widened)); !d.HasBreaking() {
+		t.Errorf("widening an implier of an excluded relation should be breaking, got %+v", d.Changes)
+	}
+}
+
+func TestDiff_CountsAndHasBreaking(t *testing.T) {
+	// One additive (new type) and one breaking (removed relation).
+	variant := strings.Replace(diffBase, "    define blocked: [user]\n", "", 1) + "\ntype folder\n"
+	d := diffFor(t, variant)
+
+	additive, breaking := d.Counts()
+	if additive != 1 || breaking != 1 {
+		t.Errorf("expected 1 additive + 1 breaking, got %d/%d: %+v", additive, breaking, d.Changes)
+	}
+	if !d.HasBreaking() {
+		t.Error("expected HasBreaking to be true")
+	}
+}

--- a/pkg/schema/diff_test.go
+++ b/pkg/schema/diff_test.go
@@ -324,3 +324,82 @@ func TestDiff_CountsAndHasBreaking(t *testing.T) {
 		t.Error("expected HasBreaking to be true")
 	}
 }
+
+// BreakingSummaries feeds the doctor advisory and status drift block, which show
+// only what narrows access.
+func TestBreakingSummaries_SelectsOnlyBreaking(t *testing.T) {
+	d := schema.SchemaDiff{Changes: []schema.Change{
+		{Class: schema.ClassAdditive, Type: "audit_log", Summary: "type audit_log added"},
+		{Class: schema.ClassBreaking, Type: "document", Relation: "viewer", Summary: "relation document.viewer removed"},
+		{Class: schema.ClassBreaking, Type: "folder", Relation: "editor", Summary: "relation folder.editor removed"},
+	}}
+
+	got := d.BreakingSummaries()
+	if len(got) != 2 {
+		t.Fatalf("got %d summaries, want 2: %v", len(got), got)
+	}
+	for _, s := range got {
+		if strings.Contains(s, "audit_log") {
+			t.Errorf("additive change leaked into breaking summaries: %q", s)
+		}
+	}
+	if len(schema.SchemaDiff{}.BreakingSummaries()) != 0 {
+		t.Error("an empty diff must produce no summaries")
+	}
+}
+
+// A TTU grant renders as "relation from parent" on both sides of the diff, so a
+// change to the linking relation reads as a real change rather than a rename.
+func TestDiff_TupleToUsersetGrant(t *testing.T) {
+	deployed := []schema.TypeDefinition{{Name: "document", Relations: []schema.RelationDefinition{{
+		Name:            "viewer",
+		ParentRelations: []schema.ParentRelationCheck{{Relation: "viewer", LinkingRelation: "parent"}},
+	}}}}
+	local := []schema.TypeDefinition{{Name: "document", Relations: []schema.RelationDefinition{{
+		Name:            "viewer",
+		ParentRelations: []schema.ParentRelationCheck{{Relation: "viewer", LinkingRelation: "owner"}},
+	}}}}
+
+	d := schema.Diff(deployed, local)
+	additive, breaking := d.Counts()
+	if breaking != 1 || additive != 1 {
+		t.Fatalf("counts = %d breaking, %d additive; want 1 and 1: %+v", breaking, additive, d.Changes)
+	}
+	joined := strings.Join(summaries(d), " | ")
+	if !strings.Contains(joined, "viewer from parent") || !strings.Contains(joined, "viewer from owner") {
+		t.Errorf("summaries should name both TTU tokens, got: %s", joined)
+	}
+}
+
+// An intersection member carrying its own exclusion is rendered with that
+// exclusion, so tightening it is not mistaken for an unrelated grant.
+func TestDiff_IntersectionMemberExclusion(t *testing.T) {
+	deployed := []schema.TypeDefinition{{Name: "document", Relations: []schema.RelationDefinition{{
+		Name:               "viewer",
+		IntersectionGroups: []schema.IntersectionGroup{{Relations: []string{"editor", "member"}}},
+	}}}}
+	local := []schema.TypeDefinition{{Name: "document", Relations: []schema.RelationDefinition{{
+		Name: "viewer",
+		IntersectionGroups: []schema.IntersectionGroup{{
+			Relations:  []string{"editor", "member"},
+			Exclusions: map[string][]string{"editor": {"banned"}},
+		}},
+	}}}}
+
+	d := schema.Diff(deployed, local)
+	if d.Empty() {
+		t.Fatal("narrowing an intersection member must register as a change")
+	}
+	joined := strings.Join(summaries(d), " | ")
+	if !strings.Contains(joined, "editor but not banned") {
+		t.Errorf("summary should render the member exclusion, got: %s", joined)
+	}
+}
+
+func summaries(d schema.SchemaDiff) []string {
+	out := make([]string, 0, len(d.Changes))
+	for _, c := range d.Changes {
+		out = append(out, c.Summary)
+	}
+	return out
+}

--- a/pkg/schema/model_json.go
+++ b/pkg/schema/model_json.go
@@ -1,0 +1,29 @@
+package schema
+
+import "encoding/json"
+
+// MarshalModel serializes a parsed model to a compact JSON representation for
+// storage (e.g. the model_json column of melange_migrations). It is the inverse
+// of UnmarshalModel: MarshalModel followed by UnmarshalModel round-trips a model
+// without loss.
+//
+// The JSON shape is the natural encoding of []TypeDefinition. All fields are
+// exported and JSON-safe (no pointers, interfaces, or non-string map keys), so
+// the round-trip is exact — see TestModelJSONRoundTrip.
+func MarshalModel(types []TypeDefinition) ([]byte, error) {
+	return json.Marshal(types)
+}
+
+// UnmarshalModel deserializes a model previously produced by MarshalModel.
+// Empty or nil input yields a nil model with no error, matching the "no model
+// recorded" case for databases migrated before model storage existed.
+func UnmarshalModel(data []byte) ([]TypeDefinition, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	var types []TypeDefinition
+	if err := json.Unmarshal(data, &types); err != nil {
+		return nil, err
+	}
+	return types, nil
+}

--- a/pkg/schema/model_json_test.go
+++ b/pkg/schema/model_json_test.go
@@ -1,0 +1,108 @@
+package schema
+
+import (
+	"reflect"
+	"testing"
+)
+
+// fullModel exercises every rule variant so the round-trip test proves the JSON
+// encoding preserves the whole schema surface: direct, wildcard, implied,
+// parent (TTU), simple exclusion, excluded-parent, userset references,
+// intersection groups (with per-relation exclusions and parent checks), and
+// excluded intersection groups.
+func fullModel() []TypeDefinition {
+	return []TypeDefinition{
+		{Name: "user"},
+		{Name: "group", Relations: []RelationDefinition{
+			{Name: "member", SubjectTypeRefs: []SubjectTypeRef{{Type: "user"}}},
+		}},
+		{
+			Name: "folder",
+			Relations: []RelationDefinition{
+				{Name: "parent", SubjectTypeRefs: []SubjectTypeRef{{Type: "folder"}}},
+				{Name: "viewer", SubjectTypeRefs: []SubjectTypeRef{{Type: "user"}}},
+			},
+		},
+		{
+			Name: "document",
+			Relations: []RelationDefinition{
+				// Direct + wildcard + userset reference.
+				{Name: "owner", SubjectTypeRefs: []SubjectTypeRef{
+					{Type: "user"},
+					{Type: "user", Wildcard: true},
+					{Type: "group", Relation: "member"},
+				}},
+				// Implied (computed userset) + simple exclusion.
+				{
+					Name:              "editor",
+					ImpliedBy:         []string{"owner"},
+					ExcludedRelations: []string{"banned"},
+				},
+				// Parent (TTU) + excluded parent (TTU exclusion).
+				{
+					Name:            "viewer",
+					ImpliedBy:       []string{"editor"},
+					ParentRelations: []ParentRelationCheck{{Relation: "viewer", LinkingRelation: "parent"}},
+					ExcludedParentRelations: []ParentRelationCheck{
+						{Relation: "banned", LinkingRelation: "parent"},
+					},
+				},
+				// Intersection group with a per-relation exclusion and a parent check.
+				{
+					Name: "can_share",
+					IntersectionGroups: []IntersectionGroup{
+						{
+							Relations:       []string{"editor", "viewer"},
+							ParentRelations: []ParentRelationCheck{{Relation: "can_share", LinkingRelation: "parent"}},
+							Exclusions:      map[string][]string{"editor": {"banned"}},
+						},
+					},
+				},
+				// Excluded intersection group: "but not (editor and owner)".
+				{
+					Name: "restricted",
+					ExcludedIntersectionGroups: []IntersectionGroup{
+						{Relations: []string{"editor", "owner"}},
+					},
+				},
+				{Name: "banned", SubjectTypeRefs: []SubjectTypeRef{{Type: "user"}}},
+			},
+		},
+	}
+}
+
+func TestModelJSONRoundTrip(t *testing.T) {
+	original := fullModel()
+
+	data, err := MarshalModel(original)
+	if err != nil {
+		t.Fatalf("MarshalModel: %v", err)
+	}
+
+	got, err := UnmarshalModel(data)
+	if err != nil {
+		t.Fatalf("UnmarshalModel: %v", err)
+	}
+
+	if !reflect.DeepEqual(original, got) {
+		t.Fatalf("round-trip mismatch:\n original = %#v\n got      = %#v", original, got)
+	}
+}
+
+func TestUnmarshalModel_Empty(t *testing.T) {
+	for _, in := range [][]byte{nil, {}} {
+		got, err := UnmarshalModel(in)
+		if err != nil {
+			t.Fatalf("UnmarshalModel(%v): %v", in, err)
+		}
+		if got != nil {
+			t.Errorf("UnmarshalModel(%v) = %#v, want nil", in, got)
+		}
+	}
+}
+
+func TestUnmarshalModel_Invalid(t *testing.T) {
+	if _, err := UnmarshalModel([]byte("not json")); err == nil {
+		t.Error("expected error for invalid JSON, got nil")
+	}
+}

--- a/test/doctor_test.go
+++ b/test/doctor_test.go
@@ -3,6 +3,8 @@ package test
 import (
 	"context"
 	"database/sql"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -11,6 +13,7 @@ import (
 
 	"github.com/pthm/melange/internal/doctor"
 	"github.com/pthm/melange/pkg/compiler"
+	"github.com/pthm/melange/pkg/migrator"
 	"github.com/pthm/melange/pkg/parser"
 	"github.com/pthm/melange/pkg/schema"
 	"github.com/pthm/melange/test/testutil"
@@ -719,4 +722,153 @@ func findCheck(checks []doctor.CheckResult, name string) *doctor.CheckResult {
 		}
 	}
 	return nil
+}
+
+// TestDoctor_DeployedModelChecks verifies the "Deployed Model" checks: the model
+// is recorded, and a pending local change is classified additive vs breaking.
+func TestDoctor_DeployedModelChecks(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	const docBase = `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+    define viewer: [user] or owner
+`
+	const docAdditive = `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+    define editor: [user]
+    define viewer: [user] or owner
+`
+	const docBreaking = `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+`
+
+	m := migrator.NewMigrator(db, "")
+	migrateSchema(t, ctx, m, docBase, migrator.InternalMigrateOptions{Version: "v0.9.0", SchemaFormat: "single"})
+
+	run := func(content string) []doctor.CheckResult {
+		path := filepath.Join(t.TempDir(), "schema.fga")
+		require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+		d := doctor.New(db, path, doctor.Options{SkipPerformance: true})
+		report, err := d.Run(ctx)
+		require.NoError(t, err)
+		return filterCategory(report, "Deployed Model")
+	}
+
+	// In sync: model recorded, no drift advisory.
+	inSync := run(docBase)
+	assertCheck(t, inSync, "recorded", doctor.StatusPass)
+	assert.Nil(t, findCheck(inSync, "drift_safety"), "no drift advisory when in sync")
+
+	// Additive local change: drift advisory passes.
+	additive := run(docAdditive)
+	assertCheck(t, additive, "recorded", doctor.StatusPass)
+	assertCheck(t, additive, "drift_safety", doctor.StatusPass)
+
+	// Breaking local change: drift advisory warns and names the change.
+	breaking := run(docBreaking)
+	assertCheck(t, breaking, "drift_safety", doctor.StatusWarn)
+	if c := findCheck(breaking, "drift_safety"); assert.NotNil(t, c) {
+		assert.Contains(t, c.Details, "viewer", "breaking detail should name the removed relation")
+	}
+}
+
+// TestDoctor_DeployedModelCorruptDegradesToWarning verifies that a corrupt
+// stored model_json produces a warning rather than aborting the whole run —
+// doctor must still diagnose the broken deployment.
+func TestDoctor_DeployedModelCorruptDegradesToWarning(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	const doc = `model
+  schema 1.1
+type user
+type document
+  relations
+    define viewer: [user]
+`
+	m := migrator.NewMigrator(db, "")
+	migrateSchema(t, ctx, m, doc, migrator.InternalMigrateOptions{Version: "v0.9.0", SchemaFormat: "single"})
+
+	// Corrupt the stored model: valid JSON (the column is jsonb) but the wrong
+	// shape for UnmarshalModel, which expects an array of type definitions.
+	_, err := db.ExecContext(ctx, `UPDATE melange_migrations SET model_json = '{"corrupt": true}'`)
+	require.NoError(t, err)
+
+	path := filepath.Join(t.TempDir(), "schema.fga")
+	require.NoError(t, os.WriteFile(path, []byte(doc), 0o644))
+	d := doctor.New(db, path, doctor.Options{SkipPerformance: true})
+	report, err := d.Run(ctx)
+	require.NoError(t, err, "doctor must not abort on a corrupt deployed model")
+
+	dm := filterCategory(report, "Deployed Model")
+	c := findCheck(dm, "recorded")
+	require.NotNil(t, c)
+	assert.Equal(t, doctor.StatusWarn, c.Status)
+	assert.Contains(t, c.Message, "could not be decoded")
+
+	// Subsequent checks still ran — the run was not aborted.
+	assert.NotEmpty(t, filterCategory(report, "Generated Functions"), "later checks should still run")
+}
+
+// TestDoctor_DeployedModelDriftFromDSLFallback verifies the drift advisory still
+// works when a record has schema_dsl but no usable model_json (an older/partial
+// record): the deployed model is reconstructed by parsing the stored DSL.
+func TestDoctor_DeployedModelDriftFromDSLFallback(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	const withViewer = `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+    define viewer: [user] or owner
+`
+	const withoutViewer = `model
+  schema 1.1
+type user
+type document
+  relations
+    define owner: [user]
+`
+	m := migrator.NewMigrator(db, "")
+	migrateSchema(t, ctx, m, withViewer, migrator.InternalMigrateOptions{Version: "v0.9.0", SchemaFormat: "single"})
+
+	// Blank out the JSON model, leaving schema_dsl — forces the DSL fallback.
+	_, err := db.ExecContext(ctx, `UPDATE melange_migrations SET model_json = 'null'`)
+	require.NoError(t, err)
+
+	// Local schema removes viewer: a breaking change that must still be caught.
+	path := filepath.Join(t.TempDir(), "schema.fga")
+	require.NoError(t, os.WriteFile(path, []byte(withoutViewer), 0o644))
+	d := doctor.New(db, path, doctor.Options{SkipPerformance: true})
+	report, err := d.Run(ctx)
+	require.NoError(t, err)
+
+	dm := filterCategory(report, "Deployed Model")
+	assertCheck(t, dm, "recorded", doctor.StatusPass)
+	assertCheck(t, dm, "drift_safety", doctor.StatusWarn)
 }

--- a/test/migration_test.go
+++ b/test/migration_test.go
@@ -1156,3 +1156,29 @@ func TestMigration_BackfillsModelOnRerun(t *testing.T) {
 	require.NotNil(t, model, "rerun should backfill the deployed model")
 	assert.Equal(t, schemaV1, model.DSL)
 }
+
+// TestMigration_GetLastMigrationToleratesMissingMelangeVersion verifies that a
+// database migrated before the melange_version column existed can still be read
+// — status now depends on GetLastMigration, so a missing optional column must
+// not fail the whole command.
+func TestMigration_GetLastMigrationToleratesMissingMelangeVersion(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{Version: "v0.9.0"})
+
+	// Simulate a legacy table that predates the melange_version column.
+	_, err := db.ExecContext(ctx, "ALTER TABLE melange_migrations DROP COLUMN melange_version")
+	require.NoError(t, err)
+
+	rec, err := m.GetLastMigration(ctx)
+	require.NoError(t, err, "read should tolerate a missing melange_version column")
+	require.NotNil(t, rec)
+	assert.Empty(t, rec.MelangeVersion)
+	assert.NotEmpty(t, rec.FunctionNames)
+}

--- a/test/migration_test.go
+++ b/test/migration_test.go
@@ -1,6 +1,7 @@
 package test
 
 import (
+	"bytes"
 	"context"
 	"database/sql"
 	"strings"
@@ -951,4 +952,207 @@ func TestMigration_Modular_EquivalentToSingleFile(t *testing.T) {
 	fnModular := getFunctionNames(t, ctx, db2)
 	assert.Equal(t, fnSingle, fnModular,
 		"installed functions should be identical between single-file and modular schemas")
+}
+
+// TestMigration_RecordsDeployedModel verifies that a migration persists the
+// schema DSL, format, and parsed model, and that GetDeployedModel reads them
+// back losslessly. This is the foundation for `melange schema pull` and diffs.
+func TestMigration_RecordsDeployedModel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{
+		Version:      "v0.9.0",
+		SchemaFormat: "single",
+	})
+
+	model, err := m.GetDeployedModel(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, model, "deployed model should be recorded")
+
+	assert.Equal(t, schemaV1, model.DSL, "stored DSL should match the migrated schema")
+	assert.Equal(t, "single", model.Format)
+	assert.Equal(t, "v0.9.0", model.MelangeVersion)
+	assert.False(t, model.MigratedAt.IsZero(), "migrated_at should be populated")
+
+	// The parsed model round-trips to exactly what the schema parses to.
+	wantTypes, err := parser.ParseSchemaString(schemaV1)
+	require.NoError(t, err)
+	assert.Equal(t, wantTypes, model.Types, "stored model should round-trip to the parsed types")
+}
+
+// TestMigration_DeployedModelAbsentColumns simulates a database migrated before
+// model storage existed: GetLastMigration still works (dynamic column
+// selection) and GetDeployedModel returns nil gracefully rather than erroring.
+func TestMigration_DeployedModelAbsentColumns(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{Version: "v0.9.0"})
+
+	// Drop the model columns to mimic an older installation.
+	for _, col := range []string{"schema_dsl", "schema_format", "model_json"} {
+		_, err := db.ExecContext(ctx, "ALTER TABLE melange_migrations DROP COLUMN "+col)
+		require.NoError(t, err, "dropping column %s", col)
+	}
+
+	// GetLastMigration still reads the surviving columns.
+	rec, err := m.GetLastMigration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.NotEmpty(t, rec.FunctionNames, "function names should still be read")
+	assert.Empty(t, rec.SchemaDSL, "schema_dsl is absent on an old install")
+
+	// GetDeployedModel reports "no model recorded" as nil, not an error.
+	model, err := m.GetDeployedModel(ctx)
+	require.NoError(t, err)
+	assert.Nil(t, model)
+}
+
+// TestMigration_DryRunScriptRecordsModel verifies that a dry-run migration
+// script, applied separately, records a self-describing migration: applying the
+// emitted SQL creates the tracking table and an INSERT that GetDeployedModel can
+// read back. Guards the dry-run INSERT against dropping the model columns.
+func TestMigration_DryRunScriptRecordsModel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	types, err := parser.ParseSchemaString(schemaV1)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = m.MigrateWithTypesAndOptions(ctx, types, migrator.InternalMigrateOptions{
+		DryRun:        &buf,
+		Version:       "v0.9.0",
+		SchemaContent: schemaV1,
+		SchemaFormat:  "single",
+	})
+	require.NoError(t, err)
+
+	// The emitted script must be valid SQL end-to-end.
+	_, err = db.ExecContext(ctx, buf.String())
+	require.NoError(t, err, "dry-run script should apply cleanly")
+
+	// And it must have recorded a model the read-back API can return.
+	model, err := m.GetDeployedModel(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, model, "applied dry-run script should record the model")
+	assert.Equal(t, schemaV1, model.DSL)
+	assert.Equal(t, "single", model.Format)
+	assert.Equal(t, "v0.9.0", model.MelangeVersion)
+}
+
+// TestMigration_DryRunScriptUpgradesOldTable applies a dry-run script to a
+// database whose melange_migrations table predates the deployed-model columns.
+// The script must ADD the columns (CREATE TABLE IF NOT EXISTS is a no-op on the
+// existing table) before its INSERT references them.
+func TestMigration_DryRunScriptUpgradesOldTable(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	// Establish an older installation, then drop the model columns.
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{Version: "v0.8.0"})
+	for _, col := range []string{"schema_dsl", "schema_format", "model_json"} {
+		_, err := db.ExecContext(ctx, "ALTER TABLE melange_migrations DROP COLUMN "+col)
+		require.NoError(t, err, "dropping column %s", col)
+	}
+
+	types, err := parser.ParseSchemaString(schemaV1)
+	require.NoError(t, err)
+
+	var buf bytes.Buffer
+	err = m.MigrateWithTypesAndOptions(ctx, types, migrator.InternalMigrateOptions{
+		DryRun:        &buf,
+		Version:       "v0.9.0",
+		SchemaContent: schemaV1,
+		SchemaFormat:  "single",
+	})
+	require.NoError(t, err)
+
+	_, err = db.ExecContext(ctx, buf.String())
+	require.NoError(t, err, "dry-run script should upgrade the old table then insert")
+
+	model, err := m.GetDeployedModel(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, model, "model should be readable after applying upgrade script")
+	assert.Equal(t, schemaV1, model.DSL)
+}
+
+// TestMigration_MigrateFromStringRecordsModel verifies the high-level
+// MigrateFromString entrypoint records a self-describing migration, so
+// GetDeployedModel works for library users following the recommended APIs.
+func TestMigration_MigrateFromStringRecordsModel(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	require.NoError(t, migrator.MigrateFromString(ctx, db, schemaV1))
+
+	m := migrator.NewMigrator(db, "")
+	model, err := m.GetDeployedModel(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, model, "MigrateFromString should record the deployed model")
+	assert.Equal(t, schemaV1, model.DSL)
+	assert.Equal(t, "single", model.Format)
+}
+
+// TestMigration_BackfillsModelOnRerun verifies that rerunning migrate with an
+// unchanged schema backfills the deployed model when an older record lacks it,
+// rather than fast-path skipping and leaving GetDeployedModel nil.
+func TestMigration_BackfillsModelOnRerun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{
+		Version:      "v0.9.0",
+		SchemaFormat: "single",
+	})
+
+	// Simulate a record written before model storage existed.
+	_, err := db.ExecContext(ctx,
+		"UPDATE melange_migrations SET schema_dsl = '', schema_format = '', model_json = '{}'::jsonb")
+	require.NoError(t, err)
+
+	model, err := m.GetDeployedModel(ctx)
+	require.NoError(t, err)
+	require.Nil(t, model, "precondition: model appears unrecorded")
+
+	// Rerunning the same schema must backfill instead of fast-path skipping.
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{
+		Version:      "v0.9.0",
+		SchemaFormat: "single",
+	})
+
+	model, err = m.GetDeployedModel(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, model, "rerun should backfill the deployed model")
+	assert.Equal(t, schemaV1, model.DSL)
 }

--- a/test/migration_test.go
+++ b/test/migration_test.go
@@ -4,6 +4,9 @@ import (
 	"bytes"
 	"context"
 	"database/sql"
+	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -1181,4 +1184,154 @@ func TestMigration_GetLastMigrationToleratesMissingMelangeVersion(t *testing.T) 
 	require.NotNil(t, rec)
 	assert.Empty(t, rec.MelangeVersion)
 	assert.NotEmpty(t, rec.FunctionNames)
+}
+
+// migrateWithGuard applies a schema with a --if-deployed-checksum precondition.
+func migrateWithGuard(t *testing.T, ctx context.Context, m *migrator.Migrator, schemaContent, version, expectedChecksum string) error {
+	t.Helper()
+	types, err := parser.ParseSchemaString(schemaContent)
+	require.NoError(t, err)
+	return m.MigrateWithTypesAndOptions(ctx, types, migrator.InternalMigrateOptions{
+		Version:            version,
+		SchemaContent:      schemaContent,
+		SchemaFormat:       "single",
+		IfDeployedChecksum: &expectedChecksum,
+	})
+}
+
+// TestMigration_DriftGuardMatches verifies a compare-and-swap migrate proceeds
+// when the deployed checksum matches the expected one.
+func TestMigration_DriftGuardMatches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{Version: "v0.9.0"})
+
+	// Deployed is V1; guard against V1's checksum, apply V2.
+	err := migrateWithGuard(t, ctx, m, schemaV2, "v0.9.1", migrator.ComputeSchemaChecksum(schemaV1))
+	require.NoError(t, err)
+	assert.True(t, functionExists(t, ctx, db, "check_document_editor"), "V2 should have been applied")
+}
+
+// TestMigration_DriftGuardMismatchAborts verifies a mismatched precondition
+// aborts without applying anything, leaving the deployed model untouched.
+func TestMigration_DriftGuardMismatchAborts(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{Version: "v0.9.0"})
+
+	err := migrateWithGuard(t, ctx, m, schemaV2, "v0.9.1", "not-the-deployed-checksum")
+	require.Error(t, err)
+	var driftErr *migrator.DeployedModelChangedError
+	require.True(t, errors.As(err, &driftErr), "expected DeployedModelChangedError, got %v", err)
+
+	// Nothing applied: V2's editor function is absent and the record is still V1.
+	assert.False(t, functionExists(t, ctx, db, "check_document_editor"), "V2 must not have been applied")
+	rec, err := m.GetLastMigration(ctx)
+	require.NoError(t, err)
+	require.NotNil(t, rec)
+	assert.Equal(t, migrator.ComputeSchemaChecksum(schemaV1), rec.SchemaChecksum, "deployed model should still be V1")
+}
+
+// TestMigration_DriftGuardEmptyMatchesFreshDatabase verifies that an empty
+// expected checksum matches a database with no migration, and a non-empty one
+// aborts against a fresh database.
+func TestMigration_DriftGuardEmptyMatchesFreshDatabase(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	ctx := context.Background()
+
+	// Empty expected checksum matches a never-migrated database → applies.
+	db := testutil.EmptyDB(t)
+	m := migrator.NewMigrator(db, "")
+	require.NoError(t, migrateWithGuard(t, ctx, m, schemaV1, "v0.9.0", ""))
+	assert.True(t, functionExists(t, ctx, db, "check_document_viewer"))
+
+	// A non-empty expected checksum against a fresh database aborts.
+	db2 := testutil.EmptyDB(t)
+	m2 := migrator.NewMigrator(db2, "")
+	err := migrateWithGuard(t, ctx, m2, schemaV1, "v0.9.0", "some-expected-checksum")
+	var driftErr *migrator.DeployedModelChangedError
+	require.True(t, errors.As(err, &driftErr), "expected DeployedModelChangedError, got %v", err)
+	assert.False(t, functionExists(t, ctx, db2, "check_document_viewer"), "nothing should have been applied")
+}
+
+// TestMigration_GuardedUnchangedReportsSkipped verifies that a guarded migrate
+// of an unchanged schema still reports skipped=true (the guard is checked before
+// the fast-path skip), and that a mismatched guard aborts.
+func TestMigration_GuardedUnchangedReportsSkipped(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+
+	path := filepath.Join(t.TempDir(), "schema.fga")
+	require.NoError(t, os.WriteFile(path, []byte(schemaV1), 0o644))
+
+	_, err := migrator.MigrateWithOptions(ctx, db, path, migrator.MigrateOptions{Version: "v0.9.0"})
+	require.NoError(t, err)
+
+	sum := migrator.ComputeSchemaChecksum(schemaV1)
+	skipped, err := migrator.MigrateWithOptions(ctx, db, path, migrator.MigrateOptions{
+		Version:            "v0.9.0",
+		IfDeployedChecksum: &sum,
+	})
+	require.NoError(t, err)
+	assert.True(t, skipped, "unchanged guarded migrate should report skipped")
+
+	wrong := "not-the-checksum"
+	_, err = migrator.MigrateWithOptions(ctx, db, path, migrator.MigrateOptions{
+		Version:            "v0.9.0",
+		IfDeployedChecksum: &wrong,
+	})
+	var driftErr *migrator.DeployedModelChangedError
+	require.True(t, errors.As(err, &driftErr), "mismatched guard should abort, got %v", err)
+}
+
+// TestMigration_DriftGuardEnforcedInDryRun verifies that --if-deployed-checksum
+// is honored in dry-run: a mismatch aborts before printing any SQL, and a match
+// still produces the preview.
+func TestMigration_DriftGuardEnforcedInDryRun(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{Version: "v0.9.0"})
+	types, err := parser.ParseSchemaString(schemaV2)
+	require.NoError(t, err)
+
+	// Mismatch → aborts, nothing printed.
+	wrong := "not-the-deployed-checksum"
+	var buf bytes.Buffer
+	err = m.MigrateWithTypesAndOptions(ctx, types, migrator.InternalMigrateOptions{
+		DryRun: &buf, Version: "v0.9.1", SchemaContent: schemaV2, SchemaFormat: "single",
+		IfDeployedChecksum: &wrong,
+	})
+	var driftErr *migrator.DeployedModelChangedError
+	require.True(t, errors.As(err, &driftErr), "dry-run should enforce the guard, got %v", err)
+	assert.Empty(t, buf.String(), "no SQL should be printed on a drift-guard failure")
+
+	// Match → proceeds and prints the preview.
+	sum := migrator.ComputeSchemaChecksum(schemaV1)
+	var buf2 bytes.Buffer
+	err = m.MigrateWithTypesAndOptions(ctx, types, migrator.InternalMigrateOptions{
+		DryRun: &buf2, Version: "v0.9.1", SchemaContent: schemaV2, SchemaFormat: "single",
+		IfDeployedChecksum: &sum,
+	})
+	require.NoError(t, err)
+	assert.Contains(t, buf2.String(), "Melange Migration (dry-run)", "matching guard should still preview")
 }

--- a/test/migration_test.go
+++ b/test/migration_test.go
@@ -1335,3 +1335,39 @@ func TestMigration_DriftGuardEnforcedInDryRun(t *testing.T) {
 	require.NoError(t, err)
 	assert.Contains(t, buf2.String(), "Melange Migration (dry-run)", "matching guard should still preview")
 }
+
+// TestMigration_GetMigrationHistory verifies the audit-history reader returns
+// records most-recent-first with the expected fields, and honors the limit.
+func TestMigration_GetMigrationHistory(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+	db := testutil.EmptyDB(t)
+	ctx := context.Background()
+	m := migrator.NewMigrator(db, "")
+
+	empty, err := m.GetMigrationHistory(ctx, 10)
+	require.NoError(t, err)
+	assert.Empty(t, empty, "fresh database has no history")
+
+	migrateSchema(t, ctx, m, schemaV1, migrator.InternalMigrateOptions{Version: "v0.9.0", SchemaFormat: "single"})
+	migrateSchema(t, ctx, m, schemaV2, migrator.InternalMigrateOptions{Version: "v0.9.1", SchemaFormat: "single"})
+
+	h, err := m.GetMigrationHistory(ctx, 10)
+	require.NoError(t, err)
+	require.Len(t, h, 2)
+
+	// Most recent first.
+	assert.Equal(t, migrator.ComputeSchemaChecksum(schemaV2), h[0].SchemaChecksum)
+	assert.Equal(t, "v0.9.1", h[0].MelangeVersion)
+	assert.Equal(t, "single", h[0].SchemaFormat)
+	assert.NotEmpty(t, h[0].FunctionNames)
+	assert.False(t, h[0].MigratedAt.IsZero())
+	assert.Equal(t, migrator.ComputeSchemaChecksum(schemaV1), h[1].SchemaChecksum)
+
+	// Limit is honored.
+	one, err := m.GetMigrationHistory(ctx, 1)
+	require.NoError(t, err)
+	require.Len(t, one, 1)
+	assert.Equal(t, migrator.ComputeSchemaChecksum(schemaV2), one[0].SchemaChecksum)
+}


### PR DESCRIPTION
Melange's design has always been "the `.fga` is the source of truth in git, the database holds compiled functions." That is right for the compile-and-deploy direction, but it leaves the reverse direction unsupported: a running database can't tell you what model it is actually running. `melange_migrations` stored only a SHA256, so a checksum mismatch told you *that* something differed, never *what*.

This stack makes a migrated database self-describing and builds the operability tooling that falls out of that. The enabling fact is that the schema DSL is already in hand at migrate time — it was threaded through purely to compute the checksum, then discarded.

## What's in it

**Model storage.** Three additive columns on `melange_migrations` (`schema_dsl`, `schema_format`, `model_json`), applied with `ADD COLUMN IF NOT EXISTS` exactly like the existing `melange_version` and `function_checksums` migrations. Both forms are stored deliberately: the DSL is what humans want back, the parsed JSON is what tooling wants to compare. `Migrator.GetDeployedModel` reads it back. Databases migrated before this change keep working and report "not recorded" rather than erroring, and a plain re-run backfills them without needing `--force`.

**Environment profiles.** Named connection profiles selected with a single `--env` flag, so targeting staging or production stops meaning hand-swapping `--db` strings. Precedence is `--env` > `MELANGE_ENV` > `default_environment` > base, resolved once in `PersistentPreRunE` so every subcommand inherits it. `${VAR}` expansion keeps credentials out of the committed file, `config show` masks passwords by default, and the active environment is echoed to stderr so a command targeting production is never silent. With no `environments` block, behaviour is identical to today.

**`melange schema pull`.** Reconstructs the `.fga` recorded by the most recent migration, for a database whose schema file was lost or a codebase you're onboarding onto. Single-file schemas come back byte-identical with a `#`-comment provenance header, so the output still parses as valid DSL. The connection string is never included — a pulled schema gets committed, and a DSN in its header would be a credential leak.

**`melange diff`.** A semantic diff engine in `pkg/schema` comparing two parsed models — the same structures melange compiles to SQL, so the diff reflects real runtime behaviour — classifying every change as additive or breaking. Sources reuse the vocabulary `generate migration` already has: deployed database, `--git-ref`, or `--previous-schema`. `--exit-code` makes it a CI gate. The engine is reused by `status`, `doctor`, and `generate migration` rather than each growing its own comparison.

**Drift-safe `migrate`.** `--if-deployed-checksum` turns migrate into a compare-and-swap: it applies only if the database is at the checksum you expected, otherwise it aborts having changed nothing. This closes the window where someone else migrates between the time you read a database's state and the time your deploy lands, which last-writer-wins would silently clobber. The guard is checked up front and again inside the apply transaction, and is enforced under `--dry-run` and `--force` too.

**`melange status`, enriched.** Deployed-model provenance, a sync state, and `--format json`. When the local schema has drifted, status now says what drifted — counts plus the changes themselves, capped at five lines with `melange diff` for the rest. Reading the migration record is non-fatal, so status never loses its basic reachability signal.

**`melange history`.** The migration audit trail, essentially free once rows carry the model.

**Doctor checks** for a recorded deployed model and for breaking drift between local and deployed, plus a semantic-diff header in generated migrations.

## Notes on two design calls

The drift guard is a precondition, not a lock. It is checked up front and re-checked inside the apply transaction under read-committed, so a migration that commits while this one runs is caught — but two migrations reading at the same instant could both proceed. Concurrent migrations against one database are unsupported regardless, and the realistic threat (drift between a prior read and this apply, on human timescales) is covered.

The `database_ahead` sync state — the deployed model is not any version of your schema in git history, so someone migrated from a different checkout — is deliberately advisory and biased toward saying nothing. A false negative is a missing hint; a false positive accuses a colleague of a migration they did not perform. It gives up rather than guess in a shallow or partial clone (CI checkouts are shallow by default), with a dirty working tree (migrating from uncommitted edits is routine), for modular schemas, past a 50-commit window, and when no revision could be read. Each of those has a regression test that fails if the guard is removed.

## Compatibility

Every read degrades gracefully on databases migrated by older versions: absent columns, absent model, and unparseable recorded DSL are all handled as "not recorded" plus a note, never as an error. `MigrateWithTypes` is left untouched — it stays the no-bookkeeping path the OpenFGA suite and testutil depend on.

## Testing

Unit coverage for the diff engine, model JSON round-trip over every rule variant, config overlay and precedence, the sync classifier, and the git probe. Integration tests cover recording and reading the model back, an old-install simulation with the columns absent, backfill on re-run, dry-run scripts that record an identical migration, all the drift-guard paths, and history. The integration and OpenFGA suites need Docker and run here in CI.

One deliberate omission: no release notes blog post. Those get written against a version number when the release PR exists.
