### PR TITLE
fix(parser): preserve pure TTU intersections

### DIFF
--- a/pkg/compiler/pure_ttu_intersection_test.go
+++ b/pkg/compiler/pure_ttu_intersection_test.go
@@ -1,0 +1,54 @@
+package compiler_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/pthm/melange/pkg/compiler"
+	"github.com/pthm/melange/pkg/parser"
+	"github.com/pthm/melange/pkg/schema"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGenerateSQL_PureTTUIntersection(t *testing.T) {
+	model := `
+model
+  schema 1.1
+
+type user
+
+type project
+  relations
+    define reader: [user]
+
+type document
+  relations
+    define primary_project: [project]
+    define secondary_project: [project]
+    define can_view: reader from primary_project and reader from secondary_project
+`
+
+	types, err := parser.ParseSchemaString(model)
+	require.NoError(t, err)
+
+	closureRows := schema.ComputeRelationClosure(types)
+	analyses := compiler.AnalyzeRelations(types, closureRows)
+	analyses = compiler.ComputeCanGenerate(analyses)
+	inlineData := compiler.BuildInlineSQLData(closureRows, analyses)
+
+	generated, err := compiler.GenerateSQL(analyses, inlineData, "")
+	require.NoError(t, err)
+	require.Contains(t, compiler.CollectFunctionNames(analyses), "check_document_can_view")
+	require.Contains(t, generated.Dispatcher, "check_document_can_view")
+
+	var canViewFunction string
+	for _, function := range generated.Functions {
+		if strings.Contains(function, "CREATE OR REPLACE FUNCTION check_document_can_view(") {
+			canViewFunction = function
+			break
+		}
+	}
+	require.NotEmpty(t, canViewFunction, "generated SQL should contain check_document_can_view")
+	require.Contains(t, canViewFunction, "primary_project")
+	require.Contains(t, canViewFunction, "secondary_project")
+}

--- a/pkg/parser/parser.go
+++ b/pkg/parser/parser.go
@@ -322,7 +322,7 @@ func extractUserset(us *openfgav1.Userset, rel *schema.RelationDefinition) {
 		// E.g., "a and (b or c)" expands to [[a,b], [a,c]]
 		groups := expandIntersection(v.Intersection, rel.Name)
 		for _, group := range groups {
-			if len(group.Relations) > 0 {
+			if len(group.Relations) > 0 || len(group.ParentRelations) > 0 {
 				rel.IntersectionGroups = append(rel.IntersectionGroups, group)
 			}
 		}

--- a/pkg/parser/parsing_patterns_test.go
+++ b/pkg/parser/parsing_patterns_test.go
@@ -221,3 +221,45 @@ type folder
 	require.True(t, parentRels["member"], "should have 'member from group' parent relation")
 	require.True(t, parentRels["owner"], "should have 'owner from group' parent relation")
 }
+
+func TestIntersectionWithOnlyTTUParsing(t *testing.T) {
+	dsl := `
+model
+  schema 1.1
+
+type user
+
+type project
+  relations
+    define reader: [user]
+
+type document
+  relations
+    define primary_project: [project]
+    define secondary_project: [project]
+    define can_view: reader from primary_project and reader from secondary_project
+`
+
+	types, err := parser.ParseSchemaString(dsl)
+	require.NoError(t, err)
+
+	var canViewRel *schema.RelationDefinition
+	for i := range types {
+		if types[i].Name != "document" {
+			continue
+		}
+		for j := range types[i].Relations {
+			if types[i].Relations[j].Name == "can_view" {
+				canViewRel = &types[i].Relations[j]
+				break
+			}
+		}
+	}
+	require.NotNil(t, canViewRel, "can_view relation not found")
+	require.Equal(t, []schema.IntersectionGroup{{
+		ParentRelations: []schema.ParentRelationCheck{
+			{Relation: "reader", LinkingRelation: "primary_project"},
+			{Relation: "reader", LinkingRelation: "secondary_project"},
+		},
+	}}, canViewRel.IntersectionGroups)
+}


### PR DESCRIPTION
## Summary

- preserve intersection groups composed entirely of tuple-to-userset checks
- add parser coverage for pure TTU intersections
- verify the SQL compiler emits the specialized check function and dispatcher route

## Problem

`expandIntersection` correctly records tuple-to-userset operands in an intersection group's `ParentRelations`. However, `extractUserset` only retained groups with at least one entry in `Relations`.

As a result, a permission such as:

```fga
define can_view: reader from primary_project and reader from secondary_project
```

was discarded during parsing because it contains no ordinary computed relations. The generated migration therefore omitted the specialized permission function and its dispatcher route, causing the permission check to deny at runtime.

## Fix

Retain an intersection group when it contains either ordinary relations or parent relations. The downstream schema and SQL-generation stages already support parent-only intersection groups.

## Testing

- added a parser regression test asserting that both TTU operands are retained in one intersection group
- added an end-to-end compiler regression test asserting that the specialized check function contains both parent checks and is registered in the dispatcher
- `go test ./... -count=1`
